### PR TITLE
Add support for custom time decoding for intake driver in Reader class

### DIFF
--- a/.github/workflows/aqua-complete.yml
+++ b/.github/workflows/aqua-complete.yml
@@ -52,7 +52,7 @@ jobs:
       # If true, the entire matrix will stop running when one of the jobs fails.
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -124,4 +124,4 @@ jobs:
       - name: Run tests
         run: |
           # Produce the HTML report. Defaults to writing in htmlcov/index.html.
-          pytest -m "aqua or slow or gsv or graphics or catgen or timeseries or ecmean or teleconnections or global_biases"
+          pytest -m "aqua or slow or gsv or graphics or catgen or diagnostics"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
+- Reader intake-xarray sources can select a coder for time decoding (#1778)
 - Added history logging for lat-lon in area selection (#1479)
 - Cleaner workflow and pytest/coverage configuration (#1755, #1758)
 - catalog, model, exp, source info are now stored in the DataArray attributes (#1753)

--- a/docs/sphinx/source/adding_data.rst
+++ b/docs/sphinx/source/adding_data.rst
@@ -110,6 +110,7 @@ Finally, the ``metadata`` entry contains optional additional information useful 
     - ``source_grid_name``: the grid name defined in ``aqua-grids.yaml`` to be used for areas and regridding
     - ``fixer_name``: the name of the fixer defined in the fixes folder
     - ``deltat`` (optional): the cumulation window of fluxes in the dataset. This is a fixer option. If not present, the default is 1 second.
+    - ``time_coder``: if specified modifies the target resolution when decoding dates. Defaults to “ns”. Used by the ``CFDatetimeCoder`` and working only for netcdf sources.
 
 You can add fixes to your dataset by following examples in the ``config/fixes/`` directory (see :ref:`fixer`).
 
@@ -327,10 +328,6 @@ Some of the parameters are here described:
 
     For FDB sources the ``metadata`` section contains very important informations that are used to
     retrieve the correct variables and levels.
-
-.. warning::
-
-    Please notice that the recent version of ecCodes used by AQUA (>= 2.36.0) is not compatible anymore with definition files from earlier versions (<2.34.0). For this reason we point now to older definition files which have been 'fixed' to keep working. The CLI tool to create such fixed definition files (``fix_eccodes.sh``) is available.
 
 Experiment metadata
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -57,7 +56,7 @@ dependencies = [
     "ruamel.yaml",
     "smmregrid==0.1.0",
     "sparse",
-    "xarray>=2025.01.2",
+    "xarray>=2025.01.2", # Version 2025.01.2 is the first version introducing the CFDatetimeCoder
     "kerchunk",
     "h5py@git+https://github.com/h5py/h5py.git@3.12.1", #specific github pin to avoid installation of binaries
     "fastparquet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "ruamel.yaml",
     "smmregrid==0.1.0",
     "sparse",
-    "xarray",
+    "xarray>=2025.01.2",
     "kerchunk",
     "h5py@git+https://github.com/h5py/h5py.git@3.12.1", #specific github pin to avoid installation of binaries
     "fastparquet",

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -1204,6 +1204,10 @@ class Reader(FixerMixin, RegridMixin, TimStatMixin):
         Returns:
             Dataset
         """
+        # The coder introduces the possibility to specify a time decoder for the time axis
+        if 'time_coder' in esmcat.metadata:
+            coder = xr.coders.CFDatetimeCoder(time_unit=esmcat.metadata['time_coder'])
+            esmcat.xarray_kwargs.update({'decode_times': coder})
 
         data = esmcat.to_dask()
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -106,4 +106,9 @@ class TestAqua:
         reader = Reader(model=model, exp=exp, source=source, regrid=regrid,
                         fix=False, loglevel=loglevel)
         data = reader.retrieve()
+
+        # Check the time precision
+        if model == 'NEMO':
+            assert data.time.values[0].dtype == 'datetime64[s]'
+
         assert len(data) > 0


### PR DESCRIPTION
## PR description:

xarray v2025.01.2 introduced the possibility to ask for non nanosecond precision when opening a dataset.
The PR introduces the possibility to use this info in the catalog metadata, so that we can open with catalog-specified precision

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [x] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. Pin to xarray >= v2025.01.2 
