### PR TITLE
ICON production grids

### DIFF
--- a/config/grids/ICON.yaml
+++ b/config/grids/ICON.yaml
@@ -49,6 +49,24 @@ grids:
     space_coord: ["cell"]
     vert_coord: ["depth_half", "depth_full"]
 
+  icon-R02B08-hpz9-nested-v2: #ClimateDT cycle2, 924355 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_v2.nc'
+    space_coord: ["cell"]
+  icon-R02B08-hpz9-nested-3d-v2: #ClimateDT cycle2, 72 levels starting at 1, 924355 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_level_full_v2.nc'
+    space_coord: ["cell"]
+    vert_coord: ["level"]
+  icon-R02B09-hpz7-nested-v2: #ClimateDT cycle2, 57642 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_v2.nc'
+    space_coord: ["cell"]
+  icon-R02B09-hpz7-nested-3d-v2: #ClimateDT cycle2, 72 levels starting at 1, 57642 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_level_full_v2.nc'
+    space_coord: ["cell"]
+    vert_coord: ["level"]
   icon-R02B08-hpz6-nested-v2: #ClimateDT cycle2, 14415 missing values
     cdo_options: '--force'
     path: '{{ grids }}/HealPix/icon-R02B08_hpz6_nested_oce_v2.nc'
@@ -59,32 +77,43 @@ grids:
     space_coord: ["cell"]
     vert_coord: ["level"]
 
-  icon-R02B08-hpz9-nested-v2: #ClimateDT cycle2, 924355 missing values
+  # ICON v3: These are grids for DestinE O-25.1 cycle.
+  # Interpolation to HealPix is now conservative and this
+  # produced a change in the land sea mask, so all the grids
+  # are different from the previous ones
+  icon-R02B09-hpz10-nested-v3: #ClimateDT cycle2, 3686446 missing values - same as v1
     cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_v2.nc'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz10_nested_oce_v3.nc'
     space_coord: ["cell"]
-  icon-R02B08-hpz9-nested-3d-v2: #ClimateDT cycle2, 72 levels starting at 1, 924355 missing values
+  icon-R02B09-hpz10-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 3686446 missing values - same as v1
     cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_level_full_v2.nc'
-    space_coord: ["cell"]
-    vert_coord: ["level"]
-
-  icon-R02B09-hpz7-nested-v2: #ClimateDT cycle2, 57642 missing values
-    cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_v2.nc'
-    space_coord: ["cell"]
-  icon-R02B09-hpz7-nested-3d-v2: #ClimateDT cycle2, 72 levels starting at 1, 57642 missing values
-    cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_level_full_v2.nc'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz10_nested_oce_level_full_v3.nc'
     space_coord: ["cell"]
     vert_coord: ["level"]
-
-  icon-R02B09-hpz10-nested-v2: #ClimateDT cycle2, 3686446 missing values - same as v1
+  icon-R02B08-hpz9-nested-v3: #ClimateDT cycle2, 924355 missing values
     cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B09_hpz10_nested_oce_v2.nc'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_v3.nc'
     space_coord: ["cell"]
-  icon-R02B09-hpz10-nested-3d-v2: #ClimateDT cycle2, 72 levels starting at 1, 3686446 missing values - same as v1
+  icon-R02B08-hpz9-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 924355 missing values
     cdo_options: '--force'
-    path: '{{ grids }}/HealPix/icon-R02B09_hpz10_nested_oce_level_full_v2.nc'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz9_nested_oce_level_full_v3.nc'
+    space_coord: ["cell"]
+    vert_coord: ["level"]
+  icon-R02B09-hpz7-nested-v3: #ClimateDT cycle2, 57642 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_v3.nc'
+    space_coord: ["cell"]
+  icon-R02B09-hpz7-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 57642 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B09_hpz7_nested_oce_level_full_v3.nc'
+    space_coord: ["cell"]
+    vert_coord: ["level"]
+  icon-R02B08-hpz6-nested-v3: #ClimateDT cycle2, 14415 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz6_nested_oce_v3.nc'
+    space_coord: ["cell"]
+  icon-R02B08-hpz6-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 14415 missing values
+    cdo_options: '--force'
+    path: '{{ grids }}/HealPix/icon-R02B08_hpz6_nested_oce_level_full_v3.nc'
     space_coord: ["cell"]
     vert_coord: ["level"]


### PR DESCRIPTION
## PR description:

Thanks to Jairo I have been able to get some data for ICON production simulation. The data has been manually added through a branch https://github.com/DestinE-Climate-DT/Climate-DT-catalog/tree/test-production

With these data I created the hpz7 and hpz10 production grids, currently named as `v2`. Actually hpz10 is the same as previous v1 (due to the policy from MPI). 

We still need to update the checksum. 

 - [ ] Changelog is updated.
