### PR TITLE
[OP] Intake GSV can now handle fdb_info_file with only the data block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 Unreleased in the current development version:
+- Fix for the `fdb_info_file` feature, that now can have a `data` only block when no data is on the bridge (#1761)
 
 ## [v0.13.3]
 

--- a/docs/sphinx/source/adding_data.rst
+++ b/docs/sphinx/source/adding_data.rst
@@ -311,11 +311,14 @@ Some of the parameters are here described:
     - ``variables``: a list of variables available in the fdb.
     - ``source_grid_name``: the grid name defined in aqua-grids.yaml to be used for areas and regridding
     - ``fixer_name``: the name of the fixer defined in the fixes folder
-    - ``levels``: for 3D FDB data with a `levelist` in the request, this is the list of physical levels 
+    - ``levels``: for 3D FDB data with a ``levelist`` in the request, this is the list of physical levels 
                   (e.g. [0.5, 10, 100, ...] meters while levelist contains [1, 2, 3, ...]).
     - ``deltat`` (optional): the cumulation window of fluxes in the dataset. This is a fixer option. If not present, the default is 1 second.
-    - ``fdb_info_file``(optional): the path to the YAML file written by the workflow that can be used to infer `data_start_date`, `data_end_date`
-                  and other information as `bridge_start_date` and `bridge_end_date`. If not present, default values are used.     
+    - ``fdb_info_file`` (optional): the path to the YAML file written by the workflow that can be used to infer ``data_start_date``, ``data_end_date``
+                  and other information as ``bridge_start_date`` and ``bridge_end_date``. If not present, default values are used.
+                  It consists of two blocks, a ``data`` block and a ``bridge`` block. The first one contains the information for the entire
+                  simulation and it is mandatory, while the second one contains the information for the databridge and can be written
+                  only if the data are split between the FDB and the databridge.
 
     If the ``levels`` key is defined, then retrieving 3D data is greatly accelerated, since only one level 
     of each variable will actually have to be retrieved in order to define the Dataset.

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -679,9 +679,10 @@ class GSVSource(base.DataSource):
             try:
                 fdb_info['bridge']['bridge_start_date'] = self._validate_info_date(fdb_info, 'bridge', 'start')
                 fdb_info['bridge']['bridge_end_date'] = self._validate_info_date(fdb_info, 'bridge', 'end')
+            # if bridge dates are wrongly defined, set the bridge block to None
             except KeyError:
                 self.logger.error("FDB info file %s does not contain bridge dates in correct form", fdb_info_file)
-                return None
+                fdb_info['bridge'] = None
         else:
             fdb_info['bridge'] = None
 

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -662,24 +662,26 @@ class GSVSource(base.DataSource):
         except (OSError, yaml.YAMLError) as e:
             self.logger.error("Error reading or parsing YAML file %s: %s", fdb_info_file, str(e))
             return None
-
-        if not all(key in fdb_info for key in ['data', 'bridge']):
-            self.logger.error("FDB info file %s does not contain expected sections ('data' and 'bridge')", fdb_info_file)
+        
+        # The 'data' block is mandatory and present since the first chunck of simulation
+        # The 'bridge' block is written only if some data is on bridge (see #1760)
+        if 'data' in fdb_info:
+            try: 
+                fdb_info['data']['data_start_date'] = self._validate_info_date(fdb_info, 'data', 'start')
+                fdb_info['data']['data_end_date'] = self._validate_info_date(fdb_info, 'data', 'end')
+            except KeyError:
+                self.logger.error("FDB info file %s does not contain HPC dates in correct format", fdb_info_file)
+                return None
+        else:
+            self.logger.error("FDB info file %s does not contain 'data' section, which is mandatory", fdb_info_file)
             return None
-
-        try: 
-            fdb_info['data']['data_start_date'] = self._validate_info_date(fdb_info, 'data', 'start')
-            fdb_info['data']['data_end_date'] = self._validate_info_date(fdb_info, 'data', 'end')
-        except KeyError:
-            self.logger.error("FDB info file %s does not contain HPC dates in correct format", fdb_info_file)
-            return None
-        if self.fdbhome_bridge or self.fdbpath_bridge:
-                try:
-                    fdb_info['bridge']['bridge_start_date'] = self._validate_info_date(fdb_info, 'bridge', 'start')
-                    fdb_info['bridge']['bridge_end_date'] = self._validate_info_date(fdb_info, 'bridge', 'end')
-                except KeyError:
-                    self.logger.error("FDB info file %s does not contain bridge dates in correct form", fdb_info_file)
-                    return None
+        if 'bridge' in fdb_info and (self.fdbhome_bridge or self.fdbpath_bridge):
+            try:
+                fdb_info['bridge']['bridge_start_date'] = self._validate_info_date(fdb_info, 'bridge', 'start')
+                fdb_info['bridge']['bridge_end_date'] = self._validate_info_date(fdb_info, 'bridge', 'end')
+            except KeyError:
+                self.logger.error("FDB info file %s does not contain bridge dates in correct form", fdb_info_file)
+                return None
         else:
             fdb_info['bridge'] = None
 

--- a/tests/catgen/fdb_info_hpc-only.yaml
+++ b/tests/catgen/fdb_info_hpc-only.yaml
@@ -1,0 +1,7 @@
+# This is a mockup version of the yaml file that the workflow
+# writes in the FDB_HOME so that dynamically we can know
+# if a date is on the HPC FDB or in the DataBridge FDB
+data:
+  data_end_date: 19900103T2300
+  data_start_date: 19900101T0000
+  expver: t039

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -214,7 +214,9 @@ class TestGsv():
 
     def test_fdb_from_file(self) -> None:
         """
-        Reading fdb dates from a file
+        Reading fdb dates from a file.
+        First test with a file that contains both data and bridge dates.
+        Second test with a file that contains only data dates.
         """
         source = GSVSource(DEFAULT_GSV_PARAMS['request'],  "20080101", "20080101",
                            metadata={'fdb_home': FDB_HOME, 'fdb_home_bridge': FDB_HOME,
@@ -225,3 +227,11 @@ class TestGsv():
         assert source.data_end_date == '19900103T2300'
         assert source.bridge_start_date == '19900101T0000'
         assert source.bridge_end_date == '19900102T2300'
+
+        source = GSVSource(DEFAULT_GSV_PARAMS['request'],  "20080101", "20080101",
+                           metadata={'fdb_home': FDB_HOME, 'fdb_home_bridge': FDB_HOME,
+                                     'fdb_info_file': 'tests/catgen/fdb_info_hpc-only.yaml'},
+                            loglevel=loglevel)
+        
+        assert source.data_start_date == '19900101T0000'
+        assert source.data_end_date == '19900103T2300'


### PR DESCRIPTION
## PR description:

The intake GSV can now load as well a fdb_info_file which contains only the data block, as it will be as long as something is transferred on the bridge.
Only in that moment the bridge block will be added by the workflow.

## Issues closed by this pull request:

Close #1760 

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
