### PR TITLE
removed fix for avg_tos, as it is named as that in the data as well.

### DIFF
--- a/config/fixes/IFS.yaml
+++ b/config/fixes/IFS.yaml
@@ -97,9 +97,6 @@ fixer_name:
             2t: 
                 source: mean2t
                 grib: true
-            avg_tos:
-                source: sst
-                grib: true
             mtpr: # https://codes.ecmwf.int/grib/param-db/235055
                 source: mtpr
                 grib: True


### PR DESCRIPTION
Removed avg_tos -> sst fix. Only with this the ENSO teleconnection diagnostic works using the reduced output. 