### PR TITLE
List of conditions to drop variables for `_retrieve_plain` expanded

### DIFF
--- a/aqua/reader/regrid.py
+++ b/aqua/reader/regrid.py
@@ -290,7 +290,8 @@ class RegridMixin():
         if isinstance(data, types.GeneratorType):
             data = next(data)
 
-        vars = [var for var in data.data_vars if not var.endswith("_bnds")]
+        vars = [var for var in data.data_vars if
+                not var.endswith("_bnds") and not var.startswith("bounds") and not var.endswith("_bounds")]
         data = data[[vars[0]]]
 
         return data
@@ -300,7 +301,7 @@ class RegridMixin():
         Given a set of default space and vertical dimensions, 
         find the one present in the data and return them
 
-        Args: 
+        Args:
             space_coord (str or list): horizontal dimension already defined. If None, autosearch enabled.
             vert_coord (str or list): vertical dimension already defined. If None, autosearch enabled.
             default_horizontal_dims (list): default dimensions for the horizontal search


### PR DESCRIPTION
## PR description:

As the title, make more generic the "bounds"-like variable exclusion condition in the `_retrieve_plain` in order to be ready for area generation for more generic datasets and observations

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.

 - [ ] Changelog is updated.
