### PR TITLE
[OP] Enable tests for v0.13-operational

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -2,9 +2,9 @@ name: AQUA tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, v0.13-operational ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, v0.13-operational ]
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * 1" # run every Monday night at 3AM UTC
@@ -78,7 +78,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: DestinE-Climate-DT/Climate-DT-catalog
-          token: github_pat_${{ secrets.CLIMATEDT_TOKEN }}
           path: Climate-DT-catalog 
       - name: Clone GitLab data-portfolio repository
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 
-AQUA diagnostics complete list:
+AQUA core complete list:
+- Enable tests for the operational v0.13-operational branch (#1730)
 - push_s3 compatibility with boto3>=1.36.0 (#1709)
+
+AQUA diagnostics complete list:
 - Ecmean: Fix net surface radiative flux and wind stresses in ecmean (#1697)
 - Tropical Rainfall: Update of the precomputed histograms paths for lumi and MN5 operational (#1702)
 

--- a/src/aqua/cli/main.py
+++ b/src/aqua/cli/main.py
@@ -444,9 +444,7 @@ class AquaConsole():
             # before going open source, we will use a basic token and PD account.
             fs = fsspec.filesystem("github",
                                     org="DestinE-Climate-DT",
-                                    repo="Climate-DT-catalog",
-                                    username="mnurisso",
-                                    token="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") # noqa
+                                    repo="Climate-DT-catalog")
             self.logger.info('Accessed remote repository https://github.com/DestinE-Climate-DT/Climate-DT-catalog')
         except HTTPError:
             self.logger.error('Permission issues in accessing Climate-DT catalog, please contact AQUA mantainers')

--- a/tests/test_catgen.py
+++ b/tests/test_catgen.py
@@ -108,7 +108,7 @@ def test_catgen_reduced(tmp_path, model, nsources, nocelevels):
 @pytest.mark.parametrize(('model,nsources,nocelevels'),
                         [('IFS-NEMO', 28, 75),
                          ('IFS-FESOM', 31, 69),
-                         ('ICON', 31, 72)])
+                         ('ICON', 21, 72)])
 @pytest.mark.catgen
 def test_catgen_production(tmp_path, model, nsources, nocelevels):
     """test for production portfolio"""


### PR DESCRIPTION
## PR description:

Enable tests for the operational branch and remove the climatedt token which is not necessary anymore and disabled now.

 - [x] Changelog is updated.