### PR TITLE
Add additional command-line arguments for configuration and processing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ AQUA core complete list:
 - Multiple updates to allow for AQUA open source, including Dockerfiles, actions, dependencies and containers (#1574)
 
 AQUA diagnostics complete list:
+- Diagnostic core: Add additional command-line arguments for configuration and processing options (#1745)
 - Global bias: Handling plev and using scientific notation in contour plots (#1649)
 - Ecmean: Fix net surface radiative flux and wind stresses in ecmean (#1696)
 - Diagnostic core: A common parser and fuctions to open/close the dask cluster are provided (#1703)

--- a/docs/sphinx/source/diagnostics/guidelines/default_parser.rst
+++ b/docs/sphinx/source/diagnostics/guidelines/default_parser.rst
@@ -1,0 +1,21 @@
+Default parser
+==============
+
+All the state of the art diagnostics (See :ref:`diagnostics` for a description) needs to have a
+command line interface (CLI) to be able to run them together with the other diagnostics in the AQUA framework.
+
+In order to facilitate the usage of different diagnostics, a set of common arguments that the CLI should be able
+to parse has been defined. A utility parser function is present in the `aqua.diagnostics.core` module as `template_parser`.
+The function will take any parser and add the mandatory arguments.
+
+These are:
+    * --loglevel, -l: Set logging level (str)
+    * --catalog: Catalog name (str) 
+    * --model: Model name (str)
+    * --exp: Experiment name (str)
+    * --source: Source name (str)
+    * --config, -c: YAML configuration file (str)
+    * --nworkers, -n: Number of workers (int)
+    * --cluster: Cluster address (str) 
+    * --regrid: Regrid data to the target grid (str)
+    * --outputdir: Output directory path (str)

--- a/docs/sphinx/source/diagnostics/index.rst
+++ b/docs/sphinx/source/diagnostics/index.rst
@@ -169,3 +169,4 @@ In this section we provide some guidelines for the development of new diagnostic
 
    guidelines/output_management
    guidelines/configuration_files
+   guidelines/default_parser

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -16,7 +16,6 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
     Returns:
         argparse.ArgumentParser
     """
-
     parser.add_argument("--loglevel", "-l", type=str,
                         required=False, help="loglevel")
     parser.add_argument("--catalog", type=str,
@@ -27,8 +26,16 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
                         required=False, help="experiment name")
     parser.add_argument("--source", type=str,
                         required=False, help="source name")
-    parser.add_argument('-c', '--config', type=str,
+    parser.add_argument("--config", "-c", type=str,
                         help='yaml configuration file')
+    parser.add_argument("--nworkers", "-n", type=int,
+                        required=False, help="number of workers")
+    parser.add_argument("--cluster", type=str,
+                        required=False, help="cluster address")
+    parser.add_argument("--regrid", action='store_true',
+                        help="regrid data to r100")
+    parser.add_argument("--outputdir", type=str,
+                        required=False, help="output directory")
 
     return parser
 

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -32,8 +32,8 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
                         required=False, help="number of workers")
     parser.add_argument("--cluster", type=str,
                         required=False, help="cluster address")
-    parser.add_argument("--regrid", action='store_true',
-                        help="regrid data to r100")
+    parser.add_argument("--regrid", type=str,
+                        required=False, help="target regrid resolution")
     parser.add_argument("--outputdir", type=str,
                         required=False, help="output directory")
 

--- a/tests/diagnostic_core/test_core_util.py
+++ b/tests/diagnostic_core/test_core_util.py
@@ -11,15 +11,21 @@ def test_template_parse_arguments():
     """Test the template_parse_arguments function"""
     parser = argparse.ArgumentParser()
     parser = template_parse_arguments(parser)
-    args = parser.parse_args(["--loglevel", "DEBUG", "--catalog", "test_catalog", "--model", "test_model"])
+    args = parser.parse_args(["--loglevel", "DEBUG", "--catalog", "test_catalog", "--model", "test_model",
+                              "--exp", "test_exp", "--source", "test_source", "--config", "test_config.yaml",
+                              "--regrid", "r100", "--outputdir", "test_outputdir", "--cluster", "test_cluster",
+                              "--nworkers", "2"])
 
     assert args.loglevel == "DEBUG"
     assert args.catalog == "test_catalog"
     assert args.model == "test_model"
-    assert args.exp is None
-    assert args.source is None
-    assert args.config is None
-
+    assert args.exp == "test_exp"
+    assert args.source == "test_source"
+    assert args.config == "test_config.yaml"
+    assert args.regrid == "r100"
+    assert args.outputdir == "test_outputdir"
+    assert args.cluster == "test_cluster"
+    assert args.nworkers == 2
 
 @pytest.mark.aqua
 @patch("aqua.diagnostics.core.util.Client")


### PR DESCRIPTION
## PR description:

Add to the default parser:

- `--regrid` to enable `r100` regrid
- `--nworkers`, `-n` to set the workers number
- `--cluster` to store an already open cluster
- `--outputdir` to specify directory for output

## Issues closed by this pull request:

Close #1713

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.