### PR TITLE
[Lumi] Modules load and PATH export in the bash_profile (through load_aqua.sh)

### DIFF
--- a/config/machines/lumi/installation/lumi_install.sh
+++ b/config/machines/lumi/installation/lumi_install.sh
@@ -82,32 +82,29 @@ else
   fi
 fi
 
-# check if the line is already present in the .bashrc file
-if ! grep -q 'module use /project/project_465000454/devaraju/modules/LUMI/22.08/C' ~/.bashrc; then
+# check if the line is already present in the load_aqua.sh file
+if ! grep -q 'module use /project/project_465000454/devaraju/modules/LUMI/22.08/C' ~/load_aqua.sh; then
     # if not, append it to the end of the file
-  echo 'module use /project/project_465000454/devaraju/modules/LUMI/22.08/C' >> ~/.bashrc
-  echo 'module purge' >> ~/.bashrc
-  echo 'module load pyfdb/0.0.2-cpeCray-22.08' >> ~/.bashrc
-  echo 'module load ecCodes/2.30.0-cpeCray-22.08' >> ~/.bashrc
-  echo 'module load python-climatedt/3.11.3-cpeCray-22.08.lua' >> ~/.bashrc
-  echo "modules for added to .bashrc. Please run 'source ~/.bashrc' to load the new configuration."
-else
-  echo "modules already present in .bashrc."
-fi
-
-# Config FDB5
-if ! grep -q 'export FDB5_CONFIG_FILE=/scratch/project_465000454/igonzalez/fdb-test/config.yaml' ~/.bashrc; then
-  echo 'export FDB5_CONFIG_FILE=/scratch/project_465000454/igonzalez/fdb-test/config.yaml' >> ~/.bashrc
-  echo 'export GSV_WEIGHTS_PATH=/scratch/project_465000454/igonzalez/gsv_weights' >> ~/.bashrc
+  echo 'module use /project/project_465000454/devaraju/modules/LUMI/22.08/C' >> ~/load_aqua.sh
+  echo 'module purge' >> ~/load_aqua.sh
+  echo 'module load pyfdb/0.0.2-cpeCray-22.08' >> ~/load_aqua.sh
+  echo 'module load ecCodes/2.30.0-cpeCray-22.08' >> ~/load_aqua.sh
+  echo 'module load python-climatedt/3.11.3-cpeCray-22.08.lua' >> ~/load_aqua.sh
+  
+  # Config FDB5
+  echo 'export FDB5_CONFIG_FILE=/scratch/project_465000454/igonzalez/fdb-test/config.yaml' >> ~/load_aqua.sh
+  echo 'export GSV_WEIGHTS_PATH=/scratch/project_465000454/igonzalez/gsv_weights' >> ~/load_aqua.sh
   echo "exports for FDB5 added to .bashrc. Please run 'source ~/.bashrc' to load the new configuration."
-else
-  echo "exports for FDB5 already present in .bashrc"
-fi
 
-if ! grep -q 'export PATH="'$INSTALLATION_PATH'/bin:$PATH"' ~/.bashrc; then
-  echo "# AQUA installation path" >> ~/.bashrc
-  echo 'export PATH="'$INSTALLATION_PATH'/bin:$PATH"' >> ~/.bashrc
-  echo "export PATH has been added to .bashrc. Please run 'source ~/.bashrc' to load the new configuration."
-else
-  echo "export PATH is already present in .bashrc."
-fi
+  echo "# AQUA installation path" >> ~/load_aqua.sh
+  echo 'export PATH="'$INSTALLATION_PATH'/bin:$PATH"' >> ~/load_aqua.sh
+  echo "export PATH has been added to .bashrc. Please run 'source ~/load_aqua.sh' to load the new configuration."
+
+read -p "Would you like to source load_aqua.sh in your .bash_profile? " -n 1 -r
+    echo 
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+      echo 'source  ~/load_aqua.sh' >> ~/.bash_profile
+    else
+      echo "source load_aqua.sh not added to .bash_profile"
+    fi 


### PR DESCRIPTION
Pull request Description:
At the moment the `lumi_installation.sh` script is adding to the `.bashrc` file the modules load and export of the path where the aqua environment has been added.
This is fine until you're trying to work with the workflow.
In this case having these info on the `.bashrc` and not the `.bash_profile` is creating some conflicts.

With this pull request modules and path are are exported only in the login node via the `.bash_profile`.
As  @mnurisso suggested, a load_aqua.sh script (containing all the modules load an exports) is now created when installing the environment.  During the installation, the user is asked whether they want to add `source load_aqua.sh`  into the `.bash_profile`.
This go towards the possibility to handle multiples environments on lumi, something that will be needed when running multiples diagnostics.

Issues closed by this pull request:
#299 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] environment.yml and pyproject.toml are updated if needed.