### PR TITLE
IFS-NEMO reduced plans v2 fixer

### DIFF
--- a/config/fixes/IFS-NEMO-climatedt-v2.yaml
+++ b/config/fixes/IFS-NEMO-climatedt-v2.yaml
@@ -41,3 +41,18 @@ fixer_name:
       q: 
         source: mq
         grib: true
+  
+  ifs-nemo-reduced-output-monthly-v2:
+    parent: ifs-destine-v1
+    data_model: ifs
+    deltat: monthly
+    vars:
+      2t: 
+        source: mean2t
+        grib: true
+      mtpr:
+        source: tp
+        grib: True
+        # decumulate: true
+        src_units: m
+        units: kg m**-2 s**-1


### PR DESCRIPTION
## PR description:

This PR includes a new fixer for the IFS-NEMO model, which has been successfully used to analyze the IR experiments conducted using reduced plans and the `lab/kai/DE_CY48R1.0_climateDT_20240523_intel_gpp` model version. 

It has been included as part of the existing IFS-NEMO-climatedt-v2.yaml configuration.