### PR TITLE
[WIP] Add grid_areas to dataset

### DIFF
--- a/aqua/reader/regrid.py
+++ b/aqua/reader/regrid.py
@@ -1,7 +1,6 @@
 """Regridder mixin for the Reader class"""
 
 import os
-import sys
 
 import subprocess
 import tempfile


### PR DESCRIPTION
This small PR adds a grid_areas DataArray to the dataset read by the Reader or to the result of a regridding. This way the latest grid information is always available **with** the data. The `fldmean()` method now uses the presence of this field to extract the weights for regridding (for compatibility it still falls back to using src.grid_area if this is missing, but this could probably be removed later). This should solve issue #147 since tow the "regridded" flag is not used by fldmean() anymore. We should check what happens in the LRA generator though. Since there is an additional 'variable' grid_areas in the dataset, we might not want to save this to the LRA. 