### PR TITLE
Solution for `get_fixer_varname()`

### DIFF
--- a/aqua/reader/fixer.py
+++ b/aqua/reader/fixer.py
@@ -533,11 +533,25 @@ class FixerMixin():
 
                 # get the ones from the equation of the derived ones
                 if 'derived' in variables[vvv]:
+                    # filter operations
                     required = [s for s in re.split(r'[-+*/]', variables[vvv]['derived']) if s]
-                    loadvar = loadvar + required
+                    # filter constants
+                    required_strings = [x for x in required if not x.replace('.', '').isnumeric()]
+                    if bool(set(required_strings) & set(variables.keys())):
+                        self.logger.error("Recursive fixer definition: %s are variables defined in the fixer!", 
+                                            required_strings)
+                        raise KeyError((
+                                    "Recursive fixer definition are not supported when selecting variables or working with FDB sources."
+                                    "Please change the fixes or call the retrieve() without the var arguments")
+                                    )
+                        
+                        
+
+                    loadvar = loadvar + required_strings
             else:
                 loadvar.append(vvv)
 
+        self.logger.debug("Variables to be loaded: %s", loadvar)
         return loadvar
 
     def simple_decumulate(self, data, jump=None, keep_first=True, keep_memory=None):


### PR DESCRIPTION
## PR description:

In #551 we noticed that we cannot use "recursive" fixer definitions. Also a problem with numerical values used for operations that was tentatively loaded was found. This is here addressed raising an error when the recursive definition is found and removing numerical values from the derived strings.  

I am actually partially surprised that recursive definition works also when retrieving all variables. I guess the order of the keys counts, it is actually a strategy we should discourage. 

## Issues closed by this pull request:

Close #551 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Documentation is included if a new feature is included.
 - [ ] Changelog is updated
