### PR TITLE
fix catalogue function speed

### DIFF
--- a/aqua/reader/catalogue.py
+++ b/aqua/reader/catalogue.py
@@ -13,6 +13,6 @@ def catalogue(verbose=True, configdir='config'):
                 print(model + '\t' + exp + '\t' + cat[model][exp].description)
                 if exp != "grids":
                     for k in cat[model][exp]:
-                        print('\t' + '- ' + k + '\t' + cat[model][exp][k].description)
+                        print('\t' + '- ' + k + '\t' + cat[model][exp].walk()[k]._description)
             print()
     return cat


### PR DESCRIPTION
Little fix which totally speeds up the `catalogue()` function which before was choking on intake-esm catalogue entries.