### PR TITLE
The updated fixer for CERES

### DIFF
--- a/config/fixes/CERES.yaml
+++ b/config/fixes/CERES.yaml
@@ -39,7 +39,27 @@ models:
                           attributes:
                               valid_min: 0
                               valid_max: 1400
-                              positive: down                    
+                              positive: down
+          ebaf-sfc41:
+              default:
+                  data_model: False
+                  vars:
+                      mtntrf: 
+                          derived: 0.-sfc_net_lw_all_mon
+                          grib: true
+                      mtnsrf: 
+                          derived: sfc_net_sw_all_mon
+                          grib: true
+          ebaf-sfc42:
+              default:
+                  data_model: False
+                  vars:
+                      mtntrf: 
+                          derived: 0.-sfc_net_lw_all_mon
+                          grib: true
+                      mtnsrf: 
+                          derived: sfc_net_sw_all_mon
+                          grib: true              
           syn-toa41:
               default:
                   vars:


### PR DESCRIPTION
## PR description:

The PR request includes the fixer (namely 'mtntrf' and 'mtnsrf' variables) for the following sources of 'CERES':
 - 'ebaf-toa41',
 - 'ebaf-toa42',
 - 'ebaf-sfc41'
 - 'ebaf-sfc42'

Completed.
----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated
 - [ ] environment.yml and pyproject.toml are updated if needed.
