### PR TITLE
Get a valid response at the end of aqua installation on Lumi

### DIFF
--- a/config/machines/lumi/installation/lumi_install.sh
+++ b/config/machines/lumi/installation/lumi_install.sh
@@ -169,17 +169,26 @@ fi
 # ask if you want to add this to the bash profile
 read -p "Would you like to source $load_aqua_file in your .bash_profile? (y/n) " -n 1 -r
 echo
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-  if ! grep -q "source  $load_aqua_file" ~/.bash_profile; then
-    echo "source  $load_aqua_file" >> ~/.bash_profile
-    echo 'load_aqua.sh added to your .bash_profile.'
-  else
-    echo 'load_aqua.sh is already in your bash profile, not adding it again!'
-  fi
-elif [[ $REPLY =~ ^[Nn]$ ]]; then
-  echo "source load_aqua.sh not added to .bash_profile"
-else
-  echo "Invalid response. Please enter 'y' or 'n'."
-fi
-
- 
+# ask if you want to add this to the bash profile
+while true; do
+  read -p "Would you like to source $load_aqua_file in your .bash_profile? (y/n) " -n 1 -r
+  echo
+  case $REPLY in
+    [Yy])
+      if ! grep -q "source  $load_aqua_file" ~/.bash_profile; then
+        echo "source  $load_aqua_file" >> ~/.bash_profile
+        echo 'load_aqua.sh added to your .bash_profile.'
+      else
+        echo 'load_aqua.sh is already in your bash profile, not adding it again!'
+      fi
+      break
+      ;;
+    [Nn])
+      echo "source load_aqua.sh not added to .bash_profile"
+      break
+      ;;
+    *)
+      echo "Invalid response. Please enter 'y' or 'n'."
+      ;;
+  esac
+done


### PR DESCRIPTION
## PR description:
The 'case' and 'break' statements are added to the 'lumi_install.sh', file to get a valid response at the end of the aqua installation on Lumi.

## Issues closed by this pull request: #660

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
