### PR TITLE
fix missing variables

### DIFF
--- a/aqua/reader/fixer.py
+++ b/aqua/reader/fixer.py
@@ -138,16 +138,17 @@ class FixerMixin():
         # Only now rename everything
         data = data.rename(fixd)
 
-        for var in variables:
-            # Decumulate if required
-            if variables[var].get("decumulate", None):
-                varname = varlist[var]
-                if varname in data.variables:
-                    keep_first = variables[var].get("keep_first", True)
-                    data[varname] = self.simple_decumulate(data[varname],
-                                                           jump=jump,
-                                                           keep_first=keep_first)
-                    log_history(data[varname], "variable decumulated by AQUA fixer")
+        if variables:
+            for var in variables:
+                # Decumulate if required
+                if variables[var].get("decumulate", None):
+                    varname = varlist[var]
+                    if varname in data.variables:
+                        keep_first = variables[var].get("keep_first", True)
+                        data[varname] = self.simple_decumulate(data[varname],
+                                                            jump=jump,
+                                                            keep_first=keep_first)
+                        log_history(data[varname], "variable decumulated by AQUA fixer")
 
         if apply_unit_fix:
             for var in data.variables:


### PR DESCRIPTION
The fix in #104 was not complete, we forgot a second instance below where `variables` was being used.
In fact one of the CERES daset was not being loaded correctly.
Linked to the same problem of #102.
This is really minor, we could merge right away