### PR TITLE
Limiting python to <3.12, waiting for compatibility of dependencies

### DIFF
--- a/environment-common.yml
+++ b/environment-common.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
-  - python>=3.9
+  - python>=3.9,<3.12
   - cdo>=2.2.0 #for healpix support
   - ecCodes
   - pandas      


### PR DESCRIPTION
## PR description:

python 3.12 is out since 3 days, but AQUA environment is still not fully compatible.
PR is limiting for the moment the version to be maximum 3.11

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Changelog is updated
 - [x] environment.yml and pyproject.toml are updated if needed.
