### PR TITLE
[Teleconnections] cbar range for maps can be set up from config file

### DIFF
--- a/diagnostics/teleconnections/cli/cli_config_atm.yaml
+++ b/diagnostics/teleconnections/cli/cli_config_atm.yaml
@@ -42,3 +42,4 @@ NAO:
   months_window: 3
   full_year: false
   seasons: ['DJF', 'JJA'] # to analyse additionally to the full data
+  cbar_range: [-5, 5] # colorbar range for the regression figures

--- a/diagnostics/teleconnections/cli/cli_config_oce.yaml
+++ b/diagnostics/teleconnections/cli/cli_config_oce.yaml
@@ -42,3 +42,4 @@ ENSO:
   months_window: 3
   full_year: true
   seasons: null # to analyse additionally to the full data
+  cbar_range: [-2, 2] # colorbar range for the regression figures

--- a/diagnostics/teleconnections/cli/cli_teleconnections.py
+++ b/diagnostics/teleconnections/cli/cli_teleconnections.py
@@ -426,10 +426,16 @@ if __name__ == '__main__':
                     logger.debug('titles: %s', titles)
                     logger.debug('descriptions: %s', descriptions)
                     for i, data_map in enumerate(maps):
+                        vmin, vmax = config[telec].get('cbar_range', None)
+                        if vmin is None or vmax is None:
+                            sym = True
+                        else:
+                            sym = False
                         try:
                             plot_single_map_diff(data=data_map,
                                                  data_ref=ref_maps[i],
-                                                 save=True, sym=True,
+                                                 save=True, sym=sym,
+                                                 vmin_fill=vmin, vmax_fill=vmax,
                                                  cbar_label=cbar_labels[i],
                                                  outputdir=tc.outputfig,
                                                  filename=map_names[i],
@@ -443,7 +449,7 @@ if __name__ == '__main__':
                             try:
                                 plot_single_map_diff(data=data_map,
                                                      data_ref=ref_maps[i],
-                                                     save=True, sym=True,
+                                                     save=True, sym=sym,
                                                      cbar_label=cbar_labels[i],
                                                      outputdir=tc.outputfig,
                                                      filename=map_names[i],
@@ -530,9 +536,15 @@ if __name__ == '__main__':
                     logger.debug('titles: %s', titles)
                     logger.debug('descriptions: %s', descriptions)
                     for i, data_map in enumerate(maps):
+                        vmin, vmax = config[telec].get('cbar_range', None)
+                        if vmin is None or vmax is None:
+                            sym = True
+                        else:
+                            sym = False
                         try:
                             plot_single_map(data=data_map,
-                                            save=True, sym=True,
+                                            save=True, sym=sym,
+                                            vmin=vmin, vmax=vmax,
                                             cbar_label=cbar_labels[i],
                                             outputdir=tc.outputfig,
                                             filename=map_names[i],
@@ -545,7 +557,7 @@ if __name__ == '__main__':
                             logger.info('Trying with transform_first=True')
                             try:
                                 plot_single_map(data=data_map,
-                                                save=True, sym=True,
+                                                save=True, sym=sym,
                                                 cbar_label=cbar_labels[i],
                                                 outputdir=tc.outputfig,
                                                 filename=map_names[i],


### PR DESCRIPTION
## PR description:

In order to have standard regression maps cbar range for website comparison now the config file have an optional `cbar_range` option. This is set as +/-2K for ENSO regression and +/-5 hpa for NAO regression
