### PR TITLE
Specify OutputNamer filename_keys to avoid dates in file names

### DIFF
--- a/config/diagnostics/global_biases/config_global_biases.yaml
+++ b/config/diagnostics/global_biases/config_global_biases.yaml
@@ -16,7 +16,8 @@ obs:
 output:
   outputdir: "./"
   rebuild: true
-  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  filename_keys: ['diagnostic', 'diagnostic_product', 'catalog', 'model', 'exp',
+                  'var', 'model_2', 'exp_2', 'catalog_2', 'area', 'time_precision'] # null or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_netcdf: true
   save_pdf: true
   save_png: true

--- a/config/diagnostics/radiation/config_radiation-biases.yaml
+++ b/config/diagnostics/radiation/config_radiation-biases.yaml
@@ -16,7 +16,8 @@ obs:
 output:
   outputdir: "./"
   rebuild: true
-  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  filename_keys: ['diagnostic', 'diagnostic_product', 'catalog', 'model', 'exp',
+                  'var', 'model_2', 'exp_2', 'catalog_2', 'area', 'time_precision'] # null or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_netcdf: true
   save_pdf: true
   save_png: true

--- a/config/diagnostics/radiation/config_radiation-boxplots.yaml
+++ b/config/diagnostics/radiation/config_radiation-boxplots.yaml
@@ -20,7 +20,8 @@ models:
 output:
   outputdir: "./"
   rebuild: true
-  filename_keys: null # or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
+  filename_keys: ['diagnostic', 'diagnostic_product', 'catalog', 'model', 'exp',
+                  'var', 'model_2', 'exp_2', 'catalog_2', 'area', 'time_precision'] # null or, for example,  ['diagnostic', 'catalog', 'model', 'diagnostic_product', 'var']
   save_netcdf: true
   save_pdf: true
   save_png: true


### PR DESCRIPTION
## PR description:

If `filename_keys = null` is set in a diagnostic configuration file,  all keys are included in the output file name:
```
['diagnostic', 'diagnostic_product', 'catalog', 'model', 'exp',
 'var', 'model_2', 'exp_2', 'catalog_2', 'area', 'time_start', 'time_end', 'time_precision']
```
However, including `time_start` and `time_end` may lead to duplicate figures in aqua-Web if the simulation is still in progress. 


Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Changelog is updated.
