### PR TITLE
Fix for `timmean()` to uniform output time axis

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -423,7 +423,7 @@ class Reader(FixerMixin, RegridMixin):
             out = data.resample(time=resample_freq).mean()
             # for now, we set initial time of the averaging period following ECMWF standard
             # HACK: we ignore hours/sec to uniform the output structure
-            proper_time = data.time.resample(time=resample_freq).min()
+            #proper_time = data.time.resample(time=resample_freq).min()
             #out['time'] = np.array(proper_time.values, dtype='datetime64[h]')
             out['time'] = data.time.resample(time=resample_freq).min().dt.floor('D')
         except ValueError:


### PR DESCRIPTION
## PR description:

This is a small update that tries to improve the way the `timmean()` produces averaged data. The idea is that every average is set at the beginning of the evaluation time. This is not properly correct from the scientific point of view, but allows to have data which are uniform on the time axis, which is especially relevant when working with the LRA. This new solution further push for a rounding of the data after averaging...

## Issues closed by this pull request:

Close #375 
