### PR TITLE
Delete .vscode directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "[python]": {
-
-        "editor.defaultFormatter": "ms-python.python",
-        "editor.formatOnType": false
-        "editor.formatOnSave": false
-    },
-
-}


### PR DESCRIPTION
A recent merge to the main introduced a `.vscode` directory containing VSCode settings. This interferes with personalized settings users might have:
.vscode should not be under version control!

This is a mini fix which can be merged immediately