### PR TITLE
hotifx for era5 area

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -484,9 +484,12 @@ class Reader(FixerMixin, RegridMixin):
                 if not self.grid_area[coord].equals(data.coords[coord]):
                     # if they are fine when sorted, there is a sorting mismatch
                     if self.grid_area[coord].sortby(coord).equals(data.coords[coord].sortby(coord)):
-                        raise ValueError(f'{coord} is sorted in different way between area files and your dataset.') from err
+                        self.logger.warning('%s is sorted in different way between area files and your dataset. Flipping it!', coord)
+                        self.grid_area = self.grid_area.reindex({coord: list(reversed(self.grid_area[coord]))})
+                        #raise ValueError(f'{coord} is sorted in different way between area files and your dataset.') from err
                     # something else
-                    raise ValueError(f'{coord} has a mismatch in coordinate values!') from err
+                    else:
+                        raise ValueError(f'{coord} has a mismatch in coordinate values!') from err
 
         out = data.weighted(weights=grid_area.fillna(0)).mean(dim=space_coord)
 


### PR DESCRIPTION
Pull request Description:

Small hotfix for ERA5 fldmean call. Fixes flip the latitudes to have them uniform, but areas are pre-calculated. this will be fixed in a more significant way during the reader refactor, but giving that we have an error trap that works fine I added a manual reverting of the latitude

Issues closed by this pull request:

#322 

