### PR TITLE
OPA pin for deliverable

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
     - gribscan
     - smmregrid
     # get OPA
-    - git+https://oauth2:-nnxqtXxyrs3LrJubtH1@earth.bsc.es/gitlab/digital-twins/de_340/one_pass.git
+    - git+https://oauth2:-nnxqtXxyrs3LrJubtH1@earth.bsc.es/gitlab/digital-twins/de_340/one_pass.git@v0.3.3
     - git+https://github.com/ecmwf/pyfdb.git@master
     - git+https://oauth2:NrMi_dshtmNeaWy9F3sz@earth.bsc.es/gitlab/digital-twins/de_340/gsv_interface.git
     # pip install -e of AQUA itself

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "sparse",
     "xarray",
     "smmregrid",
-    "one_pass@git+https://oauth2:-nnxqtXxyrs3LrJubtH1@earth.bsc.es/gitlab/digital-twins/de_340/one_pass.git@v0.3.2",
+    "one_pass@git+https://oauth2:-nnxqtXxyrs3LrJubtH1@earth.bsc.es/gitlab/digital-twins/de_340/one_pass.git@v0.3.3",
     "pyfdb@git+https://github.com/ecmwf/pyfdb.git@master",
     "gsv@git+https://oauth2:NrMi_dshtmNeaWy9F3sz@earth.bsc.es/gitlab/digital-twins/de_340/gsv_interface.git"
 ]


### PR DESCRIPTION
## PR description:

As discussed in #344 we pin OPA < 0.4.* so that new features can go in 0.4.* while a stable version is ready for AQUA deliverable.

Since requiring opa<0.4 and not an exact pinning is not possible in pyproject unless with poetry (not an expert) at the moment opa=0.3.3 is pinned. 
Test problem found in #338 is still solved (let's see in a moment in tests here)

## Issues closed by this pull request:

Close #344 

----

 - [x] environment.yml and pyproject.toml are updated if needed.