### PR TITLE
Fixing gsv logger

### DIFF
--- a/aqua/gsv/intake_gsv.py
+++ b/aqua/gsv/intake_gsv.py
@@ -281,22 +281,22 @@ class GSVSource(base.DataSource):
         return ds
 
 
-class NoPrinting:
-    """
-    Context manager to suppress printing
-    """
+# class NoPrinting:
+#     """
+#     Context manager to suppress printing
+#     """
 
-    def __enter__(self):
-        sys._gsv_work_counter += 1
-        if sys._gsv_work_counter == 1 and not isinstance(sys.stdout, io.StringIO):  # We are really the first
-            sys._org_stdout = sys.stdout  # Record the original in sys
-            self._trap = io.StringIO()
-            sys.stdout = self._trap
+#     def __enter__(self):
+#         sys._gsv_work_counter += 1
+#         if sys._gsv_work_counter == 1 and not isinstance(sys.stdout, io.StringIO):  # We are really the first
+#             sys._org_stdout = sys.stdout  # Record the original in sys
+#             self._trap = io.StringIO()
+#             sys.stdout = self._trap
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        sys._gsv_work_counter -= 1
-        if sys._gsv_work_counter == 0:  # We are really the last one
-            sys.stdout = sys._org_stdout  # Restore the original
+#     def __exit__(self, exc_type, exc_val, exc_tb):
+#         sys._gsv_work_counter -= 1
+#         if sys._gsv_work_counter == 0:  # We are really the last one
+#             sys.stdout = sys._org_stdout  # Restore the original
 
 
 # This function is repeated here in order not to create a cross dependency between GSVSource and AQUA

--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -4,7 +4,6 @@ import os
 import re
 
 import types
-import tempfile
 import shutil
 import intake
 import intake_esm
@@ -48,7 +47,7 @@ class Reader(FixerMixin, RegridMixin):
                  datamodel=None,
                  streaming=False, stream_generator=False,
                  startdate=None, enddate=None,
-                 rebuild=False, loglevel=None, nproc=4, aggregation=None)
+                 rebuild=False, loglevel=None, nproc=4, aggregation=None):
 
         """
         Initializes the Reader class, which uses the catalog


### PR DESCRIPTION
## PR description:

This PR remove the `verbose` flag given that GSV retriever has not a logging facility and it this was ineffective to trap the signals. However,  since the GSV is using a loglevel 'INFO' for the most of the calls, we introduced a temporary hack which increase the loglevel fed to the GSV. In this way only when loglevel is 'DEBUG' at the Reader level we get the overflow of GSV messages

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [x] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [ ] Changelog is updated
