### PR TITLE
Excluding jup notebooks from line count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Override jupyter in Github language stats for more accurate estimate of repo code languages
+# reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+*.ipynb linguist-generated


### PR DESCRIPTION
## PR description:

As title states, remove jupiter notebook from repository count
