### PR TITLE
Test Non-Editable AQUA Package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@
 # or if you really want to use conda
 # conda env create -f environment.yml
 
+#TRIGGERING THE TESTS
 name: aqua
 channels:
   - conda-forge


### PR DESCRIPTION
## PR description:

Testing the non-editable AQUA package. The environment.yml file creates an editable package. The `lumi-install.sh` script also creates an editable package (not needed for actions). Therefore, we have not thoroughly tested the non-editable, default version of AQUA. 

## Please run the workflow tests.

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.

