### PR TITLE
Check if GID exists before adding group in Dockerfile-development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Workflow modifications:
 - `push_analysis.sh`: now has an option to rsync the figures to a specified location. Extra flags have been added (see Dashboard section in the documentation).
 
 AQUA core complete list:
+- Updated AQUA development container to micromamba 2.0.7 (#1834)
+- Updated base container to eccodes 2.40 (#1833)
 - Added Healpix zoom 7 grid for ICON R02B08 native oceanic grid (#1823)
 - Remove generators from Reader (#1791)
 - Fix tcc grib code and add some cmor codes in the convention file (#1800)

--- a/dockerfiles/Dockerfile-development
+++ b/dockerfiles/Dockerfile-development
@@ -22,7 +22,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # We switch to mamba user later, root for now just to create the user.
 USER root
 
-# --- x snip x ---
 # --- This is from the official docs from the micromamba image.
 # --- https://micromamba-docker.readthedocs.io/en/latest/advanced_usage.html#adding-micromamba-to-an-existing-docker-image
 # if your image defaults to a non-root user, then you may want to make the
@@ -42,7 +41,13 @@ COPY --from=micromamba /usr/local/bin/_entrypoint.sh /usr/local/bin/_entrypoint.
 COPY --from=micromamba /usr/local/bin/_dockerfile_initialize_user_accounts.sh /usr/local/bin/_dockerfile_initialize_user_accounts.sh
 COPY --from=micromamba /usr/local/bin/_dockerfile_setup_root_prefix.sh /usr/local/bin/_dockerfile_setup_root_prefix.sh
 
-RUN /usr/local/bin/_dockerfile_initialize_user_accounts.sh && \
+#FIX: Check if GID exists before adding group
+RUN if ! getent group "$MAMBA_USER_GID" >/dev/null; then \
+        groupadd -g "$MAMBA_USER_GID" "$MAMBA_USER"; \
+    else \
+        echo "Group with GID $MAMBA_USER_GID already exists, using existing group."; \
+    fi && \
+    useradd -m -u "$MAMBA_USER_ID" -g "$MAMBA_USER_GID" -s /bin/bash "$MAMBA_USER" && \
     /usr/local/bin/_dockerfile_setup_root_prefix.sh
 
 USER $MAMBA_USER

--- a/dockerfiles/Dockerfile-development
+++ b/dockerfiles/Dockerfile-development
@@ -41,7 +41,9 @@ COPY --from=micromamba /usr/local/bin/_entrypoint.sh /usr/local/bin/_entrypoint.
 COPY --from=micromamba /usr/local/bin/_dockerfile_initialize_user_accounts.sh /usr/local/bin/_dockerfile_initialize_user_accounts.sh
 COPY --from=micromamba /usr/local/bin/_dockerfile_setup_root_prefix.sh /usr/local/bin/_dockerfile_setup_root_prefix.sh
 
-#FIX: Check if GID exists before adding group
+# FIX: Check if GID exists before adding group
+# This is needed from Ubuntu 24.04 onwards, as the user is already created
+# in the base image with GID 1000.
 RUN if ! getent group "$MAMBA_USER_GID" >/dev/null; then \
         groupadd -g "$MAMBA_USER_GID" "$MAMBA_USER"; \
     else \

--- a/dockerfiles/Dockerfile-development
+++ b/dockerfiles/Dockerfile-development
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 # --- Micromamba / Conda (used later).
-FROM mambaorg/micromamba:1.5.6 as micromamba
+FROM mambaorg/micromamba:2.0.7 as micromamba
 
 # -----------------------------------------------------------------------------
 # The container is created by the AQUA team, with the Dockerfile.ubuntu


### PR DESCRIPTION
## PR description:

Since ubuntu 24.04 the GID is set to 1000 by default in the container. We then update the dockerfile to set GID only if this is not defined yet.

 - [x] Changelog is updated.
