### PR TITLE
Push to web with a last_update text file

### DIFF
--- a/cli/aqua-web/push_analysis.sh
+++ b/cli/aqua-web/push_analysis.sh
@@ -44,6 +44,8 @@ do
     mv -- "$file" "${file%_*_*}.pdf"
 done
 
+echo $(date) > $dstdir/last_update.txt
+
 # commit and push
 log_message INFO "Commit and push"
 


### PR DESCRIPTION
## PR description:

Small change to the cli tool pushing to aqua-web which now adds a `last_update.txt` text file with the current date to the experiment figure folder uploaded to the repository. This allows determining the date of last update in a more robust way. This pairs with a recent change to aqua-web. No changelog needed.

