### PR TITLE
fix: update Codecov paths

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -15,7 +15,7 @@ permissions:
 defaults:
   run:
     # NOTE: We must take care with the shell value here. We have steps
-    #       with mutiline YAML strings. 
+    #       with mutiline YAML strings.
     #       These get converted into shell scripts.
     #       If execute as ``bash -l fail_first_command.sh``
     #       then it would fail the first command but run the second
@@ -29,9 +29,9 @@ jobs:
   aqua_test:
     # NOTE: this option can be uncommented to run the job only when
     #       a pull request contains a label with the name "Run Tests" or "Ready to Merge" or if run by Dependabot.
-    if: > 
-      contains(github.event.pull_request.labels.*.name, 'run tests') || 
-      contains(github.event.pull_request.labels.*.name, 'ready to merge') || 
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'run tests') ||
+      contains(github.event.pull_request.labels.*.name, 'ready to merge') ||
       github.actor == 'dependabot[bot]' ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: DestinE-Climate-DT/Climate-DT-catalog
-          path: Climate-DT-catalog 
+          path: Climate-DT-catalog
       - name: Clone GitLab data-portfolio repository
         run: |
           git clone https://oauth2:${{ secrets.BSC_GITLAB }}@earth.bsc.es/gitlab/digital-twins/de_340-2/data-portfolio data-portfolio
@@ -96,7 +96,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v2
         with:
           micromamba-version: 'latest'
-          environment-file: AQUA/environment.yml 
+          environment-file: AQUA/environment.yml
           environment-name: aqua
           cache-downloads: true
           cache-environment: false
@@ -160,6 +160,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
+          network_filter: "AQUA/"
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,5 +15,5 @@ comment:
   layout: "diff, flags"
   require_changes: true
 
-#fixes:
-#  - "/__w/AQUA/AQUA/AQUA/src/::src/"
+fixes:
+  - "AQUA/::"


### PR DESCRIPTION
## PR description:
fixes https://github.com/codecov/feedback/issues/663

I'm not 100% sure this will be the right fix, but I feel good that this is what needs to happen. 

> [!WARNING]
> One note, I suspect something weird is going on with getting the `git` tree and it's defaulting to our backup file searcher. I would suggest running `git ls-files` before this command to double-check that it is doing so

## Issues closed by this pull request:

Close #issue_number

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated. 
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
 - [ ] Diagnostic config files path are updated in the console if needed
