### PR TITLE
Requiring python<3.13, Fix #1400

### DIFF
--- a/cli/lumi-install/environment_lumi.yml
+++ b/cli/lumi-install/environment_lumi.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
-  - python>=3.9
+  - python>=3.9,<3.13
   - cdo>=2.2.0,<=2.4.0 #for healpix support
   - pandas      
   - pandoc

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
-  - python>=3.9
+  - python>=3.9,<3.13
   - cdo>=2.2.0,<=2.4.0 #for healpix support
   # for eccodes see issues #252, #634, #870, #1282
   # PR #36 catalog repo


### PR DESCRIPTION
## PR description:

Pinning python < 3.13 since it was released too recently.

## Issues closed by this pull request:

Close #1400 
