### PR TITLE
Version to v0.13.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.13.4
       - v0.13.3
       - v0.13.2
       - v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 Unreleased in the current development version:
+
+## [v0.13.4]
+
+Hotfixes:
 - Fix for the `fdb_info_file` feature, that now can have a `data` only block when no data is on the bridge (#1761)
 
 ## [v0.13.3]
@@ -828,7 +832,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.3...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.4...HEAD
+[v0.13.4]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.2...v0.13.3
 [v0.13.2]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...v0.13.2
 [v0.13.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.0...v0.13.1

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.13.3'
+__version__ = '0.13.4'


### PR DESCRIPTION
## Version release PR:

Release v0.13.4

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `src/aqua/version.py`