### PR TITLE
[WIP] `definition_path` instead of a switch of definition folder

### DIFF
--- a/aqua/gsv/intake_gsv.py
+++ b/aqua/gsv/intake_gsv.py
@@ -241,9 +241,9 @@ class GSVSource(base.DataSource):
         else:
             self.chunking_vertical = None  # no vertical chunking
 
-        self._switch_eccodes()
+        # self._switch_eccodes()
 
-        self.get_eccodes_shortname = init_get_eccodes_shortname()  # Can't pickle this, so we need to reinitialize it
+        self.get_eccodes_shortname = init_get_eccodes_shortname(definition_path=self.eccodes_path)  # Can't pickle this, so we need to reinitialize it
 
         super(GSVSource, self).__init__(metadata=metadata)
 
@@ -452,7 +452,7 @@ class GSVSource(base.DataSource):
             if self.fdbpath:  # if fdbpath provided, use it, since we are creating a new gsv
                 os.environ["FDB5_CONFIG_FILE"] = self.fdbpath
 
-        self._switch_eccodes()
+        # self._switch_eccodes()
 
         # this is needed here and not in init because each worker spawns a new environment
         gsv_log_level = _check_loglevel(self.logger.getEffectiveLevel())

--- a/aqua/util/eccodes.py
+++ b/aqua/util/eccodes.py
@@ -26,12 +26,13 @@ from aqua.exceptions import NoEcCodesShortNameError
 #     return yaml.load(text)
 
 
-def read_eccodes_def(filename):
+def read_eccodes_def(filename, definition_path=None):
     """
     Reads an ecCodes definition file and returns its keys as a list.
 
     Parameters:
         filename (str): The name of the ecCodes definition file to read.
+        definition_path (str): The path to the ecCodes definitions. If None, the default path is used.
 
     Returns:
         A list containing the keys of the ecCodes definition file.
@@ -47,7 +48,10 @@ def read_eccodes_def(filename):
                    'ecmwf': []
                }}
 
-    fn_eccodes = eccodes.codes_definition_path().split(':')[0]  # LUMI fix, take only first
+    if definition_path is None:
+        fn_eccodes = eccodes.codes_definition_path().split(':')[0]  # LUMI fix, take only first
+    else:
+        fn_eccodes = definition_path
 
     # WMO lists
     fn = os.path.join(fn_eccodes, 'grib2', filename)
@@ -72,13 +76,13 @@ def read_eccodes_def(filename):
 
 
 # Define this as a closure to avoid reading twice the same file
-def _init_get_eccodes_attr():
-    shortname = read_eccodes_def("shortName.def")
-    paramid = read_eccodes_def("paramId.def")
-    name = read_eccodes_def("name.def")
-    cfname = read_eccodes_def("cfName.def")
-    cfvarname = read_eccodes_def("cfVarName.def")
-    units = read_eccodes_def("units.def")
+def _init_get_eccodes_attr(definition_path=None):
+    shortname = read_eccodes_def("shortName.def", definition_path=definition_path)
+    paramid = read_eccodes_def("paramId.def", definition_path=definition_path)
+    name = read_eccodes_def("name.def", definition_path=definition_path)
+    cfname = read_eccodes_def("cfName.def", definition_path=definition_path)
+    cfvarname = read_eccodes_def("cfVarName.def", definition_path=definition_path)
+    units = read_eccodes_def("units.def", definition_path=definition_path)
 
     def _get_eccodes_attr(sn, loglevel='WARNING'):
         """
@@ -86,6 +90,7 @@ def _init_get_eccodes_attr():
 
         Args:
             shortname(str): the shortname to search
+            definition_path(str, opt): the path to the eccodes definitions
             loglevel (str): the loggin level
         Returns:
             A dictionary containing param, long_name, units, short_name
@@ -136,18 +141,19 @@ get_eccodes_attr = _init_get_eccodes_attr()
 
 
 # Define this as a closure to avoid reading twice the same file
-def init_get_eccodes_shortname():
+def init_get_eccodes_shortname(definition_path=None):
     """
     Recover eccodes shorthname from a given paramid
 
     Args:
+        definition_path(str, opt): the path to the eccodes definitions
         var(str, int): the variable name (a short_name or a paramid)
 
     Returns:
         A string containing the short_name
     """
-    shortname = read_eccodes_def("shortName.def")
-    paramid = read_eccodes_def("paramId.def")
+    shortname = read_eccodes_def("shortName.def", definition_path=definition_path)
+    paramid = read_eccodes_def("paramId.def", definition_path=definition_path)
 
     def _get_eccodes_shortname(var):
         """


### PR DESCRIPTION
Close #1282 

Testing our closure with the definition path and not a switch eccodes. Anyway the issue is the same for the GSV from my quick tests, that should probably do something similar when using eccodes.

I still have to test if this is enough if I install eccodes 2.36, now I'm in an environment with 2.33 since we need it to keep the other sources available.