### PR TITLE
Fix grids in catalog generator

### DIFF
--- a/config/catgen/matching_grids.yaml
+++ b/config/catgen/matching_grids.yaml
@@ -14,11 +14,11 @@ grid_mappings:
     default: "{aqua_grid}-nested"
   o2d:
     ifs-nemo: "nemo-{ocean_grid}-{aqua_grid}-nested"
-    ifs-fesom: "fesom-{aqua_grid}-nested"
+    ifs-fesom: "fesom-{ocean_grid}-{aqua_grid}-nested-v2"
     icon: "icon-{aqua_grid}-nested"
   o3d:
     ifs-nemo: "nemo-{ocean_grid}-{aqua_grid}-nested-3d" 
-    ifs-fesom: "fesom-{aqua_grid}-nested-3d"
+    ifs-fesom: "fesom-{ocean_grid}-{aqua_grid}-nested-3d-v2"
     icon: "icon-{aqua_grid}-nested-3d"
   default: "{aqua_grid}"
 

--- a/templates/catgen/config.tmpl
+++ b/templates/catgen/config.tmpl
@@ -24,7 +24,7 @@ num_of_realizations: 1
 data_start_date: '19900101'
 data_end_date: '19901231'
 bridge_end_date: Null   # this can be 'Null' or 'complete' or a date
-ocean_grid: eORCA1
+ocean_grid: eORCA1  # available grids: eORCA1, eORCA025, eORCA12 for NEMO; NG5, D3 for FESOM
 description: 'FDB IFS/NEMO test run' 
 
 # paths


### PR DESCRIPTION
## PR description:
This PR updates the grid-matching logic to ensure compatibility with the correct naming conventions.
in particular, for IFS-FESOM, the correct format is  `fesom-{ocean_grid}-{aqua_grid}-nested-v2`. 
Some adaptation may be needed for ICON as well, ongoing test by @mnurisso.

I also added to the config template the list of available ocean grids, making it easier for users to specify the grid choice.
so far we have:
`eORCA1, eORCA025, eORCA12` for NEMO
`NG5, D3` for FESOM

something missing? R02B08?

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Documentation is included if a new feature is included.
 - [ ] Changelog is updated.
