### PR TITLE
v0.13.3 prepare

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,12 +49,12 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.13.3
       - v0.13.2
       - v0.13.1
       - v0.13.0
       - v0.13-beta
       - v0.13-alpha
-      - v0.12.3
       - older (specify)
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 Unreleased in the current development version:
+
+## [v0.13.3]
+
+Hotfixes:
 - Fix for the `aqua-analysis` that was changing the AQUA_CONFIG environment variable with a wrong path (#1752)
 - Fix catalog generator when fdb_info_file is used (#1742)
 
@@ -823,7 +827,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.3...HEAD
+[v0.13.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.2...v0.13.3
 [v0.13.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...v0.13.2
 [v0.13.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.0...v0.13.1
 [v0.13.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13-beta...v0.13.0

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.13.2'
+__version__ = '0.13.3'


### PR DESCRIPTION
## Version release PR:

New hotfix version

Issue to keep track of what is needed for a new AQUA release

- [X] update changelog
- [X] update bug report menu
- [X] update version number in `src/aqua/version.py`
- [ ] quick check gsv pin
- [ ] if a major operational release, update Dockerfiles and relative action
