### PR TITLE
More flexible action including also Dependabot case

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -28,8 +28,11 @@ defaults:
 jobs:
   aqua_test:
     # NOTE: this option can be uncommented to run the job only when
-    #       a pull request contains a label with the name "Run Tests" or "Ready to Merge".
-    if: contains(github.event.pull_request.labels.*.name, 'run tests') || contains(github.event.pull_request.labels.*.name, 'ready to merge')
+    #       a pull request contains a label with the name "Run Tests" or "Ready to Merge" or if run by Dependabot.
+    if: > 
+      contains(github.event.pull_request.labels.*.name, 'run tests') || 
+      contains(github.event.pull_request.labels.*.name, 'ready to merge') || 
+      github.actor == 'dependabot[bot]'
     env:
       DEBIAN_FRONTEND: noninteractive
       GRID_DEFINITION_PATH: /tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
+- Enable dependabot to monitor dependencies every month (#1748)
 - Integrate codecov to monitor coverage and remove old bot (#1736, #1737)
 - Reinitialize GSVReader instance only when needed (#1733)
 - Enable the option to read FDB data info from file, and refactor start/end hpc/bridge dates handling (#1732, #1743)


### PR DESCRIPTION
## PR description:

This  - in theory - should allow for more precise label-triggering actions as well as action to be triggered when dependenabot is set up. 
