### PR TITLE
pin libnetcdf to solve hdf5 issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
   - python>=3.9,<3.11
-  - libnetcdf=4.8.1 
+  - libnetcdf<=4.8.1 
   - xarray
   - dask
   - numpy


### PR DESCRIPTION
This solves issue #68 , avoiding hdf5 warnings for some data sources based on netcdf (original FESOM, MSWEP).
The solution for now is to pin libnetcdf to its 4.8.1 version. This implies the following downgrades:
```

  - eccodes         2.29.0  h65eb51b_2               conda-forge                    
  + eccodes         2.28.0  h7513371_1               conda-forge/linux-64     Cached
  - hdf5            1.14.0  nompi_hb72d44e_103       conda-forge                    
  + hdf5            1.12.2  nompi_h4df4325_101       conda-forge/linux-64     Cached
  - jasper           4.0.0  h32699f2_1               conda-forge                    
  + jasper          2.0.33  h0ff4b12_1               conda-forge/linux-64     Cached
  - libjpeg-turbo  2.1.5.1  h0b41bf4_0               conda-forge                    
  + libjpeg-turbo    2.1.4  h166bdaf_0               conda-forge/linux-64     Cached
  - libnetcdf        4.9.1  nompi_hf3f8848_103       conda-forge                    
  + libnetcdf        4.8.1  nompi_h261ec11_106       conda-forge/linux-64     Cached
  - netcdf4          1.6.3  nompi_py310hfec4f3c_101  conda-forge                    
  + netcdf4          1.6.2  nompi_py310h55e1e36_100  conda-forge/linux-64     Cached
```

The big advantage, as noticed by @mnurisso is that it avoids creating huge notebooks full of warnings. So I would indeed agree with merging this urgently for now. We can later study if the pin can be removed again.