### PR TITLE
Removed remants of `expand` keyword in timeseries

### DIFF
--- a/diagnostics/global_time_series/cli/cli_global_time_series.py
+++ b/diagnostics/global_time_series/cli/cli_global_time_series.py
@@ -76,7 +76,7 @@ def get_plot_options(config: dict = None,
         plot_kw = plot_options.get("plot_kw", {})
         longname = plot_options.get("longname", None)
         units = plot_options.get("units", None)
-        expand = plot_options.get("expand", True)
+        extend = plot_options.get("extend", True)
     else:
         monthly = config["timeseries_plot_params"]["default"].get("monthly", True)
         annual = config["timeseries_plot_params"]["default"].get("annual", True)
@@ -94,9 +94,9 @@ def get_plot_options(config: dict = None,
         plot_kw = config["timeseries_plot_params"]["default"].get("plot_kw", {})
         longname = None
         units = None
-        expand = config["timeseries_plot_params"]["default"].get("expand", True)
+        extend = config["timeseries_plot_params"]["default"].get("extend", True)
     return monthly, annual, regrid, plot_ref, plot_ref_kw, startdate, enddate, \
-        monthly_std, annual_std, std_startdate, std_enddate, plot_kw, longname, units, expand
+        monthly_std, annual_std, std_startdate, std_enddate, plot_kw, longname, units, extend
 
 
 if __name__ == '__main__':
@@ -154,7 +154,7 @@ if __name__ == '__main__':
             logger.info(f"Plotting {var} time series")
             monthly, annual, regrid, plot_ref, plot_ref_kw, startdate, \
                 enddate, monthly_std, annual_std, std_startdate, std_enddate, \
-                plot_kw, longname, units, expand = get_plot_options(config, var)
+                plot_kw, longname, units, extend = get_plot_options(config, var)
 
             ts = Timeseries(var=var,
                             formula=False,
@@ -175,7 +175,7 @@ if __name__ == '__main__':
                             std_enddate=std_enddate,
                             longname=longname,
                             units=units,
-                            expand=expand,
+                            extend=extend,
                             plot_kw=plot_kw,
                             outdir=outputdir,
                             loglevel=loglevel)
@@ -197,7 +197,7 @@ if __name__ == '__main__':
             logger.info(f"Plotting {var} time series")
             monthly, annual, regrid, plot_ref, plot_ref_kw, startdate, \
                 enddate, monthly_std, annual_std, std_startdate, std_enddate, \
-                plot_kw, longname, units, expand = get_plot_options(config, var)
+                plot_kw, longname, units, extend = get_plot_options(config, var)
 
             ts = Timeseries(var=var,
                             formula=True,
@@ -219,7 +219,7 @@ if __name__ == '__main__':
                             plot_kw=plot_kw,
                             longname=longname,
                             units=units,
-                            expand=expand,
+                            extend=extend,
                             outdir=outputdir,
                             loglevel=loglevel)
             try:

--- a/diagnostics/global_time_series/deliverable/config_deliverable.yaml
+++ b/diagnostics/global_time_series/deliverable/config_deliverable.yaml
@@ -39,15 +39,15 @@ timeseries_plot_params:
     annual: True
     std_startdate: '1990-01-01'
     std_enddate: '2020-12-31'
-    expand: False
+    extend: False
   mtnlwrf+mtnswrf:
     longname: "Mean top net radiation" # This is to override title and ylabel
     std_startdate: '1990-01-01'
     std_enddate: '2020-12-31'
-    expand: False
+    extend: False
   86400*mtpr:
     longname: "Precipitation" # This is to override title and ylabel
     units: "mm/day" # This is to override units
     std_startdate: '1990-01-01'
     std_enddate: '2020-12-31'
-    expand: False
+    extend: False

--- a/diagnostics/global_time_series/global_time_series/timeseries.py
+++ b/diagnostics/global_time_series/global_time_series/timeseries.py
@@ -469,7 +469,7 @@ class Timeseries():
             self.logger.info(f"Monthly reference data time available {startdate} to {enddate}")
 
             if startdate > self.startdate or enddate < self.enddate:
-                self.logger.info("Expanding reference range with a seasonal cycle")
+                self.logger.info("Extending reference range with a seasonal cycle")
                 self.extending_ref_range = True
 
                 # TODO: startdate has to be rounded to the first of the month
@@ -500,7 +500,7 @@ class Timeseries():
             self.logger.info(f"Annual reference data time available {startdate} to {enddate}")
 
             if startdate > self.startdate or enddate < self.enddate:
-                self.logger.info("Expanding reference range with a band of the reference data")
+                self.logger.info("Extending reference range with a band of the reference data")
                 self.extending_ref_range = True
 
                 # TODO: startdate has to be rounded to the center of the year (month=7)


### PR DESCRIPTION
## PR description:

As noticed [here](https://earth.bsc.es/gitlab/digital-twins/de_340-2/project_management/-/issues/389#note_303072), remnants of the PR #1299
