### PR TITLE
duplicate fixer_name found in ERA5 after last update

### DIFF
--- a/config/machines/lumi/catalog/ERA5/era5.yaml
+++ b/config/machines/lumi/catalog/ERA5/era5.yaml
@@ -7,7 +7,6 @@ sources:
     description: ERA5 monthly data from 1940 to 2022
     driver: netcdf
     metadata:
-      fixer_name: ERA5-monthly
       source_grid_name: era5-r025
       fixer_name: ERA5-destine-v1
     args:
@@ -32,7 +31,6 @@ sources:
     description: ERA5 hourly data from 1940 to 2022
     driver: netcdf
     metadata:
-      fixer_name: ERA5-hourly
       source_grid_name: era5-r025
       fixer_name: ERA5-destine-v1
     args:


### PR DESCRIPTION
## PR description:

As the title says, merging immediately since I already tested the solution