### PR TITLE
fix for masked tco1279

### DIFF
--- a/config/machines/levante/regrid.yaml
+++ b/config/machines/levante/regrid.yaml
@@ -125,6 +125,16 @@ source_grids:
         extra: -setgrid,/work/bb1153/b382075/nextgems/grids/grid_lonlat_025.txt
         cellareas: /work/bb1153/b382075/nextgems/grids/cellarea_unstructured_025.nc
         cellarea_var: cell_area
+      2D_1h_0.25deg:
+        space_coord: ["value"]
+        extra: -setgrid,/work/bb1153/b382075/nextgems/grids/grid_lonlat_025.txt
+        cellareas: /work/bb1153/b382075/nextgems/grids/cellarea_unstructured_025.nc
+        cellarea_var: cell_area
+      3D_1h_0.25deg:
+        space_coord: ["value"]
+        extra: -setgrid,/work/bb1153/b382075/nextgems/grids/grid_lonlat_025.txt
+        cellareas: /work/bb1153/b382075/nextgems/grids/cellarea_unstructured_025.nc
+        cellarea_var: cell_area
   
     tco1279-orca025:
       ICMGG_atm2d:


### PR DESCRIPTION
## PR description:

I am trying to see if it is possible to produce data on for `tco1279-orca025` from the IFS grid to be fed to the LRA. 

Apparently, the MultI/O output is compromised due to interpolation and missing land-sea mask. 
An example here below. It seems to me to remind that this is a multI/O bug, and there is not a lot we can do about that since data are compromised on the original grid. 

<img width="956" alt="Schermata 2023-07-14 alle 10 16 31" src="https://github.com/oloapinivad/AQUA/assets/28352235/960757a2-21d0-41d8-8216-9e5ac8256f83">

I thus find a way to access variables making use of the `masked_vars` flag, setting up a block like this below in the `regrid.yaml`, so that we can interpolate/access those data making use of the data on the native grid. 

```
      2D_1h_native:
        path: 
          2d: /work/bb1153/b382076/AQUA-archive/grids/IFS/tco1279_grid.nc
          2dm: /work/bb1153/b382076/AQUA-archive/grids/IFS/tco1279_grid_masked.nc
        masked_vars:
          - ci
          - sst
        vert_coord: ["2d", "2dm"]
```

I created a very simple land-sea mask starting from the sea ice itself on the original grid, and doing some string manipulation with CDO: see the script below. 

```
#!/bin/bash

# Script to create an IFS mask. Need to have a file with sea ice in it on the original grid.
# It can be produced with Xarray accessing the original source. Not perfect but working. 
# this build only ocean mask

ARCHDIR=/home/b/b382076/work/AQUA-archive/grids
infile=$1
reso=$2

cdo setgrid,$ARCHDIR/IFS/${reso}_grid.nc $infile tmp.nc
cdo -f nc4 -z zip setname,lsm -setctomiss,0 -lec,1 tmp.nc $ARCHDIR/IFS/tco1279_grid_masked.nc
rm -f tmp.nc
```

I am currently recomputing the LRA and from my initial tests it seems everything is working, although the masking is not perfect probably following interpolation. However, values are ok. 

Questions:
- should I extend this also to the other IFS sources? We usually make use of FESOM data, this is an exception since we do not have NEMO data
- should I upload somewhere the bash script used, just for memory?

