### PR TITLE
Reverting machine to lumi

### DIFF
--- a/config/config-aqua.yaml
+++ b/config/config-aqua.yaml
@@ -1,6 +1,6 @@
 # machine dependent configuration file for AQUA
 # so far nothing is really strict
-machine: levante
+machine: lumi
 
 reader: 
   catalog: '{configdir}/machines/{machine}/catalog.yaml'


### PR DESCRIPTION
## PR description:

During the deliverable PRs someone didn't revert the machine to lumi while committing. This PR brings back lumi as default machine name