### PR TITLE
Timeseries hotfix lcc, mcc, hcc + scenario added variables

### DIFF
--- a/diagnostics/global_time_series/cli/config_time_series_atm.yaml
+++ b/diagnostics/global_time_series/cli/config_time_series_atm.yaml
@@ -57,12 +57,3 @@ timeseries_plot_params:
   #   resample: "M"
   #   savefig: True
   #   ylim: [-10, 10]
-  lcc: # no ERA5 yet
-    plot_era5: False
-    annual: True
-  mcc: # no ERA5 yet
-    plot_ref: False
-    annual: True
-  hcc: # no ERA5 yet
-    plot_ref: False
-    annual: True

--- a/diagnostics/global_time_series/cli/config_time_series_atm_historical.yaml
+++ b/diagnostics/global_time_series/cli/config_time_series_atm_historical.yaml
@@ -56,20 +56,3 @@ timeseries_plot_params:
   #   resample: "M"
   #   savefig: True
   #   ylim: [-10, 10]
-  lcc: # no ERA5 yet
-    plot_kw:
-      color: "tab:blue"
-    plot_ref: False
-    resample: null
-    savefig: True
-    annual: True
-  mcc: # no ERA5 yet
-    plot_ref: False
-    resample: null
-    savefig: True
-    annual: True
-  hcc: # no ERA5 yet
-    plot_ref: False
-    resample: null
-    savefig: True
-    annual: True

--- a/diagnostics/global_time_series/cli/config_time_series_atm_scenario.yaml
+++ b/diagnostics/global_time_series/cli/config_time_series_atm_scenario.yaml
@@ -12,9 +12,29 @@ models:
 outputdir: "./IFS-NEMO/scenario/"
 
 # This is the list of variables that will be plotted as timeseries
-timeseries: ['2t', 'mtpr']
+timeseries: ['2t', 'mtpr', 'mer', 'msl',
+             'tcc', 'lcc', 'mcc', 'hcc',
+             'mslhf', #Mean surface latent heat flux
+             'msshf', #Mean surface sensible heat flux
+             'msdwswrf', #Mean surface downward short-wave radiation flux
+             'msdwlwrf', #Mean surface downward long-wave radiation flux
+             'msnswrf', #Mean surface net short-wave radiation flux
+             'msnlwrf', #Mean surface net long-wave radiation flux
+             'mtnlwrf', #Mean top net long-wave radiation flux
+             'mtnswrf' #Mean top net short-wave radiation flux
+             ]
 timeseries_formulae: ['mtnlwrf+mtnswrf']
-seasonal_cycle: ['2t', 'mtpr']
+seasonal_cycle: ['2t', 'mtpr', 'mer', 'msl',
+                 'tcc', 'lcc', 'mcc', 'hcc',
+                 'mslhf', #Mean surface latent heat flux
+                 'msshf', #Mean surface sensible heat flux
+                 'msdwswrf', #Mean surface downward short-wave radiation flux
+                 'msdwlwrf', #Mean surface downward long-wave radiation flux
+                 'msnswrf', #Mean surface net short-wave radiation flux
+                 'msnlwrf', #Mean surface net long-wave radiation flux
+                 'mtnlwrf', #Mean top net long-wave radiation flux
+                 'mtnswrf' #Mean top net short-wave radiation flux
+                 ]
 
 gregory:
   ts: '2t'
@@ -43,12 +63,3 @@ timeseries_plot_params:
   #   resample: "M"
   #   savefig: True
   #   ylim: [-10, 10]
-  lcc: # no ERA5 yet
-    plot_ref: False
-    annual: True
-  mcc: # no ERA5 yet
-    plot_ref: False
-    annual: True
-  hcc: # no ERA5 yet
-    plot_ref: False
-    annual: True


### PR DESCRIPTION
## PR description:

Since lcc, mcc, hcc are now available on ERA5 I'm adding ERA5 reference data in the timeseries diagnostic.
