### PR TITLE
Fix catalogue for historical-1990-dev-lowres

### DIFF
--- a/config/fixes/IFS.yaml
+++ b/config/fixes/IFS.yaml
@@ -90,6 +90,11 @@ fixer_name:
         nanfirst_startdate: 1990-01-01
         nanfirst_enddate: 1999-10-01
 
+    ifs-nemo-destine-v1-nan-lowres:  # special version for historical-1990-dev-lowres IFS-NEMO data, fixing to nan first step of month
+        parent: ifs-destine-v1
+        nanfirst_startdate: 1990-01-01
+        nanfirst_enddate: 2020-01-01
+
     ifs-fesom-destine-v1-nan:  # special version for historical-1990 IFS-FESOM data, fixing to nan first step of month
         parent: ifs-destine-v1
         nanfirst_startdate: 1990-01-01

--- a/config/machines/lumi/catalog/IFS-NEMO/historical-1990-dev-lowres.yaml
+++ b/config/machines/lumi/catalog/IFS-NEMO/historical-1990-dev-lowres.yaml
@@ -33,7 +33,7 @@ sources:
       variables: [175, 176, 177, 178, 179, 144, 146, 147, 169, 182, 212, 228, 165,
         166, 141, 164, 78, 79, 167, 168, 235]
       source_grid_name: tco79
-      fixer_name: ifs-destine-v1-nan
+      fixer_name: ifs-nemo-destine-v1-nan-lowres
 
   daily-hpz5-atm2d:
     <<: *base-default


### PR DESCRIPTION
## PR description:

It turns out that the catalogue for this experiment had a wrong encoding of `savefreq` which was set to 'monthly' for the daily sources (so that only one frame every 30/31 days was used)
Also, fluxes are bugged and need to be corrected with our nanfix.