### PR TITLE
Fix aqua-web links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ This installation will provide both the AQUA framework and the AQUA diagnostics,
 
 ### Use of AQUA container 
 
-An alternative deployment making use of containers is available. Please refer to the `Container` chapter in the [AQUA Documentation](https://aqua-web-contbuild.2.rahtiapp.fi/documentation/container.html).
+An alternative deployment making use of containers is available. Please refer to the `Container` chapter in the [AQUA Documentation](https://aqua-web-climatedt.2.rahtiapp.fi/documentation/container.html).
 
 ## Documentation
 
-Full [AQUA Documentation](https://aqua-web-contbuild.2.rahtiapp.fi/documentation/index.html) is available.
+Full [AQUA Documentation](https://aqua-web-climatedt.2.rahtiapp.fi/documentation/index.html) is available.
 Please notice that the webpage is password protected.
 You can find the credentials in the [wiki page](https://wiki.eduuni.fi/display/cscRDIcollaboration/AQUA+-+Meetings) or please contact the AQUA team to get access.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ all = [
 aqua = "aqua.cli.main:main"
 
 [project.urls]
-homepage = "https://aqua-web-contbuild.2.rahtiapp.fi"
-documentation = "https://aqua-web-contbuild.2.rahtiapp.fi/documentation/index.html"
+homepage = "https://aqua-web-climatedt.2.rahtiapp.fi"
+documentation = "https://aqua-web-climatedt.2.rahtiapp.fi/documentation/index.html"
 repository = "https://github.com/DestinE-Climate-DT/AQUA/"
 issues = "https://github.com/DestinE-Climate-DT/AQUA/issues/"
 


### PR DESCRIPTION
This fixes links to Aqua explorer in `pyproject.toml` and in the `README.md`.
It is a minor hotfix, so a changelog is not needed.

### Issues closed by this pull request:

Close #1221 

