### PR TITLE
Handle `omit-resolutions` in catgen

### DIFF
--- a/src/aqua/cli/catgen.py
+++ b/src/aqua/cli/catgen.py
@@ -283,6 +283,8 @@ class AquaFDBGenerator:
         for profile in self.dp[self.model]:
             if not grid_resolutions:
                 self.logger.error('No resolutions found, generating an empty file!')
+            if 'omit-resolutions' in profile:
+                grid_resolutions = [res for res in grid_resolutions if res not in profile['omit-resolutions']]
             for grid_resolution in grid_resolutions:
                 content = self.get_profile_content(profile, grid_resolution)
                 combined = {**self.config, **content}


### PR DESCRIPTION
## PR description:

This PR updates the catgen to align with the new feature introduced in the Data Portfolio, as discussed [here](https://earth.bsc.es/gitlab/digital-twins/de_340-2/data-portfolio/-/issues/24#note_334488). 
In particular, it is now possible to disable certain resolutions in the catalog generation process checking for the presence of the  `omit-resolutions` field when parsing portfolio.yaml and skip any resolutions listed under` omit-resolutions `for each entry in the portfolio.

@igonzal-bsc 

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Changelog is updated.

