### PR TITLE
ICON grids `space_coord` from cell to ncells

### DIFF
--- a/config/grids/ICON.yaml
+++ b/config/grids/ICON.yaml
@@ -84,36 +84,36 @@ grids:
   icon-R02B09-hpz10-nested-v3: #ClimateDT cycle2, 3686446 missing values - same as v1
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz10_nested_oce_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
   icon-R02B09-hpz10-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 3686446 missing values - same as v1
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz10_nested_oce_level_full_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
     vert_coord: ["level"]
   icon-R02B08-hpz9-nested-v3: #ClimateDT cycle2, 924355 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B08_hpz9_nested_oce_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
   icon-R02B08-hpz9-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 924355 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B08_hpz9_nested_oce_level_full_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
     vert_coord: ["level"]
   icon-R02B09-hpz7-nested-v3: #ClimateDT cycle2, 57642 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz7_nested_oce_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
   icon-R02B09-hpz7-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 57642 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz7_nested_oce_level_full_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
     vert_coord: ["level"]
   icon-R02B08-hpz6-nested-v3: #ClimateDT cycle2, 14415 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B08_hpz6_nested_oce_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
   icon-R02B08-hpz6-nested-3d-v3: #ClimateDT cycle2, 72 levels starting at 1, 14415 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B08_hpz6_nested_oce_level_full_v3.nc'
-    space_coord: ["cell"]
+    space_coord: ["ncells"]
     vert_coord: ["level"]


### PR DESCRIPTION
## PR description:

In #1658 we realized that there is some strange behaviour in fldmean with recent ICON data. This is mostly done to the `space_coord` that was wrongly defined. This PR fixes the naming of ALL the ICON v3 grids, and after (very important) rebuild of the areas now the problem discussed is no longer found.  

## Issues closed by this pull request:

Close #1658

----

 - [ ] Changelog is updated.

