### PR TITLE
Revisiting `catalog` and `inspect_catalog` functions

### DIFF
--- a/.github/workflows/teleconnections.yaml
+++ b/.github/workflows/teleconnections.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up AQUA
         run: |
           # Initialize the AQUA catalog in the $HOME/.aqua folder
-          aqua -vv install
+          aqua -vv install github
           # Add the ci/cd catalog
           aqua -vv add ci
           # Double check the catalogs

--- a/.github/workflows/tropical-rainfall-diagnostic.yml
+++ b/.github/workflows/tropical-rainfall-diagnostic.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up AQUA
         run: |
           # Initialize the AQUA catalog in the $HOME/.aqua folder
-          aqua -vv install
+          aqua -vv install github
           # Add the ci/cd catalog
           aqua -vv add ci
           # Double check the catalogs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased in the current development version:
 AQUA core complete list:
 - Eccodes version 2.38.3 and new base container for aqua-container (#1441)
 - Autodetection of latest AQUA in `load-aqua-container.sh` script (#1437)
+- Refactor of `inspect_catalog()` and new `aqua_catalog()` to replace `catalog() function (#1454)
 
 AQUA diagnostic complete list:
 - Tropical Cyclones: Adaptation to IFS-FESOM and tool to compute orography from data (#1393)

--- a/diagnostics/teleconnections/teleconnections/tc_class.py
+++ b/diagnostics/teleconnections/teleconnections/tc_class.py
@@ -411,9 +411,9 @@ class Teleconnection():
         self.logger.debug("Catalog: %s", self.catalog)
 
         # Check that the data is available in the catalog
-        if inspect_catalog(catalog_name=self.catalog, model=self.model, exp=self.exp,
+        if inspect_catalog(catalog=self.catalog, model=self.model, exp=self.exp,
                            source=self.source,
-                           verbose=False) is False:
+                           verbose=False) is not True:
             raise NoDataError('Data not available')
 
     def _load_figs_options(self, savefig=False, outputfig=None):

--- a/docs/sphinx/source/core_components.rst
+++ b/docs/sphinx/source/core_components.rst
@@ -44,7 +44,7 @@ Catalog exploration
 ^^^^^^^^^^^^^^^^^^^^^
 
 To check what is available in the catalog, we can use the ``inspect_catalog()`` function.
-Three hierarchical layer structures (e.g AQUA triplet) describe each dataset.
+On top of the ``catalog`` key, three hierarchical layer structures (e.g AQUA triplet) describe each dataset.
 At the top level, there are *models* (keyword ``model``) (e.g., ICON, IFS-NEMO, IFS-FESOM, etc.). 
 Each model has different *experiments* (keyword ``exp``) and each experiment can have different *sources* (keyword ``source``).
 
@@ -55,13 +55,14 @@ Calling, for example:
     from aqua import inspect_catalog
     inspect_catalog(model='CERES')
 
-will return experiments available in the catalog for model CERES.
+will return experiments available in the catalog for model CERES. Please notice that it is not required to specify the ``catalog`` key since 
+the AQUA will scan automatically all the available catalogs. 
 
 .. warning::
     The ``inspect_catalog()`` and the ``Reader`` are based on the catalog and AQUA path configuration.
     If you don't find a source you're expecting, please check these are correctly set (see :ref:`getting_started`).
 
-If you want to have a complete overview of the sources available in the catalog, you can use the ``catalog()`` function.
+If you want to have a complete overview of the sources available in the catalog, you can use the ``aqua_catalog()`` function.
 This will return a list of all the sources available in the catalog, listed by model and experiment.
 
 Reader basic usage

--- a/src/aqua/__init__.py
+++ b/src/aqua/__init__.py
@@ -2,7 +2,7 @@
 from .graphics import plot_single_map, plot_maps, plot_single_map_diff, plot_timeseries
 from .graphics import plot_hovmoller
 from .lra_generator import LRAgenerator
-from .reader import Reader, catalog, Streaming, inspect_catalog
+from .reader import Reader, Streaming, inspect_catalog, aqua_catalog
 from .slurm import squeue, job, output_dir, scancel, max_resources_per_node
 from .accessor import AquaAccessor
 
@@ -11,5 +11,5 @@ __version__ = '0.12.2'
 __all__ = ["plot_single_map", "plot_maps", "plot_single_map_diff", "plot_timeseries",
            "plot_hovmoller",
            "LRAgenerator",
-           "Reader", "catalog", "Streaming", "inspect_catalog",
+           "Reader", "Streaming", "inspect_catalog", "aqua_catalog",
            "squeue", "job", "output_dir", "scancel", "max_resources_per_node"]

--- a/src/aqua/cli/main.py
+++ b/src/aqua/cli/main.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError
 import fsspec
 
 from aqua import __path__ as pypath
-from aqua import catalog
+from aqua import aqua_catalog
 from aqua.util import load_yaml, dump_yaml, load_multi_yaml, ConfigPath, create_folder
 from aqua.logger import log_configure
 from aqua.util.util import HiddenPrints, to_list
@@ -411,7 +411,7 @@ class AquaConsole():
         # verify that the new catalog is compatible with AQUA, loading it with catalog()
         try:
             with HiddenPrints():
-                catalog()
+                aqua_catalog()
         except Exception as e:
             self.remove(args)
             self.logger.error('Current catalog is not compatible with AQUA, removing it for safety!')

--- a/src/aqua/reader/__init__.py
+++ b/src/aqua/reader/__init__.py
@@ -1,6 +1,6 @@
 """Reader module."""
 from .reader import Reader
-from .catalog import catalog, inspect_catalog
+from .catalog import inspect_catalog, aqua_catalog
 from .streaming import Streaming
 
-__all__ = ["Reader", "catalog", "Streaming"]
+__all__ = ["Reader", "Streaming"]

--- a/src/aqua/reader/catalog.py
+++ b/src/aqua/reader/catalog.py
@@ -74,12 +74,13 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
 
     aquacats = aqua_catalog(catalog=catalog, verbose=False)
 
+    # get all info from with the scan_catalog function
     infodict = {}
     for aquacat, cat in aquacats.items():
         infodict[aquacat] = {}
         infodict[aquacat]['check'], infodict[aquacat]['level'], infodict[aquacat]['avail'] = scan_catalog(cat, model, exp, source)
 
-
+    # return information to the user
     for level in ['variables', 'source', 'exp', 'model']:
         status = find_string_in_dict(infodict, level)
         if status:
@@ -100,6 +101,7 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
     
 
 def find_string_in_dict(data, target_string):
+    """Helper function"""
     matches = []
     
     for key, sub_dict in data.items():
@@ -108,59 +110,3 @@ def find_string_in_dict(data, target_string):
             matches.append((key, sub_dict['level']))
     
     return matches
-
-        # if model and exp and not source:
-        #     if is_in_cat(cat, model, exp, None):
-        #         if verbose:
-        #             print(f"Sources available in catalog {aquacat} for model {model} and exp {exp}:")
-        #         infodict[aquacat]=list(cat[model][exp].keys())
-        # elif model and not exp:
-        #     if is_in_cat(cat, model, None, None):
-        #         if verbose:
-        #             print(f"Experiments available in catalog {aquacat} for model {model}:")
-        #         infodict[aquacat]=list(cat[model].keys())
-        # elif not model:
-        #     if verbose:
-        #         print(f"Models available in catalog {aquacat}:")
-        #     infodict[aquacat]=list(cat.keys())
-
-        # elif model and exp and source:
-        #     # Check if variables can be explored
-        #     # Added a try/except to avoid the KeyError when the source is not in the catalog
-        #     # because model or exp are not in the catalog
-        #     # This allows to always have a True/False or var list return
-        #     # when model/exp/source are provided
-        #     try:
-        #         if is_in_cat(cat, model, exp, source):
-        #             # Ok, it exists, but does it have metadata?
-        #             try:
-        #                 variables = cat[model][exp][source].metadata['variables']
-        #                 if verbose:
-        #                     print(f"The following variables are available for model {model}, exp {exp}, source {source}:")
-        #                 infodict[cat]=variables
-        #             except KeyError:
-        #                 return True
-        #     except KeyError:
-        #         pass  # go to return False
-        # else:
-        #    infodict[aquacat]=False
-        # if verbose:
-        #     print(f"The combination model={model}, exp={exp}, source={source} is not available in the catalog.")
-        #     if model:
-        #         if is_in_cat(aquacat, model, None, None):
-        #             if exp:
-        #                 if is_in_cat(aquacat, model, exp, None):
-        #                     print(f"Available sources for model {model} and exp {exp}:")
-        #                     return list(aquacat[model][exp].keys())
-        #                 else:
-        #                     print(f"Experiment {exp} is not available for model {model}.")
-        #                     print(f"Available experiments for model {model}:")
-        #                     return list(aquacat[model].keys())
-        #             else:
-        #                 print(f"Available experiments for model {model}:")
-        #                 return list(aquacat[model].keys())
-        #         else:
-        #             print(f"Model {model} is not available.")
-        #             print("Available models:")
-        #             return list(aquacat.keys())
-

--- a/src/aqua/reader/catalog.py
+++ b/src/aqua/reader/catalog.py
@@ -72,7 +72,13 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
         KeyError: If the input specifications are incorrect.
     """
 
-    aquacats = aqua_catalog(catalog=catalog, verbose=False) 
+    aquacats = aqua_catalog(catalog=catalog, verbose=False)
+
+    # return a list of catalogs if nothing is provided
+    if not catalog and not model and not exp and not source:
+        if verbose:
+            print(f"Catalog available in AQUA: {list(aquacats)}")
+        return list(aquacats)
 
     # get all info from with the scan_catalog function
     infodict = {}

--- a/src/aqua/reader/catalog.py
+++ b/src/aqua/reader/catalog.py
@@ -72,7 +72,7 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
         KeyError: If the input specifications are incorrect.
     """
 
-    aquacats = aqua_catalog(catalog=catalog, verbose=False)
+    aquacats = aqua_catalog(catalog=catalog, verbose=False) 
 
     # get all info from with the scan_catalog function
     infodict = {}

--- a/src/aqua/reader/catalog.py
+++ b/src/aqua/reader/catalog.py
@@ -5,7 +5,7 @@ from aqua.util import ConfigPath
 from aqua.util.config import scan_catalog
 
 
-def aqua_catalog(verbose=True, configdir=None, catalog=None):
+def aqua_catalog(catalog=None, configdir=None, verbose=True):
     """
     Catalog of available data.
 
@@ -46,7 +46,7 @@ def aqua_catalog(verbose=True, configdir=None, catalog=None):
     return aquacats
 
 
-def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=True):
+def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=False):
     """
     Basic function to simplify catalog inspection.
     If a partial match between model, exp and source is provided, then it will return a list
@@ -62,11 +62,16 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
             If None, all experiments are returned. Defaults to None.
         source (str, optional): The source ID to filter the catalog.
             If None, all sources are returned. Defaults to None.
-        verbose (bool, optional): Print the catalog information to the console. Defaults to True.
+        verbose (bool, optional): Print the catalog information to the console. Defaults to False.
 
     Returns:
-        list:   A list of available items in the catalog, depending on the
+        list or dict:   A list of available items in the catalog, depending on the
                 specified model and/or experiment, a list of variables or True/False.
+                If multiple entries are matched in multiple catalogs
+                it will return a dictionary with all the entries available
+                for each catalog
+            
+
 
     Raises:
         KeyError: If the input specifications are incorrect.
@@ -133,6 +138,9 @@ def inspect_catalog(catalog=None, model=None, exp=None, source=None, verbose=Tru
                     print(f"Source {source} for exp {exp} and model {model} in catalog {printcat} is found!")
 
             return infodict[printcat]['avail']
+
+    # safety return
+    return False
     
 
 

--- a/src/aqua/util/config.py
+++ b/src/aqua/util/config.py
@@ -328,6 +328,8 @@ def scan_catalog(cat, model=None, exp=None, source=None):
         if exp in cat[model]:
             if source in cat[model][exp]:
                 status = True
+                avail = cat[model][exp][source].metadata.get('variables', True)
+                level = 'variables'
             else:
                 level = 'source'
                 avail = list(cat[model][exp].keys())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from aqua import Reader, catalog
+from aqua import Reader, aqua_catalog
 
 # pytest approximation, to bear with different machines
 approx_rel = 1e-4
@@ -30,7 +30,7 @@ class TestAqua:
         """
         Test if the catalog function returns a non-empty list
         """
-        cat = catalog()
+        cat = aqua_catalog()
         assert len(cat) > 0
 
     def test_reader_init(self):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -8,28 +8,28 @@ from aqua import Reader, aqua_catalog, inspect_catalog
 loglevel = "DEBUG"
 
 @pytest.fixture(params=[(catalog, model, exp, source)
-                        for catalog in aqua_catalog()
-                        for model in aqua_catalog()[catalog]
-                        for exp in aqua_catalog()[catalog][model]
-                        for source in aqua_catalog()[catalog][model][exp]])
+                        for catalog in aqua_catalog(verbose=False)
+                        for model in aqua_catalog(verbose=False)[catalog]
+                        for exp in aqua_catalog(verbose=False)[catalog][model]
+                        for source in aqua_catalog(verbose=False)[catalog][model][exp]])
 def reader(request):
     """Reader instance fixture"""
     catalog, model, exp, source = request.param
     print([catalog, model, exp, source])
     # very slow access, skipped
-    if model == 'ICON' and source == 'intake-esm-test':
-        pytest.skip()
-    if model == 'ICON' and exp == 'hpx':
-        pytest.skip()
-    if model == 'MSWEP':
-        pytest.skip()
-    if model == 'ERA5':
-        pytest.skip()
-    if model == 'IFS' and exp == 'test-fdb':
-        pytest.skip()
-    # teleconnections catalog, only on teleconnections workflow
-    if model == 'IFS' and exp == 'test-tco79' and source == 'teleconnections':
-        pytest.skip()
+    # if model == 'ICON' and source == 'intake-esm-test':
+    #     pytest.skip()
+    # if model == 'ICON' and exp == 'hpx':
+    #     pytest.skip()
+    # if model == 'MSWEP':
+    #     pytest.skip()
+    # if model == 'ERA5':
+    #     pytest.skip()
+    # if model == 'IFS' and exp == 'test-fdb':
+    #     pytest.skip()
+    # # teleconnections catalog, only on teleconnections workflow
+    # if model == 'IFS' and exp == 'test-tco79' and source == 'teleconnections':
+    #     pytest.skip()
     myread = Reader(catalog=catalog, model=model, exp=exp, source=source, areas=False,
                     fix=False, loglevel=loglevel)
     data = myread.retrieve()
@@ -51,28 +51,28 @@ def test_catalog_gsv(reader):
         assert isinstance(data, xarray.Dataset)
 
 @pytest.fixture(params=[(catalog, model, exp, source)
-                        for catalog in aqua_catalog()
-                        for model in aqua_catalog()[catalog]
-                        for exp in aqua_catalog()[catalog][model]
-                        for source in aqua_catalog()[catalog][model][exp]])
+                        for catalog in aqua_catalog(verbose=False)
+                        for model in aqua_catalog(verbose=False)[catalog]
+                        for exp in aqua_catalog(verbose=False)[catalog][model]
+                        for source in aqua_catalog(verbose=False)[catalog][model][exp]])
 def reader_regrid(request):
     """Reader instance fixture"""
     catalog, model, exp, source = request.param
     print([catalog, model, exp, source])
     # very slow access, skipped
-    if model == 'ICON' and source == 'intake-esm-test':
-        pytest.skip()
-    if model == 'ICON' and exp == 'hpx':
-        pytest.skip()
-    if model == 'MSWEP':
-        pytest.skip()
-    if model == 'ERA5':
-        pytest.skip()
-    if model == 'IFS' and source == 'fdb':  # there is another test for that
-        pytest.skip()
-    # teleconnections catalog, only on teleconnections workflow
-    if model == 'IFS' and exp == 'test-tco79' and source == 'teleconnections':
-        pytest.skip()
+    # if model == 'ICON' and source == 'intake-esm-test':
+    #     pytest.skip()
+    # if model == 'ICON' and exp == 'hpx':
+    #     pytest.skip()
+    # if model == 'MSWEP':
+    #     pytest.skip()
+    # if model == 'ERA5':
+    #     pytest.skip()
+    # if model == 'IFS' and source == 'fdb':  # there is another test for that
+    #     pytest.skip()
+    # # teleconnections catalog, only on teleconnections workflow
+    # if model == 'IFS' and exp == 'test-tco79' and source == 'teleconnections':
+    #     pytest.skip()
     myread = Reader(catalog=catalog, model=model, exp=exp, source=source, areas=True, regrid='r200',
                     loglevel=loglevel, rebuild=False)
     data = myread.retrieve()
@@ -109,21 +109,35 @@ def test_catalog_reader(reader_regrid):
 def test_inspect_catalog():
     """Checking that inspect catalog works"""
 
-
     # inspect catalog
+    catalogs = inspect_catalog()
+    assert isinstance(catalogs, list)
+    assert 'ci' in catalogs
+
     models = inspect_catalog(catalog='ci')
     assert isinstance(models, list)
+
     exps = inspect_catalog(model='IFS')
     assert isinstance(exps, list)
+
     sources = inspect_catalog(model='IFS', exp='test-tco79')
     assert isinstance(sources, list)
+
     variables = inspect_catalog(model='IFS', exp="test-tco79", source='short')
     assert variables is True
 
-    # wrong calls
+    #wrong calls
     models = inspect_catalog(catalog='ci', model='antani')
-    assert 'IFS' in models 
+    assert 'IFS' in models
+
     exps = inspect_catalog(model='IFS', exp="antani")
     assert 'test-tco79' in exps
+
     sources = inspect_catalog(model='IFS', exp="test-tco79", source='antani')
     assert 'short' in sources
+
+    #errors
+    with pytest.raises(ValueError):
+        inspect_catalog(exp='antani')
+    with pytest.raises(ValueError):
+        inspect_catalog(model='pippo', source='pluto')

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -109,11 +109,6 @@ def test_catalog_reader(reader_regrid):
 def test_inspect_catalog():
     """Checking that inspect catalog works"""
 
-    # calling the catalog
-    #cat = catalog(verbose=True)
-    #out, _ = capfd.readouterr()
-    #assert 'FESOM' in out
-    #assert 'IFS' in out
 
     # inspect catalog
     models = inspect_catalog(catalog='ci')


### PR DESCRIPTION
## PR description:

Tried to revisit the two function in the title accomodating the new feature of having multiple catalogs installed. As a first step, the `catalog`function is renamed to `aqua_catalog` so that naming convention of the arguments is respected.

However, It is not a trivial task and the current solution leave me a bit puzzled. Indeed, there are situations where the `inspect_catalog()`return lists (legacy behaviour) or dictionaries (if the catalog is not specified and there are multiple entries). This is everything but safe. 
The only solution would be to force `inspect_catalog` to have catalog as mandatory argument

This - if I get it to work - should superseed #1261

## Issues closed by this pull request:

Close #1260

----

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.

