### PR TITLE
`--bind /appl/local/destine/ \` added to containers call on lumi

### DIFF
--- a/cli/lumi-container/load_container_lumi.sh
+++ b/cli/lumi-container/load_container_lumi.sh
@@ -83,6 +83,7 @@ singularity $cmd \
     --bind /pfs/lustrep4/ \
     --bind /pfs/lustrep3/scratch/ \
     --bind /appl/local/climatedt/ \
+    --bind /appl/local/destine/ \
     --bind /flash/project_465000454 \
     --bind /projappl/ \
     --bind /project \

--- a/cli/lumi-container/slurm_job_container.sh
+++ b/cli/lumi-container/slurm_job_container.sh
@@ -29,6 +29,7 @@ singularity exec \
     --bind /pfs/lustrep4/ \
     --bind /pfs/lustrep3/scratch/ \
     --bind /appl/local/climatedt/ \
+    --bind /appl/local/destine/ \
     --bind /flash/project_465000454 \
     --bind /projappl/ \
     --bind /project \


### PR DESCRIPTION
## PR description:

Due to new links created in `/appl/local/climatedt` the container bindings are failing with some sources. This is a fix of the issue.
