### PR TITLE
[Dev] Common env allows python 3.11

### DIFF
--- a/environment-common.yml
+++ b/environment-common.yml
@@ -9,7 +9,7 @@ channels:
   - numba
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
-  - python>=3.9,<3.11
+  - python>=3.9
   - libnetcdf 
   - netcdf4
   - xarray


### PR DESCRIPTION
## PR description:

Tests are available for python 3.11 so that common environment has to relax the python version requirement, otherwise tests in dev will fail.

I also want to point that the simplified env merged with #286 is not applied to common_env and new adaptation should be done

 - [x] environment.yml and pyproject.toml are updated if needed.