### PR TITLE
Hotfix: disable ocean drifts when running analysis

### DIFF
--- a/cli/aqua-analysis/config.aqua-analysis.yaml
+++ b/cli/aqua-analysis/config.aqua-analysis.yaml
@@ -42,10 +42,17 @@ cluster:  # options for dask cluster (this works well on lumi)
 diagnostics:
 
   # List of diagnostics to run
+  # run: ["global_biases", "timeseries_atm", "timeseries_oce", "seasonal_cycles",
+  #       "radiation-boxplots", "radiation-timeseries", "radiation-biases", 
+  #       "teleconnections_atm", "teleconnections_oce",
+  #       "tropical_rainfall", "ecmean", "ocean3d_drift", "ocean3d_circulation",
+  #       "seaice_volume", "seaice_thick", "seaice_conc", "seaice_extent"]
+
+  # Drifts disabled #1652
   run: ["global_biases", "timeseries_atm", "timeseries_oce", "seasonal_cycles",
         "radiation-boxplots", "radiation-timeseries", "radiation-biases", 
         "teleconnections_atm", "teleconnections_oce",
-        "tropical_rainfall", "ecmean", "ocean3d_drift", "ocean3d_circulation",
+        "tropical_rainfall", "ecmean", "ocean3d_circulation",
         "seaice_volume", "seaice_thick", "seaice_conc", "seaice_extent"]
 
   # List of diagnostics


### PR DESCRIPTION
## PR description:

Until #1651 / #1652 are resolved, disable drifts when running `aqua_analysis`
