### PR TITLE
Hotfix time chunks 

### DIFF
--- a/aqua/reader/reader.py
+++ b/aqua/reader/reader.py
@@ -1013,6 +1013,8 @@ class Reader(FixerMixin, RegridMixin, TimmeanMixin):
         if isinstance(chunks, dict):
             if self.aggregation and not chunks.get('time'):
                 chunks['time'] = self.aggregation
+            if self.streaming and not self.aggregation:
+                self.logger.warning("Aggregation is not set, using default time resolution for streaming. If you are asking for a longer chunks['time'] for GSV access, please set a suitable aggregation value")
     
         if dask:
             if chunks:  # if the chunking or aggregation option is specified override that from the catalogue


### PR DESCRIPTION
## PR description:
This PR addresses a bug found by @kat-grayson (issue #1033). 
It's a particular case in which `chunks` is a dictionary without the `time` key and `aggregation` is given . In this case we now put `chunks['time']` equal to `aggregation`

Code example:
```
reader = Reader(model="ICON", exp="ssp370", source="hourly-hpz10-atm3d", enddate = "20210201",  
        streaming = 'True', regrid = 'r100', aggregation ='D', chunks={'vertical': 5})
```
<img width="829" alt="Screenshot 2024-03-27 at 17 48 08" src="https://github.com/DestinE-Climate-DT/AQUA/assets/29037612/4a87c784-f7c4-4637-b96b-168545b4465e">




## Issues closed by this pull request:

Close #1033

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Changelog is updated.

