### PR TITLE
Raise exception only if FDB used and not available

### DIFF
--- a/aqua/gsv/intake_gsv.py
+++ b/aqua/gsv/intake_gsv.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import xarray as xr
 from intake.source import base
@@ -11,8 +10,8 @@ try:
     from gsv.retriever import GSVRetriever
     gsv_available = True
 except RuntimeError:
-    print("FDB5 binary library not present on system, disabling FDB support.")
     gsv_available = False
+
 
 class GSVSource(base.DataSource):
     container = 'xarray'
@@ -34,7 +33,7 @@ class GSVSource(base.DataSource):
         if gsv_available:
             self.gsv = GSVRetriever()
         else:
-            self.gsv = None
+            raise ImportError("FDB5 binary library not present on system or outdated.")
         self._dataset = None
         super(GSVSource, self).__init__(metadata=metadata)
 
@@ -44,7 +43,7 @@ class GSVSource(base.DataSource):
         return base.Schema(
             datashape=None,
             dtype=xr.Dataset,
-            #shape=self._dataset.shape,
+            # shape=self._dataset.shape,
             shape=None,
             npartitions=self._npartitions,
             extra_metadata={},
@@ -62,10 +61,10 @@ class GSVSource(base.DataSource):
         ds = [self._get_partition(i) for i in range(self._npartitions)]
         ds = xr.concat(ds, dim='time')
         return ds
-    
+
     def to_dask(self):
         return self.read_chunked()
-    
+
     # def _load(self):
     #     self._dataset = self._get_partition(0)
 
@@ -79,7 +78,7 @@ def make_date_list(start, end, step="M", numsteps=1):
     elif step == "H":
         delta = relativedelta(hours=numsteps)
     else:
-        sys.exit("step not recognized")        
+        sys.exit("step not recognized")
 
     start_date = datetime.strptime(start, '%Y%m%d')
     end_date = datetime.strptime(end, '%Y%m%d')


### PR DESCRIPTION
This is a rebased version of PR #340, now based on main.
It is a small change which suppresses the "FDB binary library not present ..." message on levante every time that aqua is loaded. Instead, now it silently notes if FDB is not available and then it raises an exception if we try anyway to use it .....

Issues closed by this pull request:

Close #336

----

 - [x] tested on LUMI
 - [x] tested on Levante