### PR TITLE
Logger colors refinement

### DIFF
--- a/aqua/logger.py
+++ b/aqua/logger.py
@@ -150,9 +150,9 @@ class CustomLogColors(logging.Formatter):
 
     # ANSI escape sequences for colors
     # GREY = "\x1b[38;20m"  # Unnecessary
-    # LGREY = "\x1b[37m"
+    LGREY = "\x1b[37m"
     # DGREY = "\x1b[90m"
-    LBLUE = "\x1b[38;2;64;183;197m"
+    # LBLUE = "\x1b[38;2;64;183;197m"
     # GREEN = "\x1b[32m"  # Less vibrant green
     # ORANGE = "\x1b[33m" # Less vibrant orange
     # RED = "\x1b[31;20m"  # Less vibrant red
@@ -163,7 +163,7 @@ class CustomLogColors(logging.Formatter):
     RESET = "\x1b[0m"
 
     FORMATS = {
-        logging.DEBUG: f"{LBLUE}%(asctime)s :: %(name)s :: %(levelname)-8s -> %(message)s{RESET}",
+        logging.DEBUG: f"{LGREY}%(asctime)s :: %(name)s :: %(levelname)-8s -> %(message)s{RESET}",
         logging.INFO: f"{GREEN}%(asctime)s :: %(name)s :: %(levelname)-8s -> %(message)s{RESET}",
         logging.WARNING: f"{ORANGE}%(asctime)s :: %(name)s :: %(levelname)-8s -> %(message)s{RESET}",
         logging.ERROR: f"{RED}%(asctime)s :: %(name)s :: %(levelname)-8s -> %(message)s{RESET}",


### PR DESCRIPTION
## PR description:

Since we're going to make more rational the logging of the framework (see #610) we're introducing a new set of colors so that it's clear the warning should concern you while info and debug are not problematic messages, if you see only them everything is working as expected

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [x] Docstrings are updated if needed.
 - [ ] Changelog is updated
