### PR TITLE
Further intake-gsv fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
 
-- Avoid infinite hanging when accessing bridge (#1733, #1738)
+- Avoid infinite hanging during bridge access (#1733, #1738)
 - Enable dependabot to monitor dependencies every month (#1748)
 - eccodes bump to 2.40.0 (#1747)
 - Integrate codecov to monitor coverage and remove old bot (#1736, #1737)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
 
-- Reinitialize GSVReader instance only when needed (#1733)
+- Avoid infinite hanging when accessing bridge (#1733, #1738)
 - Enable the option to read FDB data info from file, and refactor start/end hpc/bridge dates handling (#1732)
 - Fix push_analysis options and aqua_analysis config paths (#1723)
 - Enable zip compression for LRA yearly files (#1726)

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -418,16 +418,12 @@ class GSVSource(base.DataSource):
     def _switch_eccodes(self):
         """
         Internal method to switch ECCODES version if needed.
-
-        Returns a boolean indicating if the switch was done.
         """
         if self.eccodes_path:  # if needed switch eccodes path
             # unless we have already switched
             if self.eccodes_path and (self.eccodes_path != eccodes.codes_definition_path()):
                 eccodes.codes_context_delete()  # flush old definitions in cache
                 eccodes.codes_set_definitions_path(self.eccodes_path)
-                return True
-        return False
 
     def _index_to_timelevel(self, ii):
         """
@@ -514,8 +510,7 @@ class GSVSource(base.DataSource):
 
         # Select based on type of FDB
         fstream_iterator = False  # We set it False, but it works also with True
-        current_fdb_home = os.environ.get("FDB_HOME", None)
-        current_fdb_path = os.environ.get("FDB5_CONFIG_FILE", None)
+
         if self.chk_type[i]:
             # Bridge FDB type
             if self.fdbhome_bridge:
@@ -532,31 +527,15 @@ class GSVSource(base.DataSource):
             if self.hpc_expver:
                 request["expver"] = self.hpc_expver
 
-        # A rebuild of the GSV is needed if the FDB_HOME or FDB5_CONFIG_FILE has changed
-        rebuild_gsv = False
-        if current_fdb_home != os.environ.get("FDB_HOME", None):
-            self.logger.debug("FDB_HOME has been changed to from %s to %s",
-                              current_fdb_home, os.environ.get("FDB_HOME", None))
-            rebuild_gsv = True
-        if current_fdb_path != os.environ.get("FDB5_CONFIG_FILE", None):
-            self.logger.debug("FDB5_CONFIG_FILE has been changed to from %s to %s",
-                              current_fdb_path, os.environ.get("FDB5_CONFIG_FILE", None))
-            rebuild_gsv = True
+        self._switch_eccodes()
 
-        flag_eccodes_switch = self._switch_eccodes()
-
-        # this is needed here and not in init because each worker spawns a new environment
-        gsv_log_level = _check_loglevel(self.logger.getEffectiveLevel())
-
-        # The following is a hack around a pyfdb/fdb5 bug which requires a double initialization when switching from bridge to hpc and back
+        # The following is a hack around a pyfdb/fdb5 bug which requires a double initialization when reading from bridge
         # See https://github.com/DestinE-Climate-DT/AQUA/issues/1715
         # Notice also that for some mysterious reason this works only if the result is stored in self (even if then it is not used)
+        if self.chk_type[i]:
+            self.gsv = GSVRetriever(logging_level=self.gsv_log_level)
+        gsv = GSVRetriever(logging_level=self.gsv_log_level)
 
-        if flag_eccodes_switch or rebuild_gsv or not hasattr(self, 'gsv') or not self.gsv:
-            self.logger.debug("Rebuilding GSVRetrieve")
-            self.gsv = GSVRetriever(logging_level=gsv_log_level)
-            
-        gsv = GSVRetriever(logging_level=gsv_log_level)
         self.logger.debug('Request %s', request)
         dataset = gsv.request_data(request, use_stream_iterator=fstream_iterator,
                                    process_derived_variables=False)  # following 2.9.2 we avoid derived variables

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -237,8 +237,6 @@ class GSVSource(base.DataSource):
         else:
             self.chunking_vertical = None  # no vertical chunking
 
-        self.gsv = None
-
         self._switch_eccodes()
 
         super(GSVSource, self).__init__(metadata=metadata)
@@ -550,7 +548,10 @@ class GSVSource(base.DataSource):
         # this is needed here and not in init because each worker spawns a new environment
         gsv_log_level = _check_loglevel(self.logger.getEffectiveLevel())
 
-        # The following is done to recycle the GSVRetriever instance: it has to be changed only if FDB_HOME or ECCODES changed
+        # The following is a hack around a pyfdb/fdb5 bug which requires a double initialization when switching from bridge to hpc and back
+        # See https://github.com/DestinE-Climate-DT/AQUA/issues/1715
+        # Notice also that for some mysterious reason this works only if the result is stored in self (even if then it is not used)
+
         if flag_eccodes_switch or rebuild_gsv or not hasattr(self, 'gsv') or not self.gsv:
             self.logger.debug("Rebuilding GSVRetrieve")
             self.gsv = GSVRetriever(logging_level=gsv_log_level)

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -178,6 +178,21 @@ class TestGsv():
         data = reader.retrieve(level=[900, 800])  # Read only two levels
         assert data.t.isel(plev=1).mean().values == pytest.approx(271.2092), "Field values incorrect"
 
+    def test_reader_bridge(self) -> None:
+        """
+        Reading from a datasource using bridge
+        """
+
+        reader = Reader(model="IFS", exp="test-fdb", source="fdb-bridge", loglevel=loglevel)
+        data = reader.retrieve()
+        # Test if the correct dates have been found
+        assert "1990-01-01T00:00" in str(data.time[0].values)
+        assert "1990-01-02T00:00" in str(data.time[-1].values)
+        # Test if the data can actually be read and contain the expected values
+        assert data.tcc.isel(time=0).values.mean() == pytest.approx(65.30221138649116)  # This is from HPC
+        assert data.tcc.isel(time=15).values.mean() == pytest.approx(65.62109108718757)  # This is from the bridge
+        assert data.tcc.isel(time=-1).values.mean() == pytest.approx(66.87973267265382)  # This is from HPC again
+
     def test_reader_auto(self) -> None:
         """
         Reading from a datasource using new operational schema and auto dates


### PR DESCRIPTION
## PR description:

This PR is only to start working and discussing on a solution towards the continued problems discussed in #1715 

In this branch I keep the previous structure which instantiates a new GSVRetriever object the first time or every time `FDB_HOME` changes, but additionally it also instantiates a new object anyway  (as in older versions of AQUA) before running the retrieve. This means that the first time this is run two gsv objects are instantiated and again, two are instantiated if `FDB_HOME` changes. 
Apparently this allows the code to run again correctly both on bridge and hpc and avoids the 'infinite hang' issue. Basically it implements the first solution discussed at the top of #1715 where it was found that instantiating GSVRetriever twice seemed to solve the problem.  Of course the issue that accessing in sequence bridge, hpc, bridge crashes remains.

Another change here is that now the extra 'initial' GSVRetriever object is temporarily stored in `self` (not `GSVSource`) but then actually not used. Here the true magic begins: if instead of storing this extra object in `self` I discard it, writing `_ = GSVRetriever(logging_level=gsv_log_level)` in line 556 .... all this stops working!  
Clearly all this is a hack around some crazy bug of pyfdb or fdb5. 

In any case, please check, it seems to me that this branch at least avoids the infinite hang and works again.


 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
