### PR TITLE
Fix for formula in timeseries, if formula cannot be evaluated, do not create a plot

### DIFF
--- a/diagnostics/global_time_series/global_time_series/timeseries.py
+++ b/diagnostics/global_time_series/global_time_series/timeseries.py
@@ -176,6 +176,8 @@ class Timeseries():
                     data = reader.retrieve()
                     self.logger.debug(f"Evaluating formula for {self.var}")
                     data = eval_formula(self.var, data)
+                    if data is None:
+                        self.logger.error(f"Formula evaluation failed for {model} {self.exps[i]} {self.sources[i]}")
                 else:
                     data = reader.retrieve(var=self.var)
                     data = data[self.var]
@@ -202,7 +204,10 @@ class Timeseries():
                     data_mon = reader.timmean(data, freq='MS', exclude_incomplete=True)
                 data_mon = reader.fldmean(data_mon)
                 self.logger.info("Monthly data retrieved")
-                self.data_mon.append(data_mon)
+                if data_mon is not None:
+                    self.data_mon.append(data_mon)
+                else:
+                    self.logger.warning(f"No monthly data found for {model} {self.exps[i]} {self.sources[i]}")
 
             if self.annual:
                 data_ann = reader.timmean(data, freq='YS',
@@ -210,7 +215,10 @@ class Timeseries():
                                           center_time=True)
                 data_ann = reader.fldmean(data_ann)
                 self.logger.info("Annual data retrieved")
-                self.data_annual.append(data_ann)
+                if data_ann is not None:
+                    self.data_annual.append(data_ann)
+                else:
+                    self.logger.warning(f"No annual data found for {model} {self.exps[i]} {self.sources[i]}")
 
             # Clean up
             del reader


### PR DESCRIPTION
## PR description:

Since for eval_formula we do a full retrieve, the normal NoDataError handling does not work and we've noticed in a framework test run that an empty plot (ERA5 only) plot is produced in that case.
This PR avoid this possibility with an ad-hoc error handling for formulae-
