### PR TITLE
Reintroduce check for lat flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.14.1):
 
 AQUA core complete list:
+- Fix flipped latitudes when regridding data flipped by datamodel (#1869)
 - Refactor of `plot_single_map()` and `plot_single_map_diff()` functions with projection support (#1854)
 - Refactor time handling: replacement of `datetime` objects and of `pd.Timestamp` lists (#1828)
 - Fix the `regrid_method` option in the Reader (#1859)

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -13,6 +13,7 @@ from aqua.logger import log_configure, log_history
 from aqua.exceptions import NoDataError, NoRegridError
 from aqua.version import __version__ as aqua_version
 from aqua.regridder import Regridder
+from aqua.util import flip_lat_dir
 import aqua.gsv
 
 from .streaming import Streaming
@@ -419,6 +420,9 @@ class Reader(FixerMixin, TimStatMixin):
 
     def regrid(self, data):
         """Call the regridder function returning container or iterator"""
+
+        # Check if original lat has been flipped and in case flip back, returns a deep copy in that case
+        data = flip_lat_dir(data)
 
         if self.tgt_grid_name is None:
             raise NoRegridError('regrid has not been initialized in the Reader, cannot perform any regrid.')


### PR DESCRIPTION
## PR description:

This reintroduces a call to the `flip_lat_dir()` utility before regridding to make sure that in cases where the data model has flipped meridional  coordinates these are reversed again before regridding, to avoid flipped images. 
The call had been removed by mistake in the PR to remove generator support.

## Issues closed by this pull request:

Close #1868

----
 - [x] Changelog is updated.
