### PR TITLE
Preparation for v0.11.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,11 +49,11 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.11.3
       - v0.11.2
       - v0.11.1
       - v0.11
       - v0.10.*
-      - v0.9.*
       - older
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version:
 
 AQUA core complete list:
+
+AQUA diagnostic complete list:
+
+## [v0.11.3]
+
+AQUA core complete list:
 - LRA, both from CLI and worklow, is part of the AQUA console and can be run with `aqua lra $options` (#1294)
 - FDB catalog generator is part of the AQUA console and can be run with `aqua catgen $options` (#1294)
 - Coordinate unit overriding is now possible via the `tgt_units` argument (#1320)
@@ -636,7 +642,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.11.2...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.11.3...HEAD
+[v0.11.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.11.2...v0.11.3
 [v0.11.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.11.1...v0.11.2
 [v0.11.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.11...v0.11.1
 [v0.11]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.10.3...v0.11

--- a/aqua/__init__.py
+++ b/aqua/__init__.py
@@ -6,7 +6,7 @@ from .reader import Reader, catalog, Streaming, inspect_catalog
 from .slurm import squeue, job, output_dir, scancel, max_resources_per_node
 from .accessor import AquaAccessor
 
-__version__ = '0.11.2'
+__version__ = '0.11.3'
 
 __all__ = ["plot_single_map", "plot_maps", "plot_single_map_diff", "plot_timeseries",
            "plot_hovmoller",

--- a/cli/levante-container/load_container_levante.sh
+++ b/cli/levante-container/load_container_levante.sh
@@ -12,7 +12,7 @@ else
     # Your subsequent commands here
 fi
 setup_log_level 2 # 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=CRITICAL
-AQUA_container="/work/bb1153/b382289/container/AQUA/aqua-v0.11.2.sif"
+AQUA_container="/work/bb1153/b382289/container/AQUA/aqua-v0.11.3.sif"
 GRID_DEFINITION_PATH="/work/bb1153/b382321/grid_definitions"
 
 # Simple command line parsing

--- a/cli/levante-container/slurm_job_container.sh
+++ b/cli/levante-container/slurm_job_container.sh
@@ -11,7 +11,7 @@
 set -e
 
 # export AQUA = PATH_TO_AQUA_repo
-AQUA_container="/work/bb1153/b382289/container/AQUA/aqua-v0.11.2.sif"
+AQUA_container="/work/bb1153/b382289/container/AQUA/aqua-v0.11.3.sif"
 GRID_DEFINITION_PATH="/work/bb1153/b382321/grid_definitions"
 
 module load singularity

--- a/cli/lumi-container/load_container_lumi.sh
+++ b/cli/lumi-container/load_container_lumi.sh
@@ -12,7 +12,7 @@ else
     # Your subsequent commands here
 fi
 setup_log_level 2 # 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=CRITICAL
-AQUA_container="/project/project_465000454/containers/aqua/aqua-v0.11.2.sif"
+AQUA_container="/project/project_465000454/containers/aqua/aqua-v0.11.3.sif"
 GSV_WEIGHTS_PATH="/scratch/project_465000454/igonzalez/gsv_weights/"
 GRID_DEFINITION_PATH="/scratch/project_465000454/igonzalez/grid_definitions"
 

--- a/cli/lumi-container/slurm_job_container.sh
+++ b/cli/lumi-container/slurm_job_container.sh
@@ -10,7 +10,7 @@
 #SBATCH -p debug    #change the partition
 
 AQUA_path=$AQUA
-AQUA_container=/project/project_465000454/containers/aqua/aqua-v0.11.2.sif
+AQUA_container=/project/project_465000454/containers/aqua/aqua-v0.11.3.sif
 GSV_WEIGHTS_PATH=/scratch/project_465000454/igonzalez/gsv_weights/
 GRID_DEFINITION_PATH=/scratch/project_465000454/igonzalez/grid_definitions
 

--- a/cli/marenostrum5-container/load_container_mn5.sh
+++ b/cli/marenostrum5-container/load_container_mn5.sh
@@ -14,7 +14,7 @@ fi
 setup_log_level 2 # 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=CRITICAL
 # If you don't have access to ehpc01, use the below bsc32 path
 # AQUA_container="/gpfs/projects/bsc32/DestinE/containers/aqua/aqua_0.9.2.sif"
-AQUA_container="/gpfs/projects/ehpc01/containers/AQUA/aqua_0.11.2.sif"
+AQUA_container="/gpfs/projects/ehpc01/containers/AQUA/aqua_0.11.3.sif"
 
 # Simple command line parsing
 user_defined_aqua="ask"

--- a/cli/marenostrum5-container/slurm_job_container.sh
+++ b/cli/marenostrum5-container/slurm_job_container.sh
@@ -12,7 +12,7 @@
 AQUA_path=$AQUA
 # If you don't have access to ehpc01, use the below bsc32 path
 # AQUA_container="/gpfs/projects/bsc32/DestinE/containers/aqua/aqua_0.9.2.sif"
-AQUA_container="/gpfs/projects/ehpc01/containers/AQUA/aqua_0.11.2.sif"
+AQUA_container="/gpfs/projects/ehpc01/containers/AQUA/aqua_0.11.3.sif"
 # singularity shell can be an option depending on the requirement
 singularity exec \
     --cleanenv \


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update container name on lumi (both load and slurm scripts)
- [x] update container name on levante (both load and slurm scripts)
- [x] update container name on MN5 (both load and slurm scripts)
- [x] update bug report menu
- [x] update version number on init
- [x] quick check gsv pin
