### PR TITLE
Hotfix github actions on main

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(name='aqua',
         'pyYAML',
         'sparse', 
         'xarray',
-        'smmregrid @ git+ssh://git@github.com/jhardenberg/smmregrid'
+        'smmregrid @ git+https://github.com/jhardenberg/smmregrid'
       ]
     )


### PR DESCRIPTION
Hotfix to the github actions failing on the `main` branch.
`smmregrid` is now downloaded with `https`, avoiding the tests failure, as reported in issue #69 