### PR TITLE
Healpix 7 grids for R02B08 ICON

### DIFF
--- a/config/grids/ICON.yaml
+++ b/config/grids/ICON.yaml
@@ -99,6 +99,15 @@ grids:
     path: '{{ grids }}/ICON/icon-R02B08_hpz9_nested_oce_level_full_v3.nc'
     space_coord: ["ncells"]
     vert_coord: ["level"]
+  icon-R02B08-hpz7-nested-v3:
+    cdo_options: '--force'
+    path: '{{ grids }}/ICON/icon-R02B08_hpz7_nested_oce_v3.nc'
+    space_coord: ["ncells"]
+  icon-R02B08-hpz7-nested-3d-v3:
+    cdo_options: '--force'
+    path: '{{ grids }}/ICON/icon-R02B08_hpz7_nested_oce_level_full_v3.nc'
+    space_coord: ["ncells"]
+    vert_coord: ["level"]
   icon-R02B09-hpz7-nested-v3: #ClimateDT cycle2, 57642 missing values
     cdo_options: '--force'
     path: '{{ grids }}/ICON/icon-R02B09_hpz7_nested_oce_v3.nc'


### PR DESCRIPTION
## PR description:

Adding missing yaml blocks for R02B08 ICON oceanic grid healpix zoom 7

 - [ ] Changelog is updated.
 - [ ] Checksum for grids is updated
 - [ ] Files are sync on levante
 - [ ] Files are sync on MN5
 - [ ] Swift backup is updated