### PR TITLE
Add regrid option to relevant diagnostic cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 Unreleased in the current development version (target v0.14):
 
 AQUA core complete list:
+- Add a regrid option to cli of relevant diagnostics (#1792)
 - Reader intake-xarray sources can select a coder for time decoding (#1778)
 - Document use of AQUA on ECMWF HPC2020 (#1782)
 - Added history logging for lat-lon in area selection (#1479)

--- a/config/diagnostics/global_biases/config_global_biases.yaml
+++ b/config/diagnostics/global_biases/config_global_biases.yaml
@@ -35,6 +35,7 @@ diagnostic_attributes:
   enddate_data: null
   startdate_obs: "1990-01-01" 
   enddate_obs: "2020-12-31"
+  regrid: null
 
 # Here you can specify the colorbar limits for each variable
 # If you don't specify them, the colorbar limits will be automatically calculated

--- a/diagnostics/ocean3d/cli/cli_ocean3d.py
+++ b/diagnostics/ocean3d/cli/cli_ocean3d.py
@@ -80,6 +80,7 @@ class Ocean3DCLI:
         self.config["model"] = self.get_arg('model', self.ocean3d_config_dict['model'])
         self.config["exp"] = self.get_arg('exp', self.ocean3d_config_dict['exp'])
         self.config["source"] = self.get_arg('source', self.ocean3d_config_dict['source'])
+        self.config["regrid"] = self.get_arg('regrid', self.ocean3d_config_dict.get('regrid', None))
         self.config["outputdir"] = self.get_arg('outputdir', self.ocean3d_config_dict['outputdir'])
         self.config["outputdir"] = os.path.realpath(self.config['outputdir'])
         self.logger.info(f"output will be saved here: {self.config['outputdir']}")
@@ -104,10 +105,11 @@ class Ocean3DCLI:
         model = self.config["model"]
         exp = self.config["exp"]
         source = self.config["source"]
-        self.logger.info(f"Reader selecting for model={model}, exp={exp}, source={source}")
+        regrid = self.config["regrid"]
+        self.logger.info(f"Reader selecting for model={model}, exp={exp}, source={source}, regrid={regrid}")
 
         reader = Reader(model=model, exp=exp, source=source,
-                        fix=True, loglevel=self.loglevel)
+                        fix=True, regrid=regrid, loglevel=self.loglevel)
         
         if self.config["variables"] == []:
             self.config["variables"] = None
@@ -115,11 +117,14 @@ class Ocean3DCLI:
             self.logger.info(f"retrieving {self.config['variables']}")
 
         if self.config["select_time"]:
-            self.data["catalog_data"] = reader.retrieve(var= self.config["variables"],
-                                                        startdate= str(self.config["start_year"]),
-                                                        enddate= str(self.config["end_year"]))
+            self.data["catalog_data"] = reader.retrieve(var=self.config["variables"],
+                                                        startdate=str(self.config["start_year"]),
+                                                        enddate=str(self.config["end_year"]))
         else:
-            self.data["catalog_data"] = reader.retrieve(var= self.config["variables"])
+            self.data["catalog_data"] = reader.retrieve(var=self.config["variables"])
+        if regrid:
+            self.data["catalog_data"] = reader.regrid(self.data["catalog_data"])
+
         self.logger.info(f"data retrieved for model={model}, exp={exp}, source={source}")
         self.logger.debug("model data: %s", self.data["catalog_data"])   
         self.data["catalog_data"] = check_variable_name(self.data["catalog_data"])
@@ -127,8 +132,10 @@ class Ocean3DCLI:
         if self.config["ocean_circulation"]:
             if self.config["compare_model"]== True:
                 self.logger.info("Loading Observation data")
-                obs_data = Reader("EN4", "en4", "monthly", loglevel=self.loglevel)
+                obs_data = Reader("EN4", "en4", "monthly", loglevel=self.loglevel, regrid=regrid)
                 self.data["obs_data"] = obs_data.retrieve()
+                if regrid:
+                    self.data["obs_data"] = reader.regrid(self.data["obs_data"])
                 self.data["obs_data"] = check_variable_name(self.data["obs_data"], loglevel=self.loglevel)
                 self.logger.info("Loaded Observation data")
 
@@ -300,6 +307,7 @@ def parse_arguments(args):
     parser.add_argument('--model', type=str, help='Model name')
     parser.add_argument('--exp', type=str, help='Experiment name')
     parser.add_argument('--source', type=str, help='Source name')
+    parser.add_argument('--regrid', type=str, help='Regrid target grid')
     parser.add_argument('--outputdir', type=str,
                         help='Output directory')
     parser.add_argument("--cluster", type=str,

--- a/docs/sphinx/source/diagnostics/atm_global_mean.rst
+++ b/docs/sphinx/source/diagnostics/atm_global_mean.rst
@@ -80,15 +80,17 @@ The diagnostic can be run from the command line interface (CLI) by running the f
 
 Additionally the CLI can be run with the following optional arguments:
 
-- ``--config``, ``-c``: Path to the configuration file.
-- ``--nworkers``, ``-n``: Number of workers to use for parallel processing.
-- ``--loglevel``, ``-l``: Logging level. Default is ``WARNING``.
 - ``--catalog``: Catalog to use for the analysis. It can be defined in the config file.
 - ``--model``: Model to analyse. It can be defined in the config file.
 - ``--exp``: Experiment to analyse. It can be defined in the config file.
 - ``--source``: Source to analyse. It can be defined in the config file.
-- ``--outputdir``: Output directory for the plots.
+
 - ``--cluster``: Dask cluster address.
+- ``--config``, ``-c``: Path to the configuration file.
+- ``--loglevel``, ``-l``: Logging level. Default is ``WARNING``.
+- ``--nworkers``, ``-n``: Number of workers to use for parallel processing.
+- ``--outputdir``: Output directory for the plots.
+- ``--regrid``: Target grid for regridding.
 
 
 Config file structure

--- a/docs/sphinx/source/diagnostics/ocean3d.rst
+++ b/docs/sphinx/source/diagnostics/ocean3d.rst
@@ -64,6 +64,21 @@ Under the cli folder, upon updating the config file and running the cli_ocean3d.
 
     python cli_ocean3d.py --model <model> --exp <experiment> --source <source> 
 
+
+The CLI accepts the following arguments:
+
+- ``--catalog``: the catalog to analyze.
+- ``--model``: the model to analyze.
+- ``--exp``: the experiment to analyze.
+- ``--source``: the source to analyze.
+- ``--config``: path to the configuration file.
+- ``--cluster``: run the diagnostic on a dask cluster already existing (used by aqua-analysis).
+- ``-l`` or ``--loglevel``: log level for the logger. Default is WARNING.
+- ``-n`` or ``--nworkers``: number of dask workers for parallel computation.
+- ``--outputdir``: path to the output folder.
+- ``--regrid``: Target grid for regridding.
+
+
 Prepare the o3d request
 ---------------------------
 

--- a/docs/sphinx/source/diagnostics/teleconnections.rst
+++ b/docs/sphinx/source/diagnostics/teleconnections.rst
@@ -108,14 +108,15 @@ The CLI accepts the following arguments:
 - ``--model``: the model to analyze.
 - ``--exp``: the experiment to analyze.
 - ``--source``: the source to analyze.
-- ``--ref``: activate the reference run.
 - ``-c`` or ``--config``: path to the configuration file.
-- ``--interface``: path to the interface file.
-- ``--outputdir``: path to the output folder.
-- ``-n`` or ``--nworkers``: number of dask workers for parallel computation.
-- ``-d`` or ``--dry``: dry run, no files are written.
-- ``-l`` or ``--loglevel``: log level for the logger. Default is WARNING.
 - ``--cluster``: run the diagnostic on a dask cluster already existing (used by aqua-analysis).
+- ``-d`` or ``--dry``: dry run, no files are written.
+- ``--interface``: path to the interface file.
+- ``-l`` or ``--loglevel``: log level for the logger. Default is WARNING.
+- ``-n`` or ``--nworkers``: number of dask workers for parallel computation.
+- ``--outputdir``: path to the output folder.
+- ``--ref``: activate the reference run.
+- ``--regrid``: Target grid for regridding.
 
 Configuration file structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/aqua_diagnostics/cli/cli_checker.py
+++ b/src/aqua_diagnostics/cli/cli_checker.py
@@ -63,6 +63,7 @@ if __name__ == '__main__':
     model = get_arg(args, 'model', None)
     exp = get_arg(args, 'exp', None)
     source = get_arg(args, 'source', None)
+    regrid = get_arg(args, 'regrid', None)
     yamldir = get_arg(args, 'yaml', None)
     fread = args.no_read
     frebuild = args.no_rebuild
@@ -74,7 +75,7 @@ if __name__ == '__main__':
 
     try:
         reader = Reader(catalog=catalog, model=model, exp=exp, source=source,
-                        loglevel=loglevel, rebuild=frebuild)
+                        loglevel=loglevel, rebuild=frebuild, regrid=regrid)
 
         # extract metadata from catalog
         if yamldir:

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -29,6 +29,8 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
                         required=False, help="experiment name")
     parser.add_argument("--source", type=str,
                         required=False, help="source name")
+    parser.add_argument('--regrid', type=str, 
+                        required=False, help='Regrid target grid')
     parser.add_argument("--config", "-c", type=str,
                         help='yaml configuration file')
     parser.add_argument("--nworkers", "-n", type=int,

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -29,8 +29,6 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
                         required=False, help="experiment name")
     parser.add_argument("--source", type=str,
                         required=False, help="source name")
-    parser.add_argument('--regrid', type=str, 
-                        required=False, help='Regrid target grid')
     parser.add_argument("--config", "-c", type=str,
                         help='yaml configuration file')
     parser.add_argument("--nworkers", "-n", type=int,

--- a/src/aqua_diagnostics/global_biases/cli_global_biases.py
+++ b/src/aqua_diagnostics/global_biases/cli_global_biases.py
@@ -25,6 +25,7 @@ def parse_arguments(args):
     parser.add_argument('--source', type=str, help='Source name')
     parser.add_argument('--outputdir', type=str, help='Output directory')
     parser.add_argument("--cluster", type=str, required=False, help="dask cluster address")
+    parser.add_argument("--regrid", type=str, required=False, help="Regrid the source data to a specified grid")
 
     return parser.parse_args(args)
 
@@ -85,8 +86,10 @@ def main():
     seasons_bool = config['diagnostic_attributes'].get('seasons', False)
     seasons_stat = config['diagnostic_attributes'].get('seasons_stat', 'mean')
     vertical = config['diagnostic_attributes'].get('vertical', False)
-    regrid = config['diagnostic_attributes'].get('regrid', None)
+    regrid = get_arg(args, 'regrid', config['diagnostic_attributes'].get('regrid'))
 
+    logger.debug(f"Data read from Catalog: {catalog_data}; Model: {model_data}; Exp: {exp_data}; Source: {source_data}; Regrid: {regrid_data}")
+    logger.debug(f"Observations read from Catalog: {catalog_obs}; Model: {model_obs}; Exp: {exp_obs}; Source: {source_obs}; Regrid: {regrid_data}")
 
     # Retrieve data and handle potential errors
     try:

--- a/src/aqua_diagnostics/global_biases/cli_global_biases.py
+++ b/src/aqua_diagnostics/global_biases/cli_global_biases.py
@@ -88,8 +88,8 @@ def main():
     vertical = config['diagnostic_attributes'].get('vertical', False)
     regrid = get_arg(args, 'regrid', config['diagnostic_attributes'].get('regrid'))
 
-    logger.debug(f"Data read from Catalog: {catalog_data}; Model: {model_data}; Exp: {exp_data}; Source: {source_data}; Regrid: {regrid_data}")
-    logger.debug(f"Observations read from Catalog: {catalog_obs}; Model: {model_obs}; Exp: {exp_obs}; Source: {source_obs}; Regrid: {regrid_data}")
+    logger.debug(f"Data read from Catalog: {catalog_data}; Model: {model_data}; Exp: {exp_data}; Source: {source_data}; Regrid: {regrid}")
+    logger.debug(f"Observations read from Catalog: {catalog_obs}; Model: {model_obs}; Exp: {exp_obs}; Source: {source_obs}; Regrid: {regrid}")
 
     # Retrieve data and handle potential errors
     try:

--- a/src/aqua_diagnostics/teleconnections/cli_teleconnections.py
+++ b/src/aqua_diagnostics/teleconnections/cli_teleconnections.py
@@ -52,6 +52,8 @@ def parse_arguments(cli_args):
                         required=False)
     parser.add_argument('--source', type=str, help='source name',
                         required=False)
+    parser.add_argument('--regrid', type=str, help='regrid target grid',
+                        required=False)
     parser.add_argument('--outputdir', type=str, help='output directory',
                         required=False)
     parser.add_argument('--interface', type=str, help='interface to use',
@@ -158,6 +160,10 @@ if __name__ == '__main__':
     models[0]['exp'] = get_arg(args, 'exp', models[0]['exp'])
     models[0]['source'] = get_arg(args, 'source', models[0]['source'])
 
+    # regrid is optional and overrides all models
+    for mod in models:
+        mod['regrid'] = get_arg(args, 'regrid', mod.get('regrid'))
+
     for telec in teleclist:
         logger.info('Running %s teleconnection', telec)
         # Getting generic configs
@@ -172,7 +178,7 @@ if __name__ == '__main__':
             model_ref = ref_config.get('model', 'ERA5')
             exp_ref = ref_config.get('exp', 'era5')
             source_ref = ref_config.get('source', 'monthly')
-            regrid = ref_config.get('regrid', None)
+            regrid = get_arg(args, 'regrid', ref_config.get('regrid', None))
             freq = ref_config.get('freq', None)
             logger.debug("setup: %s %s %s %s %s",
                          model_ref, exp_ref, source_ref, regrid, freq)


### PR DESCRIPTION
## PR description:

This adds a `--regrid <target>` option to several relevant diagnostics which were missing it.
The logic is always that this is optional and it overrides the config file if provided. 
The upgraded diagnostics are:

- global_biases
- teleconnections
- ocean3d
- cli_checker

Please notice that seaice diagnostics already had this capability.

----

 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
