### PR TITLE
More meaningful logging if no units are found in retrieve

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -457,9 +457,10 @@ class Reader(FixerMixin, RegridMixin):
             data = self.fixer(data, var, apply_unit_fix=apply_unit_fix)
 
         # log an error if some variables have no units
-        for var in data.data_vars:
-            if not hasattr(data[var], 'units'):
-                self.logger.error('Variable %s has no units!', var)
+        if isinstance(data, xr.Dataset):
+            for var in data.data_vars:
+                if not hasattr(data[var], 'units'):
+                    self.logger.error('Variable %s has no units!', var)
 
         if self.freq and timmean:
             data = self.timmean(data, exclude_incomplete=self.exclude_incomplete)


### PR DESCRIPTION
## PR description:

Triggered by #654 now the reader is giving a logger error (so just a message) if we retrieve a variable that (even if fixes are off) has no units attribute and log a warning if while fixing it has to give a units to a variable that was not there (before was debug).
