### PR TITLE
Remove outdated documentation on make_push_docs.sh

### DIFF
--- a/docs/sphinx/source/dashboard.rst
+++ b/docs/sphinx/source/dashboard.rst
@@ -43,12 +43,7 @@ The full pipeline is composed of the following components:
     See the :ref:`aqua_web` section for more details.
 
 
-4.  The ``make_push_docs.sh`` script can be used to build the documentation, push it to the LUMI-O bucket and trigger a rebuild of aqua-web.
-   
-    See the :ref:`aqua_web` section for more details.
-
-
-5.  The AQUA Explorer software is stored on github in the repository `aqua-web <https://github.com/DestinE-Climate-DT/aqua-web>`_.
+4.  The AQUA Explorer software is stored on github in the repository `aqua-web <https://github.com/DestinE-Climate-DT/aqua-web>`_.
     Any commit in the `aqua-web` repository will trigger a rebuild of the enclosed Dockerfile by the CSC `Rahti 2 service <https://research.csc.fi/-/rahti>`_ using OpenShift. The resulting container will run serving the web pages.
     As described in the corresponding Dockerfile, contents (figures and documentation) are downloaded from the ``aqua-web`` bucket on LUMI-O, appropriate markdown files are created and  we use python package `mkdocs` to construct static web pages from the markdown files.
 
@@ -61,8 +56,8 @@ Automatic uploading of figures and documentation to aqua-web
 ------------------------------------------------------------
 
 AQUA figures produced by the analysis can be uploaded to the `aqua-web <https://github.com/DestinE-Climate-DT/aqua-web>`_ 
-repository to publish them automatically on a dedicated website. The same site is used to host the documentation.
-Two scripts in the ``cli/aqua-web`` folder are available to push figures or documentation to aqua-web.
+repository to publish them automatically on a dedicated website.
+A script in the ``cli/aqua-web`` folder is available to push figures to the bucket shown by aqua-web.
 
 If you plan to use these scripts outside the AQUA container or environment to push figures to aqua-web,
 you will need the following scripts: ``push-analysis.sh``, ``make_contents.py``, ``pdf_to_png.sh``


### PR DESCRIPTION
## PR description:

The script was already removed, here I'm cleaning just the documentation

## Issues closed by this pull request:

Close #1875 

 - [x] Documentation is included if a new feature is included.
 - [ ] Changelog is updated.