### PR TITLE
remove broken tests on levante

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -16,9 +16,11 @@ def reader(request):
     # very slow access, skipped
     if model == 'ICON' and source == 'intake-esm-test':
         pytest.skip()
-    if model == 'MSWEP' and source == 'daily':
+    if model == 'ICON' and exp == 'hpx':
         pytest.skip()
-    if model == 'MSWEP' and source == '3hourly':
+    if model == 'MSWEP':
+        pytest.skip()
+    if model == 'ERA5':
         pytest.skip()
     myread = Reader(model=model, exp=exp, source=source, areas=False)
     data = myread.retrieve(fix=False)


### PR DESCRIPTION
This is a tiny pull request to remove the tests on the catalog entries which we know currently does not work on Levante. It is useful to be sure that tests are working for the prototype release of the deliverable. 
Pointing to `Deliverable` branch...