### PR TITLE
Fix time duplicates

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -629,7 +629,7 @@ class Reader(FixerMixin, RegridMixin):
         Args:
             esmcat (intake.catalog.Catalog): your catalog
             var (str): Variable to load
-            loadvar (list of str): List of variables to load 
+            loadvar (list of str): List of variables to load
             keep (str, optional): which duplicate entry to keep ("first" (default), "last" or None)
 
         Returns:
@@ -654,6 +654,6 @@ class Reader(FixerMixin, RegridMixin):
         len0 = len(data.time)
         data = data.drop_duplicates(dim='time', keep=keep)
         if len(data.time) != len0:
-             self.logger.warning("Duplicate entries found along the time axis, keeping the %s one.", keep)
+            self.logger.warning("Duplicate entries found along the time axis, keeping the %s one.", keep)
 
         return data


### PR DESCRIPTION
## PR description:

This solves the fact that sometimes (due to restarts etc) there may be duplicate time entries in the data. An example is (IFS, tco2559-ng5-cycle3, 2D_1h_native). 

## Issues closed by this pull request:

Close #356

----
 - [x] Docstrings are updated if needed.