### PR TITLE
AQUA env variable as first directory to search

### DIFF
--- a/aqua/util.py
+++ b/aqua/util.py
@@ -115,7 +115,7 @@ def get_config_dir(filename='config.yaml'):
         configdirs.append(os.path.join(aquadir, 'config'))
 
     # set of predefined folders to browse
-    configdirs.append(['./config', '../config', '../../config', '../../../config'])
+    configdirs.extend(['./config', '../config', '../../config', '../../../config'])
 
     # if the home is defined
     homedir = os.environ.get('HOME')


### PR DESCRIPTION
Micro PR to make sure that the AQUA environment variable is the first to search.
The logic is that "$AQUA" points to a folder containing a "config" subdirectory.

Issues closed by this pull request: #157

 - [x] This pull request is ready for review.