### PR TITLE
Preparation v0.14.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.14.0
       - v0.13.5
       - v0.13.4
       - v0.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-Unreleased in the current development version (target v0.14):
+Unreleased in the current development version (target v0.14.1):
+
+## [v0.14.0]
+
+Main changes are:
+- AQUA is now open source
+- Documentation is now available on ReadTheDocs
+- Attributes added by AQUA are now "AQUA_" prefixed
+- A core diagnostic class has been introduced
+
+Deprecated:
+- Support for python==3.9 has been dropped.
+- Generators option from the Reader has been removed.
 
 AQUA core complete list:
 - Added Healpix zoom 7 grid for ICON R02B08 native oceanic grid (#1823)
@@ -852,7 +864,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.14.0...HEAD
+[v0.14.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...v0.14.0
 [v0.13.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.0...v0.13.1
 [v0.13.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13-beta...v0.13.0
 [v0.13-beta]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13-alpha...v0.13-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
@@ -15,7 +15,7 @@ Main changes are:
 - Attributes added by AQUA are now "AQUA_" prefixed
 - A core diagnostic class has been introduced
 
-Deprecated:
+Removed:
 - Support for python==3.9 has been dropped.
 - Generators option from the Reader has been removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Removed:
 - Support for python==3.9 has been dropped.
 - Generators option from the Reader has been removed.
 
+Workflow modifications:
+- `aqua_analysis.py`: all the config files are used from the `AQUA_CONFIG` folder. This allows individual run modification kept in the `AQUA_CONFIG` folder for reproducibility.
+- `makes_contents.py`: can now take a config file as an argument to generate the `content.yaml` file.
+- `push_analysis.sh`: now has an option to rsync the figures to a specified location. Extra flags have been added (see Dashboard section in the documentation).
+
 AQUA core complete list:
 - Added Healpix zoom 7 grid for ICON R02B08 native oceanic grid (#1823)
 - Remove generators from Reader (#1791)

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.14.0-alpha'
+__version__ = '0.14.0'


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `src/aqua/version.py`
- [x] quick check gsv pin
- [x] if a major operational release, update Dockerfiles and relative action
- [x] if it's an operational release, be sure the bug report menu is updated in the main as well
