### PR TITLE
Regrid method capabilities back in the Reader

### DIFF
--- a/config/grids/IFS.yaml
+++ b/config/grids/IFS.yaml
@@ -61,10 +61,10 @@ grids:
     vert_coord: ["2d"]
     path: '{{ grids }}/IFS/ifs-multiIO-r025s.nc'
     cellareas: '{{ grids }}/IFS/cell_area_ifs-multiIO-r025s.nc'
-    cellarea_var: cell_area
+    cellareas_var: cell_area
   multio-r100s-unstructured:
     space_coord: ["value"]
     vert_coord: ["2d"]
     path: '{{ grids }}/IFS/ifs-multiIO-r100s.nc'
     cellareas: '{{ grids }}/IFS/cell_area_ifs-multiIO-r100s.nc'
-    cellarea_var: cell_area
+    cellareas_var: cell_area

--- a/config/grids/observations.yaml
+++ b/config/grids/observations.yaml
@@ -31,14 +31,14 @@ grids:
     path: '{{ grids }}/OSI-SAF/grid_osi-saf_nh.nc'
     space_coord: ['xc', 'yc']
     cellareas: '{{ grids }}/OSI-SAF/cellarea_osi-saf_nh.nc'
-    cellarea_var: areacello
+    cellareas_var: areacello
     regrid_method: 'bil'
 
   osi-saf-sh:
     path: '{{ grids }}/OSI-SAF/grid_osi-saf_sh.nc'
     space_coord: ['xc', 'yc']
     cellareas: '{{ grids }}/OSI-SAF/cellarea_osi-saf_sh.nc'
-    cellarea_var: areacello
+    cellareas_var: areacello
     regrid_method: 'bil'
 
   # WOA
@@ -52,13 +52,13 @@ grids:
   psc-piomas:
     space_coord: ["x", "y"]
     cellareas: '{{ grids }}/PSC/cellarea_piomas.nc'
-    cellarea_var: areacello
+    cellareas_var: areacello
     path: '{{ grids }}/PSC/grid_piomas_new.nc'
     regrid_method: 'bil'
   psc-giomas:
     space_coord: ["x", "y"]
     cellareas: '{{ grids }}/PSC/cellarea_giomas.nc'
-    cellarea_var: areacello
+    cellareas_var: areacello
     path: '{{ grids }}/PSC/grid_giomas_new.nc'
     regrid_method: 'bil'
 

--- a/docs/sphinx/source/adding_data.rst
+++ b/docs/sphinx/source/adding_data.rst
@@ -452,7 +452,7 @@ As an example, we use the healpix grid for ICON and tco1279 for IFS:
   Specific for oceanic models where interpolation is changing at each depth level.
 - ``cdo_extra``: (if applicable): Additional CDO command to be used to process the files defined in ``path``.
 - ``cdo_options``: (if applicable): Additional CDO options to be used to process the files defined in ``path``.
-- ``cellareas``, ``cellarea_var``: (if applicable): Optional path and variable name where to specify a file to retrieve
+- ``cellareas``, ``cellareas_var``: (if applicable): Optional path and variable name where to specify a file to retrieve
   the grid area cells when the grid shape is too complex for being automatically computed by CDO.
 - ``regrid_method``: (if applicable): Alternative CDO regridding method which is not the ``ycon`` default.
   To be used when grid corners are not available. Alterntives might be ``bil``, ``bic`` or ``nn``.

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -23,6 +23,7 @@ from .reader_utils import set_attrs
 # set default options for xarray
 xr.set_options(keep_attrs=True)
 
+
 class Reader(FixerMixin, TimStatMixin):
     """General reader for climate data."""
 
@@ -410,7 +411,6 @@ class Reader(FixerMixin, TimStatMixin):
         data = log_history(data, f"Selecting levels {level} from vertical coordinate {full_vert_coord[0]}")
         return data
 
-
     def set_default(self):
         """Sets this reader as the default for the accessor."""
 
@@ -532,7 +532,7 @@ class Reader(FixerMixin, TimStatMixin):
                     if not grid_area[coord].equals(xcoord):
                         # if they are fine when sorted, there is a sorting mismatch
                         if grid_area[coord].sortby(coord).equals(xcoord.sortby(coord)):
-                            self.logger.warning('%s is sorted in different way between area files and your dataset. Flipping it!',
+                            self.logger.warning('%s is sorted in different way between area files and your dataset. Flipping it!', # noqa E501
                                                 coord)
                             grid_area = grid_area.reindex({coord: list(reversed(grid_area[coord]))})
                         else:
@@ -625,7 +625,7 @@ class Reader(FixerMixin, TimStatMixin):
             raise ValueError('This is not an xarray object!')
 
         final = log_history(
-            final, f"Interpolated from original levels {data[vert_coord].values} {data[vert_coord].units} to level {levels} using {method} method.")
+            final, f"Interpolated from original levels {data[vert_coord].values} {data[vert_coord].units} to level {levels} using {method} method.") # noqa E501
 
         final.aqua.set_default(self)  # This links the dataset accessor to this instance of the Reader class
 
@@ -836,7 +836,7 @@ class Reader(FixerMixin, TimStatMixin):
                 chunks['time'] = self.aggregation
             if self.streaming and not self.aggregation:
                 self.logger.warning(
-                    "Aggregation is not set, using default time resolution for streaming. If you are asking for a longer chunks['time'] for GSV access, please set a suitable aggregation value")
+                    "Aggregation is not set, using default time resolution for streaming. If you are asking for a longer chunks['time'] for GSV access, please set a suitable aggregation value") # noqa E501
 
         if dask:
             if chunks:  # if the chunking or aggregation option is specified override that from the catalog

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -229,7 +229,7 @@ class Reader(FixerMixin, TimStatMixin):
             # generate source areas and expose them in the reader
             self.src_grid_area = self.regridder.areas(rebuild=rebuild, reader_kwargs=reader_kwargs)
             if self.fix:
-                # TODO: this should include the latitudes flipping fix. 
+                # TODO: this should include the latitudes flipping fix.
                 # TODO: No check is done on the areas coords vs data coords
                 self.src_grid_area = self._fix_area(self.src_grid_area)
 
@@ -239,6 +239,7 @@ class Reader(FixerMixin, TimStatMixin):
             self.regridder.weights(
                 rebuild=rebuild,
                 tgt_grid_name=self.tgt_grid_name,
+                regrid_method=self.regrid_method,
                 reader_kwargs=reader_kwargs)
 
         # generate destination areas, expost them and the associated space coordinates

--- a/src/aqua/regridder/regridder.py
+++ b/src/aqua/regridder/regridder.py
@@ -27,6 +27,7 @@ DEFAULT_DIMENSION_MASK = '2dm'  # masked grid
 # a file on the disk or xarray dataset. Possible inclusion of CDOgrid object is considered
 # but should be likely developed on the smmregrid side.
 
+
 class Regridder():
     """AQUA Regridder class"""
 
@@ -77,8 +78,8 @@ class Regridder():
         self.src_grid_name = src_grid_name  # source grid name
 
         # we want all the grid dictionary to be real dictionaries
-        self.handler = GridDictHandler(cfg_grid_dict, 
-                                       default_dimension=DEFAULT_DIMENSION, 
+        self.handler = GridDictHandler(cfg_grid_dict,
+                                       default_dimension=DEFAULT_DIMENSION,
                                        loglevel=loglevel)
         self.src_grid_dict = self.handler.normalize_grid_dict(self.src_grid_name)
         self.src_grid_path = self.src_grid_dict.get('path')
@@ -155,9 +156,9 @@ class Regridder():
             self.logger.debug("Found CDO path: %s", cdo)
             return cdo
 
-        raise FileNotFoundError(    
+        raise FileNotFoundError(
                 "CDO not found in path: Weight and area generation will fail.")
-    
+
     def _get_info_from_data(self, data):
         """
         Extract information from the dataset to be used in the regridding process
@@ -185,13 +186,13 @@ class Regridder():
             self.logger.info("Using provided dataset as a grid path for %s", vdim)
             self.src_grid_dict = {"path": {vdim: data}}
             self.src_grid_path = self.src_grid_dict.get('path')
-    
+
     def areas(self, tgt_grid_name=None, rebuild=False, reader_kwargs=None):
         """
         Load or generate regridding areas for the source or target grid.
 
         Args:
-            tgt_grid_name (str, optional): Name of the target grid. 
+            tgt_grid_name (str, optional): Name of the target grid.
                                            If None, the self.src_grid_name is used.
             rebuild (bool, optional): If True, forces regeneration of the area.
             reader_kwargs (dict, optional): Additional parameters for the reader.
@@ -305,7 +306,7 @@ class Regridder():
             regrid_method (str): The regrid method.
             nproc (int): The number of processors to use.
             rebuild (bool): If True, rebuild the weights.
-            reader_kwargs (dict): The reader kwargs for filename definition, 
+            reader_kwargs (dict): The reader kwargs for filename definition,
                                   including info on model, exp, source, etc.
         """
 
@@ -326,7 +327,7 @@ class Regridder():
             # define the vertical coordinate in the smmregrid world
             smm_vertical_dim = None if vertical_dim in [
                 DEFAULT_DIMENSION, DEFAULT_DIMENSION_MASK] else vertical_dim
-        
+
             weights_filename = self._weights_filename(tgt_grid_name, regrid_method,
                                                       vertical_dim, reader_kwargs)
 
@@ -341,12 +342,12 @@ class Regridder():
                 else:
                     self.logger.info(
                         "Generating weights for %s grid: %s", tgt_grid_name, vertical_dim)
-                    
+
                 if smm_vertical_dim:
                     self.logger.warning("Mask-changing vertical dimension identified, weights generation might take a few!")
-                    
+
                 # smmregrid call
-                #TODO: here or better in smmregird, we could use GridInspect to get the grid info
+                # TODO: here or better in smmregird, we could use GridInspect to get the grid info
                 # and reduce the dimensionality of the input data.
                 generator = CdoGenerate(source_grid=self.src_grid_path[vertical_dim],
                                         target_grid=self._get_grid_path(tgt_grid_dict.get('path')),
@@ -438,7 +439,6 @@ class Regridder():
             self.logger.warning(
                 "Weights block not found in the configuration file, using fallback naming scheme.")
             return f"weights_{tgt_grid_name}_{regrid_method}_l{levname}.nc"
-            
 
         # destination grid name is provided, use grid template
         if check_gridfile(self.src_grid_path[vertical_dim]) != 'xarray':
@@ -524,7 +524,7 @@ class Regridder():
             variables = list(gridtype.variables.keys())
 
             if gridtype.vertical_dim:
-                self.logger.debug("Variables for dimension %s: %s", 
+                self.logger.debug("Variables for dimension %s: %s",
                                   gridtype.vertical_dim, variables)
                 shared_vars[gridtype.vertical_dim] = [var for var in variables if var not in masked_vars]
             else:
@@ -566,7 +566,7 @@ class Regridder():
 
     def _apply_regrid(self, data, shared_vars):
         """
-        Core regridding function. 
+        Core regridding function.
         Apply regridding on the different vertical coordinates, including 2d and 2dm
         """
 
@@ -595,7 +595,7 @@ class Regridder():
                         filename)
 
         return filename
-    
+
     @staticmethod
     def configure_masked_fields(src_grid_dict):
         """

--- a/src/aqua/regridder/regridder.py
+++ b/src/aqua/regridder/regridder.py
@@ -296,7 +296,7 @@ class Regridder():
             loglevel=self.loglevel
         ).areas(target=bool(grid_name))
 
-    def weights(self, tgt_grid_name, regrid_method=DEFAULT_GRID_METHOD, nproc=1,
+    def weights(self, tgt_grid_name, regrid_method=None, nproc=1,
                 rebuild=False, reader_kwargs=None):
         """
         Load or generate regridding weights calling smmregrid
@@ -311,6 +311,8 @@ class Regridder():
         """
 
         # define regrid method
+        default_regrid_method = self.src_grid_dict.get('regrid_method', DEFAULT_GRID_METHOD)
+        regrid_method = regrid_method if regrid_method else default_regrid_method
         if regrid_method is not DEFAULT_GRID_METHOD:
             self.logger.info("Regrid method: %s", regrid_method)
 


### PR DESCRIPTION
## PR description:

As noticed offline, OSI-SAF data do not regrid because 'ycon' method is used by default. The regrid_method capabilities were lost in the recent Regridder update and are then reintroduced here.

 - [ ] Test 
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [ ] Changelog is updated.
