### PR TITLE
Expand LRA to compute also other statistics and some other refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Removed:
 - `aqua.slurm` has been removed.
 
 AQUA core complete list:
+- Additional stats for LRA and other refinements (#1886) 
 - New OutputSaver class (#1837)
 - Introduce a `Timstat()` module independent from the `Reader()` (#1832)
 - Adapt Catalog Generator to Data-Portfolio v1.3.0 (#1848)

--- a/docs/sphinx/source/lra.rst
+++ b/docs/sphinx/source/lra.rst
@@ -103,6 +103,10 @@ Options:
     This option will force the rebuilding of the areas and weights files for the regridding.
     If multiple variables or members are present in the configuration, this will be done only once.
 
+.. option:: --stat
+
+    Statistic to be computed (default: 'mean')
+
 Please note that this options override the ones available in the configuration file. 
 
 A basic example usage can thus be: 

--- a/docs/sphinx/source/lra.rst
+++ b/docs/sphinx/source/lra.rst
@@ -107,7 +107,7 @@ Options:
 
     Statistic to be computed (default: 'mean')
 
-Please note that this options override the ones available in the configuration file. 
+Please note that these options override the ones available in the configuration file. 
 
 A basic example usage can thus be: 
 

--- a/src/aqua/cli/lra.py
+++ b/src/aqua/cli/lra.py
@@ -52,6 +52,8 @@ def lra_parser(parser = None):
     parser.add_argument('-v', '--var', type=str,
                         help='var to be processed. Use with coherence with --source')
     parser.add_argument('--rebuild', action="store_true", help="Rebuild Reader areas and weights")
+    parser.add_argument('--stat', type=str,
+                        help="statistic to be computed. Can be one of ['min', 'max', 'mean', 'std']. Default is 'mean'")
     #parser.add_argument('-r', '--realization', type=str,
     #                    help="realization to be processed. Use with coherence with --var")
 
@@ -108,6 +110,7 @@ def lra_execute(args):
     definitive = get_arg(args, 'definitive', False)
     monitoring = get_arg(args, 'monitoring', False)
     overwrite = get_arg(args, 'overwrite', False)
+    stat = get_arg(args, 'stat', 'mean')
     rebuild = get_arg(args, 'rebuild', False)
     only_catalog = get_arg(args, 'only_catalog', False)
     if only_catalog:
@@ -119,13 +122,13 @@ def lra_execute(args):
     lra_cli(args=args, config=config, catalog=catalog, resolution=resolution,
             frequency=frequency, fix=fix,
             outdir=outdir, tmpdir=tmpdir, loglevel=loglevel,
-            region=region,
+            region=region, stat=stat,
             definitive=definitive, overwrite=overwrite, rebuild=rebuild,
             default_workers=default_workers,
             monitoring=monitoring, do_zarr=do_zarr, verify_zarr=verify_zarr, only_catalog=only_catalog)
 
 def lra_cli(args, config, catalog, resolution, frequency, fix, outdir, tmpdir, loglevel,
-            region=None,
+            region=None, stat='mean',
             definitive=False, overwrite=False,
             rebuild=False, monitoring=False,
             default_workers=1, do_zarr=False, verify_zarr=False,
@@ -146,6 +149,7 @@ def lra_cli(args, config, catalog, resolution, frequency, fix, outdir, tmpdir, l
         tmpdir: temporary directory
         loglevel: log level
         region: region to be processed
+        stat: statistic to be computed
         definitive: bool flag to create definitive files
         overwrite: bool flag to overwrite existing files
         rebuild: bool flag to rebuild the areas and weights
@@ -196,7 +200,7 @@ def lra_cli(args, config, catalog, resolution, frequency, fix, outdir, tmpdir, l
                                         frequency=frequency, fix=fix,
                                         outdir=outdir, tmpdir=tmpdir,
                                         nproc=workers, loglevel=loglevel,
-                                        region=region,
+                                        region=region, stat=stat,
                                         definitive=definitive, overwrite=overwrite,
                                         rebuild=rebuild,
                                         performance_reporting=monitoring,

--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -47,7 +47,6 @@ class LRAgenerator():
                  exclude_incomplete=False,
                  stat="mean",
                  compact="xarray",
-                 cdo="cdo",
                  cdo_options=["-f", "nc4", "-z", "zip_1"],
                  **kwargs):
         """
@@ -90,7 +89,6 @@ class LRAgenerator():
             stat (string, opt):      Statistic to compute. Can be 'mean', 'std', 'max', 'min'.
             compact (string, opt):   Compact the data into yearly files using xarray or cdo.
                                      If set to None, no compacting is performed. Default is "xarray"
-            cdo (string, opt):       Path to the cdo executable used for compacting, default is "cdo"
             cdo_options (list, opt): List of options to be passed to cdo, default is ["-f", "nc4", "-z", "zip_1"]
             **kwargs:                kwargs to be sent to the Reader, as 'zoom' or 'realization'
                                      please notice that realization will change the file name 
@@ -180,7 +178,6 @@ class LRAgenerator():
         if self.compact not in ['xarray', 'cdo', None]:
             raise KeyError('Please specify a valid compact method: xarray, cdo or None.')
         
-        self.cdo = cdo
         self.cdo_options = cdo_options
         if not isinstance(self.cdo_options, list):
             raise TypeError('cdo_options must be a list.')
@@ -500,7 +497,7 @@ class LRAgenerator():
             if self.compact == 'cdo':
                 infiles_list = sorted(glob.glob(infiles))
                 command = [
-                    self.cdo,
+                    'cdo',
                     *self.cdo_options,
                     'cat',
                     *infiles_list,

--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -40,7 +40,7 @@ class LRAgenerator():
                  resolution=None, frequency=None, fix=True,
                  outdir=None, tmpdir=None, nproc=1,
                  loglevel=None,
-                 region=None,
+                 region=None, drop=False,
                  overwrite=False, definitive=False,
                  performance_reporting=False,
                  rebuild=False,
@@ -76,6 +76,7 @@ class LRAgenerator():
             region (dict, opt):      Region to be processed, default is None, 
                                      meaning the full globe. 
                                      Requires 'name' (str), 'lon' (list) and 'lat' (list)
+            drop (bool, opt):        Drop the missing values in the region selection.
             overwrite (bool, opt):   True to overwrite existing files in LRA,
                                      default is False
             definitive (bool, opt):  True to create the output file,
@@ -166,9 +167,10 @@ class LRAgenerator():
                 raise KeyError('Please specify name in region.')
             if self.region['lon'] is None and self.region['lat'] is None:
                 raise KeyError(f'Please specify at least one between lat and lon for {region['name']}.')
-
         else:
             self.region = None
+
+        self.drop = drop
 
         self.stat = stat
         if self.stat not in ['mean', 'std', 'max', 'min']:
@@ -656,7 +658,7 @@ class LRAgenerator():
         temp_data = self._remove_regridded(temp_data)
 
         if self.region:
-            temp_data = area_selection(temp_data, lon = self.region['lon'], lat = self.region['lat'])
+            temp_data = area_selection(temp_data, lon = self.region['lon'], lat = self.region['lat'], drop=self.drop)
 
         # Splitting data into yearly files
         years = sorted(set(temp_data.time.dt.year.values))

--- a/src/aqua/lra_generator/lra_generator.py
+++ b/src/aqua/lra_generator/lra_generator.py
@@ -496,13 +496,14 @@ class LRAgenerator():
             # clean older file
             if os.path.exists(outfile):
                 os.remove(outfile)
-            
+
             if self.compact == 'cdo':
+                infiles_list = sorted(glob.glob(infiles))
                 command = [
                     self.cdo,
                     *self.cdo_options,
                     'cat',
-                    *glob.glob(infiles),
+                    *infiles_list,
                     outfile
                 ]
                 self.logger.debug("Using CDO command: %s", command)

--- a/src/aqua/util/sci_util.py
+++ b/src/aqua/util/sci_util.py
@@ -70,11 +70,7 @@ def area_selection(data=None, lat=None, lon=None,
         else:
             lon_condition = (data.lon > lon[0]) & (data.lon < lon[1])
 
-    data = data.where(lat_condition & lon_condition)
-
-    if drop:
-        data = data.dropna(dim='lon', how='all')
-        data = data.dropna(dim='lat', how='all')
+    data = data.where(lat_condition & lon_condition, drop=drop)
 
     data = log_history(data, f"Area selection: lat={lat}, lon={lon}")
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -261,7 +261,13 @@ class TestAquaConsole():
         # run the LRA and verify that at least one file exist
         run_aqua(['lra', '--config', lratest, '-w', '1', '-d', '--rebuild'])
         path = os.path.join(os.path.join(mydir, 'lra_test'),
-                            "ci/IFS/test-tco79/r200/monthly/2t_test-tco79_r200_monthly_202002.nc")
+                            "ci/IFS/test-tco79/r200/monthly/2t_test-tco79_r200_monthly_mean_202002.nc")
+        assert os.path.isfile(path)
+
+        # run the LRA with a different stat and verify that at least one file exist
+        run_aqua(['lra', '--config', lratest, '-w', '1', '-d', '--rebuild', '--stat', 'min'])
+        path = os.path.join(os.path.join(mydir, 'lra_test'),
+                            "ci/IFS/test-tco79/r200/monthly/2t_test-tco79_r200_monthly_min_202002.nc")
         assert os.path.isfile(path)
         
         # remove aqua

--- a/tests/test_lra.py
+++ b/tests/test_lra.py
@@ -49,7 +49,7 @@ class TestLRA:
         test.data = test.data.sel(time="2020-01")
         test.generate_lra()
 
-        file_path = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_202001.nc")
+        file_path = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_mean_202001.nc")
         test.check_integrity(varname=args["var"])
         assert os.path.isfile(file_path)
 
@@ -74,7 +74,7 @@ class TestLRA:
         test.data = test.data.sel(time="2020-01-20")
         test.generate_lra()
 
-        file_path = os.path.join(os.getcwd(), args["outdir"], LRAPATH_DAILY, "2t_test-tco79_r100_daily_europe_202001.nc")
+        file_path = os.path.join(os.getcwd(), args["outdir"], LRAPATH_DAILY, "2t_test-tco79_r100_daily_mean_europe_202001.nc")
         assert os.path.isfile(file_path)
 
         xfield = xr.open_dataset(file_path).where(lambda x: x.notnull(), drop=True)
@@ -133,8 +133,8 @@ class TestLRA:
         test.retrieve()
         test.generate_lra()
 
-        missing_file = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_202008.nc")
-        existing_file = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_202002.nc")
+        missing_file = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_mean_202008.nc")
+        existing_file = os.path.join(os.getcwd(), args["outdir"], LRAPATH, "2t_test-tco79_r100_monthly_mean_202002.nc")
 
         assert not os.path.exists(missing_file)
         assert os.path.exists(existing_file)


### PR DESCRIPTION
## PR description:

This expands LRA capabilities to compute also additional statistics, not only the mean.
It contains also some other minor improvements to LRA functionality, in particular grouping annual files using cdo (which is significantly faster than using xarray). 

## Issues closed by this pull request:

Close #1885

----

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.

