### PR TITLE
Ocean3d: read new varnames thetao and so

### DIFF
--- a/diagnostics/ocean3d/cli/cli_ocean3d.py
+++ b/diagnostics/ocean3d/cli/cli_ocean3d.py
@@ -94,10 +94,10 @@ class Ocean3DCLI:
         else:
             self.data["catalog_data"] = reader.retrieve()
             
-        self.data["catalog_data"] = check_variable_name(self.data["catalog_data"])
+        self.data["catalog_data"] = check_variable_name(self.data["catalog_data"], loglevel=self.loglevel)
 
         if self.config["compare_model"]== True:
-            self.data["obs_data"] = load_obs_data(model='EN4', exp='en4', source='monthly')
+            self.data["obs_data"] = load_obs_data(model='EN4', exp='en4', source='monthly', loglevel=self.loglevel)
         self.data["obs_data"] = check_variable_name(self.data["obs_data"])
         
         return

--- a/diagnostics/ocean3d/ocean3d/ocean_util.py
+++ b/diagnostics/ocean3d/ocean3d/ocean_util.py
@@ -48,16 +48,15 @@ def check_variable_name(data, loglevel= "WARNING"):
     vars = list(data.variables)
     required_vars= []
     var_list= ["SO","avg_so","thetao","THETAO","avg_SO","avg_so","avg_thetao","avg_THETAO",
-               "toce_mean","soce_mean"]
+               "toce_mean","soce_mean", "so"]
     for var in vars:
         if var in var_list:
             required_vars.append(var)
     if required_vars != []:
         logger.debug("This are the variables %s available for the diags in the catalog.", required_vars)
         data = data[required_vars]
-        logger.debug("Selected this variables")
         for var in required_vars:
-            if 'avg_so' in var.lower() or 'soce' in var.lower():
+            if 'so' in var.lower():
                 data = data.rename({var: "avg_so"})
                 logger.debug("renaming %s as avg_so", var)
             if 'thetao' in var.lower() or 'toce' in var.lower():


### PR DESCRIPTION
## PR description:

Minor fix which allows the ocean3d diagnostic  to read correctly `thetao` and `so` variables as now provided by the fixer (since AQUA v0.13-alpha).
