### PR TITLE
[OP] Changing if statement for fixer_name in catgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 Unreleased in the current development version:
+- Fix catalog generator when fdb_info_file is used (#1742)
 
 ## [v0.13.2]
 

--- a/config/catgen/production.j2
+++ b/config/catgen/production.j2
@@ -51,10 +51,7 @@
         {% endif %}
         variables: {{ variables }}
         source_grid_name: {{ grid }}
-        fixer_name: {% if fixer_name %}{{ fixer_name }}{% else %}{% raw %}climatedt-phase2-production{% endraw %}{% endif %}
+        fixer_name: {{ fixer_name | default('climatedt-phase2-production') }}
         {% if fdb_info_file %}
         fdb_info_file: {{ fdb_info_file }}
         {% endif %}
-
-
-        

--- a/config/catgen/reduced.j2
+++ b/config/catgen/reduced.j2
@@ -51,9 +51,7 @@
         {% endif %}
         variables: {{ variables }}
         source_grid_name: {{ grid }}
-        fixer_name: {% if fixer_name %}{{ fixer_name }}{% else %}{% raw %}climatedt-phase2-reduced{% endraw %}{% endif %} 
+        fixer_name: {{ fixer_name | default('climatedt-phase2-reduced') }} 
         {% if fdb_info_file %}
         fdb_info_file: {{ fdb_info_file }}
         {% endif %}
-
-        


### PR DESCRIPTION
## PR description:

Solution for #1740 
Changes the fixer_name block if-else using instead a default backfall value

## Issues closed by this pull request:

Close #1740

 - [ ] Tests are included if a new feature is included.