### PR TITLE
Correct the GSV Git token after the project was moved (mea culpa)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "sparse",
     "xarray",
     "pyfdb@git+https://github.com/ecmwf/pyfdb.git@0.0.3",
-    "gsv@git+https://oauth2:NrMi_dshtmNeaWy9F3sz@earth.bsc.es/gitlab/digital-twins/de_340/gsv_interface.git@v1.4.0"
+    "gsv@git+https://oauth2:pXj19aBDApiBPs1YgwuZ@earth.bsc.es/gitlab/digital-twins/de_340-2/gsv_interface.git@v1.4.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## PR description:

We moved the GSV Git repository, and even though we performed tests for issues/merge-requests/wiki/etc., we did not consider testing what happens to tokens in the repositories.

Unfortunately the tokens are not migrated, which caused issues when installing AQUA, apologies.

I created a new Git token with read-only for pulling the repository, with expiration set to December 31 2027. I tested it locally on a conda environment before & after the change. With the old token, it immediately failed to install due to the token. With this new token, it cloned successfully, but failed to install due to Cython.

I **think** it could be due to my environment, as I just created and randomly selected a version of Python (3.10). The errors I got were related to pyyaml and cython. Maybe someone else can test it on a working environment? (Sorry, I haven't built AQUA on my laptop in a while, and I purge old conda/docker/venv environments due to disk space).