### PR TITLE
decode times for source grid area

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -117,7 +117,7 @@ class Reader(FixerMixin, RegridMixin):
         # Expose grid information for the source
         sgridpath = source_grid.get("path", None)
         if sgridpath:
-            self.src_grid = xr.open_dataset(sgridpath)
+            self.src_grid = xr.open_dataset(sgridpath, decode_times=False)
         else:
             self.src_grid = None
 


### PR DESCRIPTION
fixing WOA13 source grid path. Adding `decode_times=False` by default for grids. 