### PR TITLE
Minor fix for eccodes on lumi

### DIFF
--- a/aqua/util.py
+++ b/aqua/util.py
@@ -198,8 +198,8 @@ def read_eccodes_dic(filename):
     Returns:
     - A dictionary containing the contents of the ecCodes definition file.
     """
-
-    fn = os.path.join(eccodes.codes_definition_path(), 'grib2', filename)
+    fn = eccodes.codes_definition_path().split(':')[0]  # LUMI fix, take only first
+    fn = os.path.join(fn, 'grib2', filename)
     with open(fn, "r", encoding='utf-8') as file:
         text = file.read()
     text = text.replace(" =", ":").replace('{', '').replace('}', '').replace(';', '').replace('\t', '    ')
@@ -229,7 +229,8 @@ def read_eccodes_def(filename):
     keylist = keylist[:-1]
 
     # WMO lists
-    fn = os.path.join(eccodes.codes_definition_path(), 'grib2', filename)
+    fn = eccodes.codes_definition_path().split(':')[0]  # LUMI fix, take only first
+    fn = os.path.join(fn, 'grib2', filename)
     with open(fn, "r", encoding='utf-8') as f:
         for line in f:
             line = line.replace(" =", "").replace('{', '').replace('}', '').replace(';', '').replace('\t', '#    ')


### PR DESCRIPTION
This is a mini fix (just two lines of code) to make eccodes based code work also on lumi when a containerized version of mamba is used. In fact `eccodes.codes_definition_path()` contains two paths separated by a colon. We split and use only the first one to find definition files.