### PR TITLE
Fallback option when required shortname mismatch the GSV provided one

### DIFF
--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -531,10 +531,21 @@ class GSVSource(base.DataSource):
                 darr = dask.array.concatenate(dalist, axis=self.ilevel)  # This is a lazy dask array
 
             shortname = self.get_eccodes_shortname(var)
+            self.logger.debug("Shortname: %s", shortname)
 
+            try:
+                attrs = self._ds[shortname].attrs
+            except KeyError as e:
+                self.logger.error('Shortname %s not found in the database, guessing it from the GSVDecoder', shortname)
+                self.logger.debug('Original error: %s', e)
+
+                shortname = self._da.GRIB_shortName
+                self.logger.warning("Guessing the shortname %s from the GSVDecoder", shortname)
+                attrs = self._ds[shortname].attrs
+            
             da = xr.DataArray(darr,
                               name=shortname,
-                              attrs=self._ds[shortname].attrs,
+                              attrs=attrs,
                               dims=self._da.dims,
                               coords=coords)
 


### PR DESCRIPTION
## PR description:

The PR tries to solve the issue found in mismatch between the shortnames.
We get the initial mismatch error, roll back into checking what is found in the GSV, raising all the possible warnings and error messages, but still providing something to the user.

In my test I was able to retrieve the variables of interest in #1477 individually, but when I run a plain retrieve() with no var specified, these variables are not in the final dataset, so I'm not fully happy of what proposed here.

@jhardenberg I'd like a double check of the modification (since it is in the intake_gsv code) and maybe you can help me with solving also the last part of the puzzle.

## Issues closed by this pull request:

Close #1477 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
