### PR TITLE
little single_map additions and fixes

### DIFF
--- a/aqua/graphics/single_map.py
+++ b/aqua/graphics/single_map.py
@@ -19,6 +19,7 @@ def plot_single_map(data: xr.DataArray,
                     vmin=None, vmax=None,
                     cmap='RdBu_r',
                     gridlines=False,
+                    display=True,
                     loglevel='WARNING',
                     **kwargs):
     """
@@ -40,6 +41,7 @@ def plot_single_map(data: xr.DataArray,
                                    Defaults to None.
         cmap (str, optional):      Colormap. Defaults to 'RdBu_r'.
         gridlines (bool, optional): If True, plot gridlines. Defaults to False.
+        display (bool, optional):  If True, display the figure. Defaults to True.
         loglevel (str, optional):  Log level. Defaults to 'WARNING'.
 
     Keyword Args:
@@ -199,7 +201,11 @@ def plot_single_map(data: xr.DataArray,
         else:
             dpi = kwargs.get('dpi', 100)
             if dpi == 100:
-                logger.warning("Setting dpi to 100 by default, use dpi kwarg to change it")
+                logger.info("Setting dpi to 100 by default, use dpi kwarg to change it")
 
         fig.savefig('{}/{}'.format(outputdir, filename),
                     dpi=dpi, bbox_inches='tight')
+    
+    if display is False:
+        logger.debug("Display is set to False, closing figure")
+        plt.close(fig)

--- a/aqua/util/graphics.py
+++ b/aqua/util/graphics.py
@@ -134,18 +134,21 @@ def cbar_get_label(data: xr.DataArray, cbar_label: str = None,
     logger = log_configure(loglevel, 'cbar get label')
 
     if cbar_label is None:
-        try:
-            cbar_label = data.long_name
-            logger.debug("Using long_name as colorbar label")
-        except AttributeError:
-            cbar_label = data.short_name
-            logger.debug("Using short_name as colorbar label")
+        cbar_label = getattr(data, 'long_name', None)
+        if cbar_label is None:
+            cbar_label = getattr(data, 'short_name', None)
+        if cbar_label is None:
+            cbar_label = getattr(data, 'shortName', None)
+        logger.debug("Using %s as colorbar label", cbar_label)
 
         units = getattr(data, 'units', None)
 
         if units:
             cbar_label = f"{cbar_label} [{units}]"
             logger.debug("Adding units to colorbar label")
+
+    if cbar_label is None:
+        logger.warning("No colorbar label found, please specify one with the cbar_label argument.")
 
     return cbar_label
 


### PR DESCRIPTION
## PR description:

Little improvements to graphics function, little improvements that I found using it more.
Specifically:
- a `display` variable that allows you to not show the plot (useful if you want to save many plots in a for loop not wasting memory
- `shortName` ans `short_name` are both explored to create the `cbar_label`

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [x] Docstrings are updated if needed.
 - [ ] Changelog is updated