### PR TITLE
[OP] Healpix 7 grids for R02B08 ICON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 Hotfixes:
+- Fix for Healpix zoom 7 grid for ICON R02B08 native oceanic grid, missing in yaml files (#1821)
 - Fix for Tropical Rainfall diagnostic to work with new E cycle and O cycle machines (#1814)
 - Update GSV to 2.9.6 (#1813)
 - Fix for target tcc grib code (#1812)

--- a/config/grids/ICON.yaml
+++ b/config/grids/ICON.yaml
@@ -99,6 +99,15 @@ grids:
     path: '{{ grids }}/ICON/icon-R02B08_hpz9_nested_oce_level_full_v3.nc'
     space_coord: ["ncells"]
     vert_coord: ["level"]
+  icon-R02B08-hpz7-nested-v3:
+    cdo_options: '--force'
+    path: '{{ grids }}/ICON/icon-R02B08_hpz7_nested_oce_v3.nc'
+    space_coord: ["ncells"]
+  icon-R02B08-hpz7-nested-3d-v3:
+    cdo_options: '--force'
+    path: '{{ grids }}/ICON/icon-R02B08_hpz7_nested_oce_level_full_v3.nc'
+    space_coord: ["ncells"]
+    vert_coord: ["level"]
   icon-R02B09-hpz7-nested-v3: #ClimateDT cycle2, 57642 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz7_nested_oce_v3.nc'


### PR DESCRIPTION
## PR description:

Adding missing yaml blocks for R02B08 ICON oceanic grid healpix zoom 7 for the operational release

 - [x] Changelog is updated.