### PR TITLE
Use -eo pipefail in the GH Actions shell so a multiline script fails correctly

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -30,7 +30,15 @@ jobs:
         python-version: ["3.10"]
     defaults:
       run:
-        shell: bash -l {0}
+        # NOTE: We must take care with the shell value here. We have steps
+        #       with mutiline YAML strings. These get converted into shell
+        #       scripts. If execute as ``bash -l fail_first_command.sh``
+        #       then it would fail the first command but run the second
+        #       command. The default value in GitHub is ``--noprofile --norc -eo pipefail``.
+        #       https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+        #       We added the ``--login`` here for environment variables, and removed
+        #       the noprofile and norc so we have pytest set by Conda in our PATH.
+        shell: bash --login -eo pipefail {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Pull request Description:

#closes 228

@mnurisso see if it makes sense to you. What I did was to open the failed GitHub Action, look at the log, scratch my head for many minutes, then copy the shell command in that step (the one that starts with a comment, then `pytest --cov etc.`) into a local bash script, then `bash -l test.sh && echo $?`. Then I realized it was not failing because the first command in that shell script failed, but the remaining command(s) succeeded.

Took me longer than I would like to admit to notice that, but gave me a good chuckle realizing why the failing test was not failing our GH Action :rofl: 

----

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] environment.yml and pyproject.toml are updated if needed.