### PR TITLE
LRA zip compression for yearly files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
+- Enable zip compression for LRA yearly files (#1726)
 - Enable publication of documentation on ReadTheDocs (#1699, #1716)
 - Adapt Catgen test to the new number of sources for ICON (#1708)
 - Added tests for the Hovmoller plot routine (#1532)

--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -431,20 +431,20 @@ class LRAgenerator():
         from the same year
         """
 
-        # infiles = os.path.join(self.outdir,
-        #                       f'{var}_{self.exp}_{self.resolution}_{self.frequency}_{year}??.nc')
         infiles = self.get_filename(var, year, month = '??')
         if len(glob.glob(infiles)) == 12:
             xfield = xr.open_mfdataset(infiles)
             self.logger.info('Creating a single file for %s, year %s...', var, str(year))
             outfile = self.get_filename(var, year)
-            # outfile = os.path.join(self.tmpdir,
-            #                        f'{var}_{self.exp}_{self.resolution}_{self.frequency}_{year}.nc')
+
             # clean older file
             if os.path.exists(outfile):
                 os.remove(outfile)
+            
+            # these are made XarrayDataset made of a single variable
+            name = list(xfield.data_vars)[0]
             xfield.to_netcdf(outfile, 
-                             encoding={'time': self.time_encoding, xfield.name: self.var_encoding})
+                             encoding={'time': self.time_encoding, name: self.var_encoding})
 
             # clean of monthly files
             for infile in glob.glob(infiles):

--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -443,7 +443,8 @@ class LRAgenerator():
             # clean older file
             if os.path.exists(outfile):
                 os.remove(outfile)
-            xfield.to_netcdf(outfile)
+            xfield.to_netcdf(outfile, 
+                             encoding={'time': self.time_encoding, xfield.name: self.var_encoding})
 
             # clean of monthly files
             for infile in glob.glob(infiles):

--- a/tests/test_lra.py
+++ b/tests/test_lra.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import pytest
+from datetime import datetime
 import xarray as xr
 from aqua import LRAgenerator, Reader
 
@@ -137,13 +138,19 @@ class TestLRA():
         for month in range(1, 13):
             mm = f'{month:02d}'
             filename =  test.get_filename(var, year, month = mm)
-            with xr.Dataset() as ds:
-                ds[var] = xr.DataArray([0], dims=['time'], coords={'time': [f'{year}-{month:02d}-01']})
-                ds.to_netcdf(filename)
+            timestr = f'{year}-{mm}-01'
+            timeobj = datetime.strptime(timestr, "%Y-%m-%d")
+            ds = xr.Dataset({
+                var: xr.DataArray([0], dims=['time'], coords={'time': [timeobj]})
+            })
+            ds.to_netcdf(filename)
 
         test._concat_var_year(var, year)
         outfile = test.get_filename(var, year)
 
         # Check if a single file is created for the year
         assert os.path.exists(outfile)
+
+        # cleaning 
         os.remove(outfile)
+        shutil.rmtree(outdir)


### PR DESCRIPTION
## PR description:

Enable LRA compression also for concat yearly files, which was missing. I would not applicate this to operational. 

 - [x] Changelog is updated.

