### PR TITLE
[Op] Fix timeseries ylabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 Unreleased in the current development version:
+Hotfixes:
+- Fix for the Timeseries diagnostic which was not creating a ylabel in the plot for some variables (#1783)
 
 ## [v0.13.4]
 

--- a/src/aqua/graphics/timeseries.py
+++ b/src/aqua/graphics/timeseries.py
@@ -60,6 +60,8 @@ def plot_timeseries(monthly_data=None,
                     label += ' monthly'
                 else:
                     label = None
+                if 'long_name' in mon_data.attrs and 'units' in mon_data.attrs:
+                    ylabel = mon_data.attrs['long_name'] + ' (' + mon_data.attrs['units'] + ')'
                 mon_data.plot(ax=ax, label=label, color=color)
             except Exception as e:
                 logger.debug(f"Error plotting monthly data: {e}")
@@ -74,6 +76,8 @@ def plot_timeseries(monthly_data=None,
                     label += ' annual'
                 else:
                     label = None
+                if 'long_name' in ann_data.attrs and 'units' in ann_data.attrs:
+                    ylabel = ann_data.attrs['long_name'] + ' (' + ann_data.attrs['units'] + ')'
                 ann_data.plot(ax=ax, label=label, color=color, linestyle='--')
             except Exception as e:
                 logger.debug(f"Error plotting annual data: {e}")
@@ -109,6 +113,10 @@ def plot_timeseries(monthly_data=None,
                                 facecolor='black', alpha=0.2)
         except Exception as e:
             logger.debug(f"Error plotting annual std data: {e}")
+
+    if not ax.get_ylabel():  # Checks if the label is empty or None
+        logger.debug(f"Default y-label will be set: {ylabel}")
+        ax.set_ylabel(ylabel)
 
     ax.legend(fontsize='small')
     ax.grid(axis="x", color="k")

--- a/src/aqua_diagnostics/timeseries/timeseries.py
+++ b/src/aqua_diagnostics/timeseries/timeseries.py
@@ -464,7 +464,7 @@ class Timeseries():
         """
         description = "Time series of the global mean of"
         if self.monthly:
-            description += f" {self.data_annual[0].attrs['long_name']}"
+            description += f" {self.data_mon[0].attrs['long_name']}"
         elif self.annual:
             description += f" {self.data_annual[0].attrs['long_name']}"
         else:


### PR DESCRIPTION
## PR description:

With @jhardenberg we noticed that the timeseries plot appearing in the aqua explorer has ylabel missing in some plot.
Despite the initial idea of a possible bug in the plot layout, this is rather a case in which data for timeseries are badly formatted and plot_timeseries do not manage to find a common ylabel for the plot.
The PR introduces an handling of this case, in which an ylabel is evaluated and used only if matplotlib fails in finding one.

Since the timeseries are being refactored in #1712 and the plot routine in #1729 I propose to introduce this solution only in the operational branch and do not apply any bugfix in the main branch.

 - [x] Changelog is updated.
