### PR TITLE
Hotfix to radiation to work with ICON

### DIFF
--- a/diagnostics/radiation/cli/cli_radiation.py
+++ b/diagnostics/radiation/cli/cli_radiation.py
@@ -108,9 +108,9 @@ if __name__ == '__main__':
 
     if box_plot_bool:
         try:
-            datasets = [ceres, model_data]
+            datasets = [era5, ceres, model_data]
             boxplot_model_data(datasets=datasets, outputdir=outputdir, outputfig=outputfig, loglevel=loglevel)
-            logger.info("The boxplot with provided model and CERES was created and saved. Variables ttr and tsr are plotted to show imbalances.")
+            logger.info("The boxplot with provided model and CERES+ERA5 was created and saved. Variables ttr and tsr are plotted to show imbalances.")
         except Exception as e:
             # Handle other exceptions
             logger.error(f"An unexpected error occurred: {e}")

--- a/diagnostics/radiation/radiation_functions.py
+++ b/diagnostics/radiation/radiation_functions.py
@@ -77,7 +77,7 @@ def process_ceres_data(exp=None, source=None, fix=True, loglevel='WARNING'):
     return dictionary
 
 
-def process_model_data(model=None, exp=None, source=None, fix=False, loglevel='WARNING'):
+def process_model_data(model=None, exp=None, source=None, fix=True, loglevel='WARNING'):
     """
     Function to extract Model output data for further analysis and create global means.
 


### PR DESCRIPTION
## PR description:

Radiation diagnostics was not working correctly with ICON.
The reason is that data retrieval was done with fix = False by default.
this hotfix solves that. I profited from this to also include again ERA5 in the comparison, I believe it is useful.

Since it is a minor fix, I do not think that a changelog is needed. 
