### PR TITLE
Temp catgen disable

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -152,7 +152,8 @@ jobs:
           # Produce the XML report
           cd AQUA
           # produce a xml report and a junit report to be used by codecov. Please notice other options are set in pyproject.toml
-          pytest --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -m "aqua or slow or gsv or graphics or catgen or diagnostics"
+          # pytest --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -m "aqua or slow or gsv or graphics or catgen or diagnostics"
+          pytest --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -m "aqua or slow or gsv or graphics or diagnostics"
       - name: Display coverage.xml contents
         run: cat AQUA/coverage.xml
       - name: Upload coverage reports to Codecov

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.14.0'
+__version__ = '0.14.1'

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.14.1'
+__version__ = '0.14.1-alpha'


### PR DESCRIPTION
## PR description:

Catgen cannot be tested and it is not working due to #1840 
Since an update is necessary we temporarily disable the catgen tests.
Also we update the version to 0.14.1-alpha to follow the strategy of always having the target version in the main