### PR TITLE
[Dev] No need for framework tests on diagnostics

### DIFF
--- a/.github/workflows/dummy-diagnostic.yml
+++ b/.github/workflows/dummy-diagnostic.yml
@@ -40,15 +40,6 @@ jobs:
           create-args: >-
               python=${{ matrix.python-version }}
 
-# Run framework tests in order to check that the diagnostic environment is
-# compatible with the framework
-      - name: Download and setup framework tests
-        run: |
-          ./download_data_for_tests.sh
-      - name: Run framework tests
-        run: |
-          python -m pytest ./tests/test_basic.py 
-
 # Run diagnostic tests
       - name: Download and setup dummy-diagnostic tests
         run: |

--- a/.github/workflows/teleconnections.yaml
+++ b/.github/workflows/teleconnections.yaml
@@ -46,10 +46,6 @@ jobs:
           create-args: >-
               python=${{ matrix.python-version }}
 
-      - name: Download and setup framework tests
-        run: |
-          ./download_data_for_tests.sh
-
       - name: Download and setup teleconnections tests
         run: |
           ./tests/teleconnections/download_data_for_tests.sh

--- a/.github/workflows/tropical-rainfall-diagnostic.yml
+++ b/.github/workflows/tropical-rainfall-diagnostic.yml
@@ -41,12 +41,6 @@ jobs:
           create-args: >-
               python=${{ matrix.python-version }}
 
-# Run framework tests in order to check that the diagnostic environment is
-# compatible with the framework
-      - name: Download and setup framework tests
-        run: |
-          ./download_data_for_tests.sh
-
 # Run diagnostic tests
       - name: Download and setup dummy-diagnostic tests
         run: |


### PR DESCRIPTION
## PR description:

Removed the framework tests from the diagnostic workflows since there is a common environment and we're sure the diagnostics are always compatible with the framework.

 - [x] Workflows updated