### PR TITLE
Fix to E999 flake8 issue on python<3.12

### DIFF
--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -255,7 +255,7 @@ class LRAgenerator():
 
         # modify filename if realization is there
         if 'realization' in self.kwargs:
-            urlpath = os.path.join(self.outdir, f'*{self.exp}_r{self.kwargs['realization']}_{self.resolution}_{self.frequency}_*.nc')
+            urlpath = os.path.join(self.outdir, f"*{self.exp}_r{self.kwargs['realization']}_{self.resolution}_{self.frequency}_*.nc")
         else:      
             urlpath = os.path.join(self.outdir, f'*{self.exp}_{self.resolution}_{self.frequency}_*.nc')
 


### PR DESCRIPTION
## PR description:

Monthly tests on multiple python versions fail because of flake8 E999 error. Trying to fix it.
