### PR TITLE
Hotfix: push_s3 compatibility with boto3>=1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
 
+- push_s3 compatibility with boto3>=1.36.0 (#1704)
 - Rsync option for push_analysis.sh (#1689)
 - Multiple updates to allow for AQUA open source, including Dockerfiles, actions, dependencies and containers (#1574)
 

--- a/cli/aqua-web/push_s3.py
+++ b/cli/aqua-web/push_s3.py
@@ -9,6 +9,7 @@
 import argparse
 import os
 import boto3
+from botocore.client import Config
 
 def upload_file_to_s3(client, bucket_name, file_path, object_name):
     """Upload a single file to an S3 bucket."""
@@ -46,10 +47,12 @@ def main():
 
     args = parser.parse_args()
 
+    config = Config(signature_version='s3')
     s3 = boto3.client('s3',
                       aws_access_key_id=args.aws_access_key_id,
                       aws_secret_access_key=args.aws_secret_access_key,
-                      endpoint_url=args.endpoint_url)
+                      endpoint_url=args.endpoint_url,
+                      config=config)
 
     if os.path.isdir(args.source):
         upload_directory_to_s3(s3, args.bucket_name, args.source, args.destination)


### PR DESCRIPTION
## PR description:

This hotfix restores compatibility with boto3 >= 1.36.0.

`push_s3.py` had stopped working after recent environment updates, throwing this error message:
```
Error uploading file: Failed to upload /users/jvonhar/test.txt to aquatest2/test.txt: An error occurred (XAmzContentSHA256Mismatch) when c
alling the PutObject operation: None
```

The problem started with boto3 version >= 1.36.0, earlier versions worked.
This solution is better than a pin, since it fixes the issue both with recent and older versions of boto3.

We will probably need to fix this also in 0.13-operational if we plan to push future op figures to the dashboard.

----

 - [x] Changelog is updated.
