### PR TITLE
Hotfix remove flash binding on lumi

### DIFF
--- a/cli/lumi-container/load_container_lumi.sh
+++ b/cli/lumi-container/load_container_lumi.sh
@@ -84,11 +84,13 @@ singularity $cmd \
     --bind /pfs/lustrep3/scratch/ \
     --bind /appl/local/climatedt/ \
     --bind /appl/local/destine/ \
-    --bind /flash/project_465000454 \
     --bind /projappl/ \
     --bind /project \
     --bind /scratch/ \
     $AQUA_container $script
+
+# Removed because not needed/not working
+#     --bind /flash/project_465000454 \
 
 # Run this script in LUMI in VSCode 
 


### PR DESCRIPTION
Hotfix to remove a possibly useless binding from `load_container_lumi.sh` which was freezing on lumi
