### PR TITLE
`convert_data()` as diagnostics core utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ AQUA core complete list:
 - Multiple updates to allow for AQUA open source, including Dockerfiles, actions, dependencies and containers (#1574)
 
 AQUA diagnostics complete list:
+- Diagnostic core: A common function to check and convert variable units is provided as `convert_data_units()` (#1806)
 - Diagnostic core: the `retrieve()` method uses internally a `_retrieve()` method that returns instead of updating attributes (#1763)
 - Diagnostic core: documentation about class and config file structure (#1790)
 - Diagnostic core: A common function to load the diagnostic config file is provided (#1750)

--- a/src/aqua_diagnostics/core/__init__.py
+++ b/src/aqua_diagnostics/core/__init__.py
@@ -1,9 +1,9 @@
 from .diagnostic import Diagnostic
 from .util import template_parse_arguments, open_cluster, close_cluster
 from .util import load_diagnostic_config, merge_config_args
-from .util import convert_data
+from .util import convert_data_units
 
 __all__ = ['Diagnostic',
            'template_parse_arguments', 'open_cluster', 'close_cluster',
            'load_diagnostic_config', 'merge_config_args',
-           'convert_data']
+           'convert_data_units']

--- a/src/aqua_diagnostics/core/__init__.py
+++ b/src/aqua_diagnostics/core/__init__.py
@@ -1,7 +1,9 @@
 from .diagnostic import Diagnostic
 from .util import template_parse_arguments, open_cluster, close_cluster
 from .util import load_diagnostic_config, merge_config_args
+from .util import convert_data
 
 __all__ = ['Diagnostic',
            'template_parse_arguments', 'open_cluster', 'close_cluster',
-           'load_diagnostic_config', 'merge_config_args']
+           'load_diagnostic_config', 'merge_config_args',
+           'convert_data']

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -157,7 +157,7 @@ def merge_config_args(config: dict, args: argparse.Namespace,
     return config
 
 
-def convert_data(data, var: str, units: str, loglevel: str = 'WARNING'):
+def convert_data_units(data, var: str, units: str, loglevel: str = 'WARNING'):
     """
     Make sure that the data is in the correct units.
 
@@ -183,6 +183,9 @@ def convert_data(data, var: str, units: str, loglevel: str = 'WARNING'):
         data_to_fix = data_to_fix * factor + offset
         data_to_fix.attrs['units'] = final_units
         log_history(data_to_fix, f"Converting units of {var}: from {initial_units} to {final_units}")
+    else:
+        logger.debug('Units of %s are already in %s', var, final_units)
+        return data
 
     if isinstance(data, xr.Dataset):
         data_fixed = data.copy()

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -3,9 +3,10 @@ Utility functions for the CLI
 """
 import argparse
 import os
+import xarray as xr
 from dask.distributed import Client, LocalCluster
-from aqua.logger import log_configure
-from aqua.util import load_yaml, get_arg
+from aqua.logger import log_configure, log_history
+from aqua.util import load_yaml, get_arg, convert_units
 from aqua.util import ConfigPath
 
 
@@ -154,3 +155,39 @@ def merge_config_args(config: dict, args: argparse.Namespace,
             logger.debug(f"  - {ref['catalog']} {ref['model']} {ref['exp']} {ref['source']}")
 
     return config
+
+
+def convert_data(data, var: str, units: str, loglevel: str = 'WARNING'):
+    """
+    Make sure that the data is in the correct units.
+
+    Args:
+        data (xarray Dataset or DataArray): The data to be checked.
+        var (str): The variable to be checked.
+        units (str): The units to be checked.
+    """
+    logger = log_configure(log_name='check_data', log_level=loglevel)
+
+    data_to_fix = data[var] if isinstance(data, xr.Dataset) else data
+    final_units = units
+    initial_units = data_to_fix.units
+
+    conversion = convert_units(initial_units, final_units)
+
+    factor = conversion.get('factor', 1)
+    offset = conversion.get('offset', 0)
+
+    if factor != 1 or offset != 0:
+        logger.debug('Converting %s from %s to %s',
+                     var, initial_units, final_units)
+        data_to_fix = data_to_fix * factor + offset
+        data_to_fix.attrs['units'] = final_units
+        log_history(data_to_fix, f"Converting units of {var}: from {initial_units} to {final_units}")
+
+    if isinstance(data, xr.Dataset):
+        data_fixed = data.copy()
+        data_fixed[var] = data_to_fix
+    else:
+        data_fixed = data_to_fix
+
+    return data_fixed

--- a/tests/diagnostic_core/test_core_util.py
+++ b/tests/diagnostic_core/test_core_util.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from aqua import Reader
 from aqua.diagnostics.core import template_parse_arguments, load_diagnostic_config
 from aqua.diagnostics.core import open_cluster, close_cluster, merge_config_args
-from aqua.diagnostics.core import convert_data
+from aqua.diagnostics.core import convert_data_units
 
 loglevel = 'DEBUG'
 
@@ -94,18 +94,23 @@ def test_merge_config_args():
 
 
 @pytest.mark.aqua
-def test_convert_data():
+def test_convert_data_units():
     """Test the check_data function"""
     data = Reader(catalog='ci', model='ERA5', exp='era5-hpz3', source='monthly', loglevel=loglevel).retrieve()
     initial_units = data['tprate'].attrs['units']
 
     # Dataset test
-    data_test = convert_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    data_test = convert_data_units(data=data, var='tprate', units='mm/day', loglevel=loglevel)
     assert data_test['tprate'].attrs['units'] == 'mm/day'
 
     # DataArray test
     data = data['tprate']
-    data_test = convert_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    data_test = convert_data_units(data=data, var='tprate', units='mm/day', loglevel=loglevel)
     # We don't test values since this is done in the test_fixer.py
     assert data_test.attrs['units'] == 'mm/day'
     assert f"Converting units of tprate: from {initial_units} to mm/day" in data_test.attrs['history']
+
+    # Test with no conversion to be done
+    data_test = convert_data_units(data=data, var='tprate', units=initial_units, loglevel=loglevel)
+    assert data_test.attrs['units'] == initial_units
+    assert f"Converting units of tprate: from {initial_units} to mm/day" not in data_test.attrs['history']

--- a/tests/diagnostic_core/test_core_util.py
+++ b/tests/diagnostic_core/test_core_util.py
@@ -1,8 +1,10 @@
 import pytest
 import argparse
 from unittest.mock import patch
+from aqua import Reader
 from aqua.diagnostics.core import template_parse_arguments, load_diagnostic_config
 from aqua.diagnostics.core import open_cluster, close_cluster, merge_config_args
+from aqua.diagnostics.core import convert_data
 
 loglevel = 'DEBUG'
 
@@ -89,3 +91,21 @@ def test_merge_config_args():
     assert merged_config['datasets'] == [{'catalog': 'test_catalog', 'exp': 'test_exp',
                                           'model': 'test_model', 'source': 'test_source'}]
     assert merged_config['output']['outputdir'] == 'test_outputdir'
+
+
+@pytest.mark.aqua
+def test_convert_data():
+    """Test the check_data function"""
+    data = Reader(catalog='ci', model='ERA5', exp='era5-hpz3', source='monthly', loglevel=loglevel).retrieve()
+    initial_units = data['tprate'].attrs['units']
+
+    # Dataset test
+    data_test = check_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    assert data_test['tprate'].attrs['units'] == 'mm/day'
+
+    # DataArray test
+    data = data['tprate']
+    data_test = check_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    # We don't test values since this is done in the test_fixer.py
+    assert data_test.attrs['units'] == 'mm/day'
+    assert f"Converting units of tprate: from {initial_units} to mm/day" in data_test.attrs['history']

--- a/tests/diagnostic_core/test_core_util.py
+++ b/tests/diagnostic_core/test_core_util.py
@@ -100,12 +100,12 @@ def test_convert_data():
     initial_units = data['tprate'].attrs['units']
 
     # Dataset test
-    data_test = check_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    data_test = convert_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
     assert data_test['tprate'].attrs['units'] == 'mm/day'
 
     # DataArray test
     data = data['tprate']
-    data_test = check_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
+    data_test = convert_data(data=data, var='tprate', units='mm/day', loglevel=loglevel)
     # We don't test values since this is done in the test_fixer.py
     assert data_test.attrs['units'] == 'mm/day'
     assert f"Converting units of tprate: from {initial_units} to mm/day" in data_test.attrs['history']


### PR DESCRIPTION
## PR description:

I introduce a conver_data() function in the diagnostic utilities in order to convert data from one unit to another one, taking a dataset/dataarray and modifying only the requested variable. It also update the history attribute as the Reader does for data provenance.

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
