### PR TITLE
retrieve method for Diagnostic class can return data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ AQUA core complete list:
 - Multiple updates to allow for AQUA open source, including Dockerfiles, actions, dependencies and containers (#1574)
 
 AQUA diagnostics complete list:
+- Diagnostic core: the `retrieve()` method uses internally a `_retrieve()` method that returns instead of updating attributes (#1763)
 - Global bias: add test (#1675)
 - Diagnostic core: Add additional command-line arguments for configuration and processing options (#1745)
 - Global bias: Handling plev and using scientific notation in contour plots (#1649)

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -56,22 +56,10 @@ class Diagnostic():
             self.catalog: The catalog used to retrieve the data if no catalog was provided.
                           If return_data is True, the catalog attribute will not be changed.
         """
-
-        self.reader = Reader(catalog=self.catalog, model=self.model, exp=self.exp, source=self.source,
-                             regrid=self.regrid, startdate=self.startdate, enddate=self.enddate)
-
-        if self.catalog is None and return_data is False:
-            self.catalog = self.reader.catalog
-
-        data = self.reader.retrieve(var=var)
-
-        if self.regrid is not None:
-            data = self.reader.regrid(data)
-
-        if return_data is True:
-            return data
-        else:
-            self.data = data
+        self.data, self.reader, self.catalog = self._retrieve(model=self.model, exp=self.exp, source=self.source,
+                                                              var=var, catalog=self.catalog, startdate=self.startdate,
+                                                              enddate=self.enddate, regrid=self.regrid,
+                                                              loglevel=self.logger.level)
 
     def save_netcdf(self, data, diagnostic: str, diagnostic_product: str = None,
                     default_path: str = '.', rebuild: bool = True, **kwargs):
@@ -96,3 +84,42 @@ class Diagnostic():
                                   model=self.model, exp=self.exp, loglevel=self.logger.level)
 
         outputsaver.save_netcdf(dataset=data, **kwargs)
+
+    @staticmethod
+    def _retrieve(model: str, exp: str, source: str, var: str = None, catalog: str = None,
+                  startdate: str = None, enddate: str = None, regrid: str = None,
+                  loglevel: str = 'WARNING'):
+        """
+        Static method to retrieve data and return everything instead of updating class
+        attributes. Used internally by the retrieve method
+
+        Args:
+            model (str): model of the dataset to retrieve.
+            exp (str): exp of the dataset to retrieve.
+            source (str): source of the dataset to retrieve.
+            var (str or list): variable to retrieve. If None all are retrieved.
+            catalog (str): catalog of the dataset to retrieve.
+            startdate (str): The start date of the data to be retrieved.
+                             If None, all available data will be retrieved.
+            enddate (str): The end date of the data to be retrieved.
+                           If None, all available data will be retrieved.
+            regrid (str): The target grid to be used for regridding. If None, no regridding will be done.
+            loglevel (str): The log level to be used. Default is 'WARNING'.
+
+        Returns:
+            data (xarray Dataset or DataArray): The data retrieved from the model.
+            reader (aqua.Reader): The reader object used to retrieve the data.
+            catalog (str): The catalog used to retrieve the data.
+        """
+        reader = Reader(catalog=catalog, model=model, exp=exp, source=source,
+                        regrid=regrid, startdate=startdate, enddate=enddate, loglevel=loglevel)
+
+        data = reader.retrieve(var=var)
+
+        if catalog is None:
+            catalog = reader.catalog
+
+        if regrid is not None:
+            data = reader.regrid(data)
+
+        return data, reader, catalog

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -43,28 +43,35 @@ class Diagnostic():
         # Data to be retrieved
         self.data = None
 
-    def retrieve(self, var: str = None):
+    def retrieve(self, var: str = None, return_data: bool = False):
         """
         Retrieve the data from the model.
 
         Args:
             var (str): The variable to be retrieved. If None, all variables will be retrieved.
+            return_data (bool): If True, the data will be returned. Default is False.
 
         Attributes:
-            self.data: The data retrieved from the model.
+            self.data: The data retrieved from the model. If return_data is True, the data will be returned.
             self.catalog: The catalog used to retrieve the data if no catalog was provided.
+                          If return_data is True, the catalog attribute will not be changed.
         """
 
         self.reader = Reader(catalog=self.catalog, model=self.model, exp=self.exp, source=self.source,
                              regrid=self.regrid, startdate=self.startdate, enddate=self.enddate)
 
-        if self.catalog is None:
+        if self.catalog is None and return_data is False:
             self.catalog = self.reader.catalog
 
-        self.data = self.reader.retrieve(var=var)
+        data = self.reader.retrieve(var=var)
 
         if self.regrid is not None:
-            self.data = self.reader.regrid(self.data)
+            data = self.reader.regrid(data)
+
+        if return_data is True:
+            return data
+        else:
+            self.data = data
 
     def save_netcdf(self, data, diagnostic: str, diagnostic_product: str = None,
                     default_path: str = '.', rebuild: bool = True, **kwargs):

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -43,18 +43,16 @@ class Diagnostic():
         # Data to be retrieved
         self.data = None
 
-    def retrieve(self, var: str = None, return_data: bool = False):
+    def retrieve(self, var: str = None):
         """
         Retrieve the data from the model.
 
         Args:
             var (str): The variable to be retrieved. If None, all variables will be retrieved.
-            return_data (bool): If True, the data will be returned. Default is False.
 
         Attributes:
             self.data: The data retrieved from the model. If return_data is True, the data will be returned.
             self.catalog: The catalog used to retrieve the data if no catalog was provided.
-                          If return_data is True, the catalog attribute will not be changed.
         """
         self.data, self.reader, self.catalog = self._retrieve(model=self.model, exp=self.exp, source=self.source,
                                                               var=var, catalog=self.catalog, startdate=self.startdate,


### PR DESCRIPTION
## PR description:

Sometimes it can be useful to return data from a retrieve instead of updating the self.data
This PR introduces such update for the Diagnostic primitive class.

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.