### PR TITLE
Refactor Time Handling: Part 1

### DIFF
--- a/diagnostics/ocean3d/ocean3d/ocean_drifts/multi_model/time_series.py
+++ b/diagnostics/ocean3d/ocean3d/ocean_drifts/multi_model/time_series.py
@@ -1,7 +1,7 @@
 from ocean3d.ocean_drifts.tools import *
 from ocean3d.ocean_drifts.hovmoller_plot import hovmoller_plot
 import re
-from datetime import datetime
+import pandas as pd
 
 class time_series:
     def __init__(self, o3d_request):
@@ -64,14 +64,14 @@ class time_series:
                     label=f"{round(int(data_level.lev.data),-2)}")
                 
                 if re.search(r'Hist', data_name):
-                    start_date = np.datetime64('1990-01-01')
-                    end_date =  np.datetime64('2006-12-31')
+                    start_date = pd.Timestamp('1990-01-01')
+                    end_date =  pd.Timestamp('2006-12-31')
                     axs[num, 1].set_xlim(start_date, end_date)
                     axs[num, 0].set_xlim(start_date, end_date)
                 
                 if re.search(r'ssp', data_name):
-                    start_date = np.datetime64('2020-01-01')
-                    end_date =  np.datetime64('2039-12-31')
+                    start_date = pd.Timestamp('2020-01-01')
+                    end_date =  pd.Timestamp('2039-12-31')
                     axs[num, 1].set_xlim(start_date, end_date)
                     axs[num, 0].set_xlim(start_date, end_date)
                 

--- a/src/aqua/util/checksum.py
+++ b/src/aqua/util/checksum.py
@@ -3,8 +3,8 @@
 
 import os
 import sys
-from datetime import datetime
 import hashlib
+import pandas as pd
 from aqua.util import to_list
 
 
@@ -27,7 +27,7 @@ def generate_checksums(folder, grids, output_file):
     """
 
     print(f"Generating datachecker to {output_file}...")
-    current_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    current_date = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
     with open(output_file, "w", encoding='utf8') as f:
         f.write("# MD5 checksum file for AQUA\n")
         f.write(f"# Folder: {folder}\n")


### PR DESCRIPTION
## PR description:
Following our internal discussion, we have started to implement the unification of the AQUA times management.
Following issues #1779 and #1788, a comprehensive assessment of how AQUA manages time objects is in progress. 

In this PR the aim is to replace all the `datetime`objects with `pd.Timestamp`objects.
These elements are not widely used at the moment in AQUA, with larger presences in diagnostics, especially on notebooks. More specifically: 

  - [ ] Sea ice
    - [ ] maps notebook
  - [ ] SSH
    - [ ] SSH class for start date and end date
    - [ ] SSH cli
  - [ ] Tropical rainfall
    - [ ] Stich nodes class
    - [ ] Main
    - [ ] tools (in `tropical_rainfall/tropical_rainfall/src`)
  - [ ] Teleconnections
    - [ ] NAO notebook
    - [ ] ENSO notebook
  - [x] Ocean
    - [x]  `diagnostics/ocean3d/ocean3d/ocean_drifts/multi_model/time_series.py`
  - [ ] logger
  - [ ] `intake_gsv` (already addressed in #1690)
  - [ ] `timeutil` in gsv
  - [ ] AQUA `util`
    - [ ] `util`
    - [x] `checksum`
  - [ ] Tests
    - [ ] `test_lra`
    - [ ] `test_util` 

## Issues closed by this pull request:
 #1779 and #1788 (along with PR #1827) 


