### PR TITLE
Fix wrapper logger

### DIFF
--- a/cli/aqua-analysis/aqua-analysis.sh
+++ b/cli/aqua-analysis/aqua-analysis.sh
@@ -219,7 +219,7 @@ mkdir -p "$outputdir"
 if [ "$run_dummy" = true ] ; then
   colored_echo $GREEN "Running setup checker"
   scriptpy="$aqua/diagnostics/dummy/cli/cli_dummy.py"
-  python $scriptpy $args -l $loglevel
+  python $scriptpy $args -l $loglevel > "$outputdir/setup_checker.log" 2>&1
   
   # Store the error code of the dummy script
   dummy_error=$?


### PR DESCRIPTION
## PR description:

As requested in #697 the logfiles are overwriting and the setup checker logs out in a file as well

## Issues closed by this pull request:

Close part of the issue on #697 