### PR TITLE
Updating Save Flags and Output Configuration for AQUA Analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ AQUA core complete list:
 - Introduce `grids-checker.py` tool to verify presence and checksum of the grid files (#1486)
 
 AQUA diagnostic complete list:
+- Timeseries: Updating Save Flags and Output Configuration for AQUA Analysis (#1516)
 - Timeseries: The `timeseries` diagnostic is now integrated in the `aqua_diagnostics` module (#1340)
 - Integrating Updated OutputSaver into Timeseries (#1492)
 - Tropical Cyclones: Adaptation to IFS-FESOM and tool to compute orography from data (#1393)

--- a/cli/aqua-analysis/config.aqua-analysis.yaml
+++ b/cli/aqua-analysis/config.aqua-analysis.yaml
@@ -23,7 +23,7 @@ job:
     run_dummy: false
 
     output:
-      outputdir: "${AQUA}/cli/aqua-analysis/output_3_dec_test_18"
+      outputdir: "${AQUA}/cli/aqua-analysis/output"
       rebuild: true
       filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
       save_netcdf: true

--- a/cli/aqua-analysis/config.aqua-analysis.yaml
+++ b/cli/aqua-analysis/config.aqua-analysis.yaml
@@ -21,9 +21,15 @@ job:
 
     # Run a dummy analysis to test the configuration and the presence of needed data
     run_dummy: false
-    
-    # Default output directory for the analysis. Can be overridden by the command line arguments
-    outputdir: "${AQUA}/cli/aqua-analysis/output" 
+
+    output:
+      outputdir: "${AQUA}/cli/aqua-analysis/output_3_dec_test_18"
+      rebuild: true
+      filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+      save_netcdf: true
+      save_pdf: true
+      save_png: true
+      dpi: 300
 
     # Default values, overriden from command line arguments
     # catalog: "lumi"  # The catalog to use for the analysis, usually defined elsewhere

--- a/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
+++ b/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
@@ -11,6 +11,7 @@ output:
   outputdir: "./"
   rebuild: true
   filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  save_netcdf: true
   save_pdf: true
   save_png: true
   dpi: 300

--- a/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
+++ b/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
@@ -10,6 +10,7 @@ models:
 output:
   outputdir: "./"
   rebuild: true
+  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_pdf: true
   save_png: true
   dpi: 300

--- a/config/diagnostics/timeseries/config_timeseries_atm.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_atm.yaml
@@ -11,6 +11,7 @@ output:
   outputdir: "./"
   rebuild: true
   filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  save_netcdf: true
   save_pdf: true
   save_png: true
   dpi: 300

--- a/config/diagnostics/timeseries/config_timeseries_atm.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_atm.yaml
@@ -10,6 +10,7 @@ models:
 output:
   outputdir: "./"
   rebuild: true
+  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_pdf: true
   save_png: true
   dpi: 300

--- a/config/diagnostics/timeseries/config_timeseries_oce.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_oce.yaml
@@ -11,6 +11,7 @@ output:
   outputdir: "./"
   rebuild: true
   filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  save_netcdf: true
   save_pdf: true
   save_png: true
   dpi: 300

--- a/config/diagnostics/timeseries/config_timeseries_oce.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_oce.yaml
@@ -10,6 +10,7 @@ models:
 output:
   outputdir: "./"
   rebuild: true
+  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_pdf: true
   save_png: true
   dpi: 300

--- a/src/aqua/util/__init__.py
+++ b/src/aqua/util/__init__.py
@@ -8,7 +8,7 @@ from .graphics import coord_names, ticks_round, set_ticks
 from .sci_util import area_selection, check_coordinates
 from .util import generate_random_string, get_arg, create_folder, to_list
 from .util import file_is_complete, find_vert_coord
-from .util import files_exist
+from .util import files_exist, load_and_override_output_config
 from .util import extract_literal_and_numeric, add_pdf_metadata, add_png_metadata
 from .util import open_image, username, update_metadata
 from .yaml import load_yaml, dump_yaml, load_multi_yaml, eval_formula
@@ -25,7 +25,7 @@ __all__ = ['ConfigPath',
            'coord_names', 'ticks_round', 'set_ticks',
            'area_selection', 'check_coordinates',
            'generate_random_string', 'get_arg', 'create_folder', 'to_list',
-           'files_exist',
+           'files_exist', 'load_and_override_output_config',
            'file_is_complete', 'find_vert_coord',
            'extract_literal_and_numeric', 'add_pdf_metadata', 'add_png_metadata',
            'open_image', 'username', 'update_metadata',

--- a/src/aqua/util/util.py
+++ b/src/aqua/util/util.py
@@ -431,3 +431,40 @@ class HiddenPrints:
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout.close()
         sys.stdout = self._original_stdout
+
+def load_and_override_output_config(config, args):
+    """
+    Load output configuration from YAML and override with command-line arguments if provided.
+
+    Args:
+        config (dict): Loaded configuration from YAML.
+        args: Parsed command-line arguments.
+
+    Returns:
+        dict: Dictionary with output configuration.
+    """
+    # Load the output configuration from YAML
+    output_config = config.get('output', {})
+
+    # Override with command-line arguments if provided, otherwise use config values
+    outputdir = getattr(args, 'outputdir', None) or output_config.get("outputdir")
+    if outputdir:
+        outputdir = os.path.expandvars(outputdir)
+
+    rebuild = getattr(args, 'rebuild', None) or output_config.get("rebuild")
+    save_pdf = getattr(args, 'save_pdf', None) or output_config.get("save_pdf")
+    save_png = getattr(args, 'save_png', None) or output_config.get("save_png")
+    save_netcdf = getattr(args, 'save_netcdf', None) or output_config.get("save_netcdf")
+    dpi = getattr(args, 'dpi', None) or output_config.get("dpi")
+    filename_keys = getattr(args, 'filename_keys', None) or output_config.get("filename_keys")
+
+    return {
+        "outputdir": outputdir,
+        "rebuild": rebuild,
+        "save_pdf": save_pdf,
+        "save_png": save_png,
+        "save_netcdf": save_netcdf,
+        "dpi": dpi,
+        "filename_keys": filename_keys
+    }
+

--- a/src/aqua_diagnostics/timeseries/cli_timeseries.py
+++ b/src/aqua_diagnostics/timeseries/cli_timeseries.py
@@ -42,8 +42,29 @@ def parse_arguments(args):
     parser.add_argument("--outputdir", type=str,
                         required=False, help="output directory")
 
-    return parser.parse_args(args)
+    # Adding new output configuration options
+    parser.add_argument("--rebuild", action="store_true",
+                        help="Whether to rebuild the plots")
+    parser.add_argument("--no_rebuild", action="store_true",
+                        help="Disable rebuilding of plots")
+    parser.add_argument("--save_netcdf", action="store_true",
+                        help="Whether to save plots as NetCDF")
+    parser.add_argument("--no_save_netcdf", action="store_true",
+                        help="Disable saving plots as NetCDF")
+    parser.add_argument("--save_pdf", action="store_true",
+                        help="Whether to save plots as PDF")
+    parser.add_argument("--no_save_pdf", action="store_true",
+                        help="Disable saving plots as PDF")
+    parser.add_argument("--save_png", action="store_true",
+                        help="Whether to save plots as PNG")
+    parser.add_argument("--no_save_png", action="store_true",
+                        help="Disable saving plots as PNG")
+    parser.add_argument("--dpi", type=int, required=False,
+                        help="DPI for saved images")
+    parser.add_argument("--filename_keys", type=str, nargs='*',
+                        help="Keys to use for filenames")
 
+    return parser.parse_args(args)
 
 def get_plot_options(config: dict = None,
                      var: str = None):
@@ -129,6 +150,18 @@ if __name__ == '__main__':
     models[0]['exp'] = get_arg(args, 'exp', models[0]['exp'])
     models[0]['source'] = get_arg(args, 'source', models[0]['source'])
 
+    # Override output parameters if provided as command-line arguments
+    outputdir = get_arg(args, "outputdir", config['output'].get("outputdir"))
+    rebuild = not args.no_rebuild if args.rebuild or args.no_rebuild else config['output'].get("rebuild")
+    save_netcdf = not args.no_save_netcdf if args.save_netcdf or args.no_save_netcdf else config['output'].get("save_netcdf")
+    save_pdf = not args.no_save_pdf if args.save_pdf or args.no_save_pdf else config['output'].get("save_pdf")
+    save_png = not args.no_save_png if args.save_png or args.no_save_png else config['output'].get("save_png")
+    dpi = args.dpi if args.dpi is not None else config['output'].get("dpi")
+    filename_keys = args.filename_keys if args.filename_keys else config['output'].get("filename_keys", [])
+
+    logger.debug(f"Saving settings - NetCDF: {'enabled' if save_netcdf else 'disabled'}, PDF: {'enabled' if save_pdf else 'disabled'}, PNG: {'enabled' if save_png else 'disabled'}")
+
+    # Prepare model-related lists for the diagnostics
     logger.debug("Analyzing models:")
     catalogs_list = []
     models_list = []
@@ -141,12 +174,6 @@ if __name__ == '__main__':
         models_list.append(model['model'])
         exp_list.append(model['exp'])
         source_list.append(model['source'])
-
-    outputdir = get_arg(args, "outputdir", config['output'].get("outputdir"))
-    rebuild = config['output'].get("rebuild")
-    save_pdf = config['output'].get("save_pdf")
-    save_png = config['output'].get("save_png")
-    dpi = config['output'].get("dpi")
 
     if "timeseries" in config:
         logger.info("Plotting timeseries")
@@ -181,6 +208,8 @@ if __name__ == '__main__':
                             outdir=outputdir,
                             loglevel=loglevel,
                             rebuild=rebuild,
+                            filename_keys=filename_keys,
+                            save_netcdf=save_netcdf,
                             save_pdf=save_pdf,
                             save_png=save_png,
                             dpi=dpi)
@@ -228,6 +257,8 @@ if __name__ == '__main__':
                             outdir=outputdir,
                             loglevel=loglevel,
                             rebuild=rebuild,
+                            filename_keys=filename_keys,
+                            save_netcdf=save_netcdf,
                             save_pdf=save_pdf,
                             save_png=save_png,
                             dpi=dpi)
@@ -275,6 +306,8 @@ if __name__ == '__main__':
                          regrid=regrid,
                          loglevel=loglevel,
                          rebuild=rebuild,
+                         filename_keys=filename_keys,
+                         save_netcdf=save_netcdf,
                          save_pdf=save_pdf,
                          save_png=save_png,
                          dpi=dpi)
@@ -318,6 +351,8 @@ if __name__ == '__main__':
                                units=units,
                                loglevel=loglevel,
                                rebuild=rebuild,
+                               filename_keys=filename_keys,
+                               save_netcdf=save_netcdf,
                                save_pdf=save_pdf,
                                save_png=save_png,
                                dpi=dpi)
@@ -360,6 +395,8 @@ if __name__ == '__main__':
                                units=units,
                                loglevel=loglevel,
                                rebuild=rebuild,
+                               filename_keys=filename_keys,
+                               save_netcdf=save_netcdf,
                                save_pdf=save_pdf,
                                save_png=save_png,
                                dpi=dpi)

--- a/src/aqua_diagnostics/timeseries/gregory.py
+++ b/src/aqua_diagnostics/timeseries/gregory.py
@@ -27,7 +27,7 @@ class GregoryPlot():
                  ts_name='2t', toa_name=['mtnlwrf', 'mtnswrf'],
                  ts_std_start='1980-01-01', ts_std_end='2010-12-31',
                  toa_std_start='2001-01-01', toa_std_end='2020-12-31',
-                 ref=True, save=True,
+                 ref=True, save_netcdf=True,
                  outdir='./',
                  loglevel='WARNING',
                  rebuild=True, filename_keys=None,
@@ -58,7 +58,7 @@ class GregoryPlot():
             ref (bool): If True, reference data is plotted.
                         Default is True. Reference data are ERA5 for 2m temperature
                         and CERES for net radiation at TOA.
-            save (bool): If True, save the figure. Default is True.
+            save_netcdf (bool): If True, save the NetCDF file. Default is True.
             outdir (str): Output directory. Default is './'.
             loglevel (str): Logging level. Default is WARNING.
             rebuild (bool, optional): If True, overwrite the existing files. If False, do not overwrite. Default is True.
@@ -104,9 +104,9 @@ class GregoryPlot():
                           f"2m temperature from {time_to_string(self.ts_std_start)} to {time_to_string(self.ts_std_end)}, "
                           f"net radiation at TOA from {time_to_string(self.toa_std_start)} to {time_to_string(self.toa_std_end)}") # noqa
 
-        self.save = save
-        if self.save is False:
-            self.logger.info("No output file will be saved.")
+        self.save_netcdf = save_netcdf
+        if self.save_netcdf is False:
+            self.logger.info("No NetCDF file will be saved.")
         self.outdir = outdir
 
         self.diagnostic_product = 'gregory_plot'
@@ -124,8 +124,8 @@ class GregoryPlot():
         self.retrieve_data()
         self.retrieve_ref()
         self.plot()
-        if self.save:
-            self.save_netcdf()
+        if self.save_netcdf:
+            self._save_netcdf()
         self.cleanup()
 
     def retrieve_data(self):
@@ -327,7 +327,7 @@ class GregoryPlot():
 
             ax2.legend()
 
-        if self.save:
+        if self.save_pdf or self.save_png:
             self.save_image(fig)
 
     def save_image(self, fig):
@@ -353,7 +353,7 @@ class GregoryPlot():
         if self.save_png:
             output_saver.save_png(fig, metadata=metadata, **common_save_args)
 
-    def save_netcdf(self):
+    def _save_netcdf(self):
         """Save the data to a netCDF file."""
 
         # Loop through the models and save their corresponding data

--- a/src/aqua_diagnostics/timeseries/seasonalcycle.py
+++ b/src/aqua_diagnostics/timeseries/seasonalcycle.py
@@ -29,7 +29,7 @@ class SeasonalCycle(Timeseries):
                  startdate=None, enddate=None,
                  std_startdate=None, std_enddate=None,
                  plot_kw={'ylim': {}},
-                 save=True,
+                 save_netcdf=True,
                  outdir='./',
                  longname=None, units=None,
                  lon_limits=None, lat_limits=None,
@@ -54,7 +54,7 @@ class SeasonalCycle(Timeseries):
             std_startdate: the start date to evaluate the standard deviation
             std_enddate: the end date to evaluate the standard deviation
             plot_kw: the keyword arguments to pass to the plot
-            save: if True, save the figure. Default is True.
+            save_netcdf: if True, save the NetCDF. Default is True.
             outdir: the output directory
             longname: the long name of the variable. Override the attribute in the data file.
             units: the units of the variable. Override the attribute in the data file.
@@ -78,7 +78,7 @@ class SeasonalCycle(Timeseries):
                          monthly_std=True, annual_std=False,
                          std_startdate=std_startdate, std_enddate=std_enddate,
                          plot_kw=plot_kw,
-                         save=save,
+                         save_netcdf=save_netcdf,
                          outdir=outdir,
                          longname=longname, units=units,
                          lon_limits=lon_limits, lat_limits=lat_limits,
@@ -164,8 +164,9 @@ class SeasonalCycle(Timeseries):
                                     loglevel=self.loglevel,
                                     title=title)
 
-        if self.save:
+        if self.save_pdf or self.save_png:
             self.save_seasonal_image(fig, ref_label)
+        if self.save_netcdf:
             self.save_seasonal_netcdf()
 
     def save_seasonal_image(self, fig, ref_label):

--- a/src/aqua_diagnostics/timeseries/timeseries.py
+++ b/src/aqua_diagnostics/timeseries/timeseries.py
@@ -38,7 +38,7 @@ class Timeseries():
                  plot_kw={'ylim': {}}, longname=None,
                  units=None, extend=True,
                  lon_limits=None, lat_limits=None,
-                 save=True,
+                 save_netcdf=True,
                  outdir='./',
                  loglevel='WARNING',
                  rebuild=None, filename_keys=None,
@@ -68,7 +68,7 @@ class Timeseries():
             extend (bool): Extend the reference range. Default is True.
             lon_limits (list): Longitude limits of the area to evaluate. Default is None.
             lat_limits (list): Latitude limits of the area to evaluate. Default is None.
-            save (bool): Save the figure. Default is True.
+            save_netcdf (bool): Save the NetCDF. Default is True.
             outdir (str): Output directory. Default is "./".
             loglevel (str): Log level. Default is "WARNING".
             rebuild (bool, optional): If True, overwrite the existing files. If False, do not overwrite. Default is True.
@@ -127,9 +127,9 @@ class Timeseries():
         self.lon_limits = lon_limits
         self.lat_limits = lat_limits
 
-        self.save = save
-        if self.save is False:
-            self.logger.info("Figure will not be saved")
+        self.save_netcdf = save_netcdf
+        if self.save_netcdf is False:
+            self.logger.info("NetCDF will not be saved")
         self.outdir = outdir
 
         self.diagnostic_product = 'timeseries'
@@ -138,6 +138,8 @@ class Timeseries():
         self.filename_keys = filename_keys
         self.save_pdf = save_pdf
         self.save_png = save_png
+        if not self.save_png and not self.save_pdf:
+            self.logger.info("Figure will not be saved")
         self.dpi = dpi
 
     def run(self):
@@ -145,8 +147,8 @@ class Timeseries():
         self.retrieve_data()
         self.retrieve_ref(extend=self.extend)
         self.plot()
-        if self.save:
-            self.save_netcdf()
+        if self.save_netcdf:
+            self._save_netcdf()
         self.cleanup()
 
     def retrieve_ref(self, extend=True):
@@ -337,7 +339,7 @@ class Timeseries():
                                  data_labels=data_labels,
                                  title=title)
 
-        if self.save:
+        if self.save_pdf or self.save_png:
             self.save_image(fig, ref_label)
 
     def save_image(self, fig, ref_label):
@@ -362,7 +364,7 @@ class Timeseries():
         if self.save_png:
             output_saver.save_png(fig, metadata=metadata, **common_save_args)
 
-    def save_netcdf(self):
+    def _save_netcdf(self):
         """
         Save the data to a netcdf file.
         Every model-exp-source combination is saved in a separate file.


### PR DESCRIPTION
## PR description:
 - Replace save Flag with `save_netcdf`: Updated the `timeseries` diagnostics to use the `save_netcdf` flag instead of save, aligning it with the flag structure used in other diagnostics.
 - Add New Parser Arguments and Config Key for `OutputSaver`: Enhanced `aqua_analysis` by adding new command-line parser arguments and a configuration key to integrate the OutputSaver class effectively.
## Issues closed by this pull request:

Close #issue_number

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
