### PR TITLE
[OP] 0.13.2 preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.13.2
       - v0.13.1
       - v0.13.0
       - v0.13-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 
+## [v0.13.2]
+
 AQUA core complete list:
 - Fix push_analysis options and aqua_analysis config paths (#1731)
 - Enable tests for the operational v0.13-operational branch (#1730)
@@ -820,6 +822,7 @@ This is the AQUA pre-release to be sent to internal reviewers.
 Documentations is completed and notebooks are working.
 
 [unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...HEAD
+[v0.13.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...v0.13.2
 [v0.13.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.0...v0.13.1
 [v0.13.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13-beta...v0.13.0
 [v0.13-beta]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13-alpha...v0.13-beta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "fastparquet",
     "pyfdb@git+https://github.com/ecmwf/pyfdb.git@0.0.3",
     "ECmean4>=0.1.12",
-    "gsv-interface@git+https://oauth2:pXj19aBDApiBPs1YgwuZ@earth.bsc.es/gitlab/digital-twins/de_340-2/gsv_interface.git@v2.9.2"
+    "gsv-interface@git+https://oauth2:pXj19aBDApiBPs1YgwuZ@earth.bsc.es/gitlab/digital-twins/de_340-2/gsv_interface.git@v2.9.5"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `src/aqua/version.py`
- [x] quick check gsv pin
- [ ] if a major operational release, update Dockerfiles and relative action
