### PR TITLE
Skipping teleconnections catalogue check

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -23,6 +23,9 @@ def reader(request):
         pytest.skip()
     if model == 'ERA5':
         pytest.skip()
+    # teleconnections catalogue, only on teleconnections workflow
+    if model == 'IFS' and exp == 'test-tco79' and source == 'teleconnections':
+        pytest.skip()
     myread = Reader(model=model, exp=exp, source=source, areas=False,
                     fix=False)
     data = myread.retrieve()


### PR DESCRIPTION
## PR description:

Skipping the check that the CI teleconnections catalogue is accessible. It is only if we're downloading the teleconnections data for tests and this is happening only in the teleconnections workflow, so we skip it in the aqua workflow.
