### PR TITLE
[WIP] Use GH Actions to run test coverage and write a comment to each PR with the Markdown report

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -9,9 +9,16 @@ on:
   schedule:
     - cron: "0 3 * * 1" #run every Monday night at 3AM UTC
 
+permissions:
+  contents: read
+
 jobs:
   aqua_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -33,12 +40,61 @@ jobs:
         run: |
           ./download_data_for_tests.sh
       - name: Run tests
+        # NOTE: We could gain a few seconds in the build, if needed,
+        #       by running with coverage in only one matrix job run.
         run: |
+          pytest --cov=aqua --cov-report=xml --cov-branch
 
-          python -m pytest ./tests/test_basic.py
-          python -m pytest ./tests/test_catalog.py 
-          python -m pytest ./tests/test_fldmean.py
-          python -m pytest ./tests/test_timmean.py                
-          python -m pytest ./tests/test_streaming.py
-          python -m pytest ./tests/test_regrid.py
+          if [[ "${{ matrix.build-backend }}" = "conda" && "${{ matrix.python-version }}" = "3.10" ]]; then
+            # Here we store the output of pycobertura (a tool that parses the
+            # Cobertura-compatible coverage.xml produced by pytest-cov) in a
+            # shell variable.
+            COVERAGE_REPORT=$(pycobertura show --format markdown coverage.xml 2>/dev/null)
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "COVERAGE_REPORT<<$EOF" >> $GITHUB_ENV
+            echo "${COVERAGE_REPORT}" >> $GITHUB_ENV
+            echo "$EOF" >> $GITHUB_ENV
+            
+            echo "Generated coverage report:"
+            echo "${COVERAGE_REPORT}"
+          fi
+      - name: Publish coverage reports
+        # Publish the coverage reports in only one matrix job run.
+        if: matrix.build-backend == 'conda' && matrix.python-version == '3.10'
+        # Comment on an issue or pull request using GH Actions tooling:
+        # https://github.com/actions/github-script#comment-on-an-issue
+        uses: actions/github-script@v6
+        id: coverage-report
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          # Based on: https://github.com/actions/github-script/blob/060d68304cc19ea84d828af10e34b9c6ca7bdb31/.github/workflows/pull-request-test.yml
+          script: |
+            // Get the existing comments.
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+            })
 
+            // Find any comment already made by the bot.
+            const botComment = comments.find(comment => comment.user.id === 41898282)
+            const commentBody = `${{ env.COVERAGE_REPORT }}`
+
+            if (botComment) {
+              console.log(`Updating comment in ${context.repo.owner}/${context.repo.repo}, comment ID: ${botComment.id}`)
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              })
+            } else {
+              console.log(`Creating comment in ${context.repo.owner}/${context.repo.repo}`)
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: commentBody
+              })
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ cli/*.err
 cli/*.out
 AQUA_tests*
 **/*.bak
+.coverage
+coverage.xml
+coverage/
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,11 @@ dependencies:
 # these below are only required for running notebooks
   - ipykernel
   - healpy
+# these below are only required for tests
+  - pytest
+  - pytest-cov
+  - coverage[toml]
+  - pycobertura
 # these are pip-based since it provides more recent versions or packages unavailable on conda-forge
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ docs = [
     "sphinx-rtd-theme==1.2.*"
 ]
 tests = [
-    "pytest==7.3.*"
+    "pytest==7.3.*",
+    "pytest-cov==4.0.*",
+    "coverage[toml]==7.2.*",
+    "pycobertura==3.0.*"
 ]
 all = [
     "aqua[tests]",
@@ -74,3 +77,38 @@ find = {}
 
 [tool.setuptools.dynamic]
 version = {attr = "aqua.__version__"}
+
+[tool.pytest.ini_options]
+addopts = "-v"
+testpaths = [
+    "tests"
+]
+markers = []
+
+# This appears to be the correct configuration, but for some reason
+# pytest-cov doesn't appear to be reading this? We are passing some
+# options via the command-line for now, but this needs to be fixed.
+# Ref: https://github.com/pytest-dev/pytest-cov/issues/390
+[tool.coverage.run]
+branch = true
+command_line = '-m pytest tests'
+source = ["aqua"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+ignore_errors = true
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "def __str__",
+  "raise AssertionError",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+  "if typing.TYPE_CHECKING:"
+]
+
+[tool.coverage.html]
+show_contexts = true
+directory = "coverage/html"

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -4,6 +4,7 @@ import pytest
 from aqua import Reader
 
 
+@pytest.mark.skip(reason="excluded from GH actions")
 def test_fixer():
     """Test basic fixing"""
 


### PR DESCRIPTION
Closes #105 

As per title, this uses [`github-scripts`](https://github.com/actions/github-script), a project by GitHub that lets you execute JavaScript in your GH Actions to call the GH REST API.

It is built on top of #103 , so please ignore all but the last 2 commits.

I altered my `main` branch to have the permissions there (the "test token" commits here), but not sure if that will be needed here.

If you push more commits, GH Actions will run again, and the code added in this PR will be able to recognize there is already a comment by the bot, and instead of adding a new comment (that could be confusing) it will update the existing comment. Here's an example of what it looks like:

![Screen Shot 2023-04-14 at 12 58 45-fullpage](https://user-images.githubusercontent.com/304786/232026722-4ce16eb1-bb75-4535-b8a9-86efdc142e3b.png)

Zooming in:

![image](https://user-images.githubusercontent.com/304786/232026832-8b6ee472-1ee1-4868-bfd5-dabfb5dd74e5.png)

Clicking on the button to view the updates to the comment.

![image](https://user-images.githubusercontent.com/304786/232026908-16a727e6-323d-47be-bc38-16e9a08b03ce.png)

GitHub UI keeps track of changes to comments for you (for free, hopefully!). So if you click on a previous coverage report, from a previous commit (this is from a test commit where I removed most test files):

![image](https://user-images.githubusercontent.com/304786/232027058-986db589-c56e-4cfc-9800-892a7033f4df.png)

And voilà, free coverage reporting with GH Actions :tada: 

GitLab provides it out of the box, so we wouldn't have to worry about it. We use it for Autosubmit: https://earth.bsc.es/gitlab/es/autosubmit/-/blob/master/.gitlab-ci.yml#L32-40

Cheers

-Bruno

p.s.: WIP because it probably needs discussing, review the other PR first, and more fine-tuning; as well as wait to see if it will work on this PR (different owner as this is from my fork).