### PR TITLE
Hotfix to catgen test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
+- Adapt Catgen test to the new number of sources for ICON (#1708)
 - push_s3 compatibility with boto3>=1.36.0 (#1704)
 - Rsync option for push_analysis.sh (#1689)
 - Multiple updates to allow for AQUA open source, including Dockerfiles, actions, dependencies and containers (#1574)

--- a/tests/test_catgen.py
+++ b/tests/test_catgen.py
@@ -108,7 +108,7 @@ def test_catgen_reduced(tmp_path, model, nsources, nocelevels):
 @pytest.mark.parametrize(('model,nsources,nocelevels'),
                         [('IFS-NEMO', 28, 75),
                          ('IFS-FESOM', 31, 69),
-                         ('ICON', 31, 72)])
+                         ('ICON', 21, 72)])
 @pytest.mark.catgen
 def test_catgen_production(tmp_path, model, nsources, nocelevels):
     """test for production portfolio"""


### PR DESCRIPTION
## PR description:

The latest version of the Data Portfolio includes a different number of sources for ICON, causing our tests to fail. Therefore, I am adapting here the Catgen test.


Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [x] Changelog is updated.

