### PR TITLE
Add container publishing to the workflow.

### DIFF
--- a/.github/workflows/create-container-from-tag.yaml
+++ b/.github/workflows/create-container-from-tag.yaml
@@ -8,7 +8,7 @@ on:
       - v*
 
 env:
-  IMAGE_NAME: aqua/aqua
+  IMAGE_NAME: aqua
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## PR description:
Adds a publish container on tag action.

Only acts on tags starting with v.
The v is stripped from the tag when it's used as the version number for the container:
tag v2.0 will be published as   aqua:2.0 and aqua:latest



## Issues closed by this pull request:


----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated
 - [ ] environment.yml and pyproject.toml are updated if needed.
