### PR TITLE
update gsv retriever version to extend support to python3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version:
 
 AQUA core complete list:
-- Full support for python>=3.9
-- Pin of eccodes=2.36.0 until issues with 2.37 are addressed
+- Full support for python>=3.9 (#1325)
+- Pin of eccodes<2.37.0 in pyproject due to recent changes in binary/python structure (#1325)
 
 AQUA diagnostic complete list:
 - Radiation: Bugfix in the CLI for the radiation diagnostic (#1319)

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - cdo>=2.2.0,<=2.4.0 #for healpix support
   # for eccodes see issues #252, #634, #870, #1282
   # PR #36 catalog repo
-  - eccodes==2.36.0
+  - eccodes>=2.36.0
   - pandas      
   - pandoc
   - pip


### PR DESCRIPTION
## PR description:

New version of GSV interface allows for support from python 3.9, checking if tests can be passed

## Issues closed by this pull request:

Close #1058 


