### PR TITLE
Introducing a `fldstat` module

### DIFF
--- a/src/aqua/__init__.py
+++ b/src/aqua/__init__.py
@@ -5,6 +5,7 @@ from .graphics import plot_hovmoller
 from .lra_generator import LRAgenerator
 from .reader import Reader, catalog, Streaming, inspect_catalog
 from. regridder import Regridder
+from .fldstat import FldStat
 from .slurm import squeue, job, output_dir, scancel, max_resources_per_node
 from .accessor import AquaAccessor
 
@@ -12,5 +13,5 @@ __all__ = ["plot_single_map", "plot_maps", "plot_single_map_diff", "plot_timeser
            "plot_hovmoller",
            "LRAgenerator",
            "Reader", "catalog", "Streaming", "inspect_catalog",
-           "Regridder",
+           "Regridder", "FldStat",
            "squeue", "job", "output_dir", "scancel", "max_resources_per_node"]

--- a/src/aqua/fldstat/__init__.py
+++ b/src/aqua/fldstat/__init__.py
@@ -1,0 +1,4 @@
+"""FldStat module."""
+from .fldstat import FldStat
+
+__all__ = ['FldStat']

--- a/src/aqua/fldstat/fldstat.py
+++ b/src/aqua/fldstat/fldstat.py
@@ -1,0 +1,102 @@
+"""AQUA class for field statitics"""
+import xarray as xr
+
+from aqua.logger import log_configure, log_history
+from aqua.util import area_selection
+
+class FldStat():
+    """AQUA class for field statitics"""
+
+    def __init__(self, area, horizontal_dims=None, grid_name=None, loglevel='WARNING'):
+        """
+        Initialize the FldStat.
+
+        Args:
+            area (str): The area to calculate the statistics for.
+            loglevel (str): The logging level.
+        """
+
+        self.loglevel = loglevel
+        self.logger = log_configure(log_level=loglevel, log_name='FldStat')
+        self.area = area
+
+        if self.area is None:
+            self.logger.warning("No area provided, no weighted area can be provided.")
+            return
+
+        # safety checks
+        if not isinstance(area, (xr.DataArray, xr.Dataset)):
+            raise ValueError("Area must be an xarray DataArray or Dataset.")
+        
+        # TODO: add a guess with smmregrid GridInspector
+        if horizontal_dims is None:
+            self.logger.warning("No horizontal coordinates provided, using default ['lon', 'lat'].")
+            horizontal_dims = ['lon', 'lat']
+        self.horizontal_dims = horizontal_dims
+        self.logger.debug('Space coordinates are %s', self.horizontal_dims)
+        self.grid_name = grid_name
+
+        
+    def fldmean(self, data, lon_limits=None, lat_limits=None, **kwargs):
+        """
+        Perform a weighted global average.
+        If a subset of the data is provided, the average is performed only on the subset.
+
+        Arguments:
+            data (xr.DataArray or xarray.DataDataset):  the input data
+            lon_limits (list, optional):  the longitude limits of the subset
+            lat_limits (list, optional):  the latitude limits of the subset
+
+        Kwargs:
+            - box_brd (bool,opt): choose if coordinates are comprised or not in area selection.
+                                  Default is True
+
+        Returns:
+            the value of the averaged field
+        """
+
+        if not isinstance(data, (xr.DataArray, xr.Dataset)):
+            raise ValueError("Data must be an xarray DataArray or Dataset.")
+
+        if self.area is None:
+            return data.mean(dim=self.horizontal_dims)
+
+        if lon_limits is not None or lat_limits is not None:
+            data = area_selection(data, lon=lon_limits, lat=lat_limits,
+                                  loglevel=self.loglevel, **kwargs)
+
+        # cleaning coordinates which have "multiple" coordinates in their own definition
+        # grid_area = self._clean_spourious_coords(grid_area, name = "area")
+        # data = self._clean_spourious_coords(data, name = "data")
+
+        # check if coordinates are aligned
+        try:
+            xr.align(self.area, data, join='exact')
+        except ValueError as err:
+            raise ValueError('Coordinates are not aligned!') from err
+            # # check in the dimensions what is wrong
+            # for coord in grid_area.coords:
+            #     if coord in space_coord:
+            #         xcoord = data.coords[coord]
+
+            #         # first case: shape different
+            #         if len(grid_area[coord]) != len(xcoord):
+            #             raise ValueError(f'{coord} has different shape between area files and your dataset.'
+            #                              'If using the LRA, try setting the regrid=r100 option') from err
+            #         # shape are ok, but coords are different
+            #         if not grid_area[coord].equals(xcoord):
+            #             # if they are fine when sorted, there is a sorting mismatch
+            #             if grid_area[coord].sortby(coord).equals(xcoord.sortby(coord)):
+            #                 self.logger.warning('%s is sorted in different way between area files and your dataset. Flipping it!',
+            #                                     coord)
+            #                 grid_area = grid_area.reindex({coord: list(reversed(grid_area[coord]))})
+            #             else:
+            #                 raise ValueError(f'{coord} has a mismatch in coordinate values!') from err
+
+        self.logger.debug('Computing the weighted average over f{self.horizontal_dims}')
+        out = data.weighted(weights=self.area.fillna(0)).mean(dim=self.horizontal_dims)
+
+        if self.grid_name is not None:
+            log_history(data, f"Spatially averaged by fldmean from {self.grid_name} grid")
+
+        return out

--- a/src/aqua/fldstat/fldstat.py
+++ b/src/aqua/fldstat/fldstat.py
@@ -30,7 +30,7 @@ class FldStat():
         
         # TODO: add a guess with smmregrid GridInspector
         if horizontal_dims is None:
-            self.logger.warning("No horizontal coordinates provided, using default ['lon', 'lat'].")
+            self.logger.warning("No horizontal dimensions provided, using default ['lon', 'lat'].")
             horizontal_dims = ['lon', 'lat']
         self.horizontal_dims = horizontal_dims
         self.logger.debug('Space coordinates are %s', self.horizontal_dims)
@@ -93,7 +93,7 @@ class FldStat():
             #             else:
             #                 raise ValueError(f'{coord} has a mismatch in coordinate values!') from err
 
-        self.logger.debug('Computing the weighted average over f{self.horizontal_dims}')
+        self.logger.debug('Computing the weighted average over  %s', self.horizontal_dims)
         out = data.weighted(weights=self.area.fillna(0)).mean(dim=self.horizontal_dims)
 
         if self.grid_name is not None:

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -8,11 +8,12 @@ import xarray as xr
 from smmregrid import GridInspector
 
 from aqua.util import load_multi_yaml, files_exist, to_list
-from aqua.util import ConfigPath, area_selection, find_vert_coord
+from aqua.util import ConfigPath, find_vert_coord
 from aqua.logger import log_configure, log_history
 from aqua.exceptions import NoDataError, NoRegridError
 from aqua.version import __version__ as aqua_version
 from aqua.regridder import Regridder
+from aqua.fldstat import FldStat
 import aqua.gsv
 
 from .streaming import Streaming
@@ -176,6 +177,18 @@ class Reader(FixerMixin, TimStatMixin):
         # init the regridder and the areas
         self._configure_regridder(machine_paths, regrid=regrid, areas=areas,
                                   rebuild=rebuild, reader_kwargs=reader_kwargs)
+        
+        # init the fldstat modules. if areas are not available, will issue a warning
+        self.src_fldstat = FldStat(
+            self.src_grid_area.cell_area, grid_name=self.src_grid_name,
+            horizontal_dims=self.src_space_coord, loglevel=self.loglevel
+            )
+        self.tgt_fldstat = None
+        if regrid:
+            self.tgt_fldstat = FldStat(
+                self.tgt_grid_area.cell_area, grid_name=self.tgt_grid_name,
+                horizontal_dims=self.tgt_space_coord, loglevel=self.loglevel
+                )
 
     def _configure_regridder(self, machine_paths, regrid=False, areas=False,
                              rebuild=False, reader_kwargs=None):
@@ -409,7 +422,13 @@ class Reader(FixerMixin, TimStatMixin):
         data = data.sel(**{full_vert_coord[0]: level})
         data = log_history(data, f"Selecting levels {level} from vertical coordinate {full_vert_coord[0]}")
         return data
+    
+    def fldmean(self, data):
+        """Fldmean average on the data. If regridded, it will use the target grid areas."""
 
+        if self._check_if_regridded(data):
+            return self.tgt_fldstat.fldmean(data)
+        return self.src_fldstat.fldmean(data)
 
     def set_default(self):
         """Sets this reader as the default for the accessor."""
@@ -477,74 +496,6 @@ class Reader(FixerMixin, TimStatMixin):
     #     self.logger.warning('Issue found in %s, removing %s coordinates',
     #                             name, list(drop_coords))
     #     return data.drop_vars(drop_coords)
-
-    def fldmean(self, data, lon_limits=None, lat_limits=None, **kwargs):
-        """
-        Perform a weighted global average.
-        If a subset of the data is provided, the average is performed only on the subset.
-
-        Arguments:
-            data (xr.DataArray or xarray.DataDataset):  the input data
-            lon_limits (list, optional):  the longitude limits of the subset
-            lat_limits (list, optional):  the latitude limits of the subset
-
-        Kwargs:
-            - box_brd (bool,opt): choose if coordinates are comprised or not in area selection.
-                                  Default is True
-
-        Returns:
-            the value of the averaged field
-        """
-
-        # If these data have been regridded we should use
-        # the destination grid info
-        if self._check_if_regridded(data):
-            space_coord = self.tgt_space_coord
-            grid_area = self.tgt_grid_area.cell_area
-        else:
-            space_coord = self.src_space_coord
-            grid_area = self.src_grid_area.cell_area
-
-        if lon_limits is not None or lat_limits is not None:
-            data = area_selection(data, lon=lon_limits, lat=lat_limits,
-                                  loglevel=self.loglevel, **kwargs)
-        self.logger.debug('Space coordinates are %s', space_coord)
-        # cleaning coordinates which have "multiple" coordinates in their own definition
-        # grid_area = self._clean_spourious_coords(grid_area, name = "area")
-        # data = self._clean_spourious_coords(data, name = "data")
-
-        # HAVE TO ADD AN ERROR IF AREAS HAVE NOT THE SAME AREAS AS DATA
-
-        # check if coordinates are aligned
-        try:
-            xr.align(grid_area, data, join='exact')
-        except ValueError as err:
-            # check in the dimensions what is wrong
-            for coord in grid_area.coords:
-                if coord in space_coord:
-                    xcoord = data.coords[coord]
-
-                    # first case: shape different
-                    if len(grid_area[coord]) != len(xcoord):
-                        raise ValueError(f'{coord} has different shape between area files and your dataset.'
-                                         'If using the LRA, try setting the regrid=r100 option') from err
-                    # shape are ok, but coords are different
-                    if not grid_area[coord].equals(xcoord):
-                        # if they are fine when sorted, there is a sorting mismatch
-                        if grid_area[coord].sortby(coord).equals(xcoord.sortby(coord)):
-                            self.logger.warning('%s is sorted in different way between area files and your dataset. Flipping it!',
-                                                coord)
-                            grid_area = grid_area.reindex({coord: list(reversed(grid_area[coord]))})
-                        else:
-                            raise ValueError(f'{coord} has a mismatch in coordinate values!') from err
-
-        out = data.weighted(weights=grid_area.fillna(0)).mean(dim=space_coord)
-
-        out.aqua.set_default(self)  # This links the dataset accessor to this instance of the Reader class
-
-        log_history(data, f"Spatially averaged from {self.src_grid_name} grid")
-
-        return out
 
     def _check_kwargs_parameters(self, main_parameters, intake_parameters):
         """

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -423,12 +423,12 @@ class Reader(FixerMixin, TimStatMixin):
         data = log_history(data, f"Selecting levels {level} from vertical coordinate {full_vert_coord[0]}")
         return data
     
-    def fldmean(self, data):
+    def fldmean(self, data, lon_limits=None, lat_limits=None, **kwargs):
         """Fldmean average on the data. If regridded, it will use the target grid areas."""
 
         if self._check_if_regridded(data):
-            return self.tgt_fldstat.fldmean(data)
-        return self.src_fldstat.fldmean(data)
+            return self.tgt_fldstat.fldmean(data, lon_limits=lon_limits, lat_limits=lat_limits, **kwargs)
+        return self.src_fldstat.fldmean(data, lon_limits=lon_limits, lat_limits=lat_limits, **kwargs)
 
     def set_default(self):
         """Sets this reader as the default for the accessor."""


### PR DESCRIPTION
## PR description:

This will move the fldmean function from the Reader creating a specific `FldStat` module that can be later extended for further horizontal dimension operations. 

There are many issues though, the most important ones are 
1. Wrong horizontal dimension naming between the areas (i.e. the source grid file) and the data
2. Wrong alignment of data models that cause latitudes and longitudes to have not the same orientation
3. Some structural confusion between dimensions and coordinates, where the first are used for spatial averaging and the second are used for area selection 


 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.

