### PR TITLE
Tco2559-ng5-cycle3 add years 2024 and 2025

### DIFF
--- a/config/machines/levante/catalog/IFS/tco1279-orca025-cycle3.yaml
+++ b/config/machines/levante/catalog/IFS/tco1279-orca025-cycle3.yaml
@@ -9,7 +9,7 @@ sources:
       consolidated: false
       urlpath: 
         reference::/work/bm1235/b381679/IFS_cycle3/9km_nemo/gribscan_1h6h_native/json.dir/atm2d.json
-  3D_1h6h_native:
+  3D_1h_native:
     driver: zarr
     args:
       consolidated: false
@@ -33,7 +33,7 @@ sources:
       consolidated: false
       urlpath: 
         reference::/work/bm1235/b381679/IFS_cycle3/9km_nemo/gribscan_1h6h_0.25deg/json.dir/atm2d.json
-  3D_1h6h_0.25deg:
+  3D_1h_0.25deg:
     driver: zarr
     args:
       consolidated: false
@@ -57,12 +57,12 @@ sources:
       consolidated: false
       urlpath: 
         reference::/work/bm1235/b381679/IFS_cycle3/9km_nemo/gribscan_1h6h_1deg/json.dir/atm2d.json
-  3D_1h6h_1deg:
-    driver: zarr
-    args:
-      consolidated: false
-      urlpath: 
-        reference::/work/bm1235/b381679/IFS_cycle3/9km_nemo/gribscan_1h6h_1deg/json.dir/atm3d.json
+  # 3D_1h_1deg:
+  #   driver: zarr
+  #   args:
+  #     consolidated: false
+  #     urlpath: 
+  #       reference::/work/bm1235/b381679/IFS_cycle3/9km_nemo/gribscan_1h6h_1deg/json.dir/atm3d.json
   2D_monthly_1deg:
     driver: zarr
     args:

--- a/config/machines/levante/catalog/IFS/tco2559-ng5-cycle3.yaml
+++ b/config/machines/levante/catalog/IFS/tco2559-ng5-cycle3.yaml
@@ -10,7 +10,7 @@ sources:
       urlpath: 
         - reference::/work/bm1235/a270046/cycle3/multio_cycle3/gribscan_1h6h_native/json.dir/atm2d.json
         - reference::/work/bm1235/a270046/cycle3/multio_cycle3/gribscan_1h6h_native_p2/json.dir/atm2d.json
-  3D_1h6h_native:
+  3D_1h_native:
     driver: zarr
     args:
       consolidated: false

--- a/config/machines/levante/regrid.yaml
+++ b/config/machines/levante/regrid.yaml
@@ -62,7 +62,7 @@ source_grids:
       2D_1h_native:
         path: /work/bm1235/ifs-grids/tco_grids/tco2559_grid.nc
         space_coord: ["value"]
-      3D_1h6h_native:
+      3D_1h_native:
         path: /work/bm1235/ifs-grids/tco_grids/tco2559_grid.nc
         space_coord: ["value"]
       2D_monthly_native:
@@ -91,7 +91,7 @@ source_grids:
       2D_1h_native:
         path: /work/bm1235/ifs-grids/tco_grids/tco1279_grid.nc
         space_coord: ["value"]
-      3D_1h6h_native:
+      3D_1h_native:
         path: /work/bm1235/ifs-grids/tco_grids/tco1279_grid.nc
         space_coord: ["value"]
       2D_monthly_native:
@@ -325,12 +325,6 @@ source_grids:
         extra: 
           - -setgrid,/work/bb1153/b382075/nextgems/grids/NG5_griddes_elems_IFS.nc 
     
-
-
-
-      
-      
-
       # 2D_1h_native:
       #   path: /work/bm1235/a270046/meshes/NG5_griddes_nodes_IFS.nc
       #   space_coord: ["nod2"]


### PR DESCRIPTION
This  hotfix solves the probelm reported in #354 that years 2024 and 2025 are missing Tco2559-ng5-cycle3  for when read by the reader. We forgot to include a couple of json files.

## Issues closed by this pull request:

Close #354