### PR TITLE
Polytope support

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -145,9 +145,10 @@ jobs:
         run: |
           # Initialize the AQUA catalog in the $HOME/.aqua folder
           aqua -vv install github
+          # Add the climatedt-phase1 catalog (for polytope testing)
+          aqua -vv add climatedt-phase1
           # Add the ci/cd catalog
           aqua -vv add ci
-          aqua -vv add climatedt-phase1
           # Double check the catalogs
           aqua -vv list
           # add default paths to the config

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -151,7 +151,7 @@ jobs:
           # Double check the catalogs
           aqua -vv list
           # add default paths to the config
-          cat >> $HOME/.aqua/config.yaml <<EOF
+          cat >> $HOME/.aqua/config-aqua.yaml <<EOF
           paths:
               grids: ./AQUA_tests/grids
               weights: ./AQUA_tests/weights

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -157,6 +157,13 @@ jobs:
               weights: ./AQUA_tests/weights
               areas: ./AQUA_tests/weights
           EOF
+          # Set up polytope secrets
+          cat >$HOME/.polytopeapirc << EOF
+          {
+            "user_email": "${{ secrets.POLYTOPE_MAIL }}",
+            "user_key": "${{ secrets.POLYTOPE_KEY }}"
+          }
+          EOF
       - name: Run tests
         run: |
           # Produce the XML report

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -147,8 +147,16 @@ jobs:
           aqua -vv install github
           # Add the ci/cd catalog
           aqua -vv add ci
+          aqua -vv add climatedt-phase1
           # Double check the catalogs
           aqua -vv list
+          # add default paths to the config
+          cat >> $HOME/.aqua/config.yaml <<EOF
+          paths:
+              grids: ./AQUA_tests/grids
+              weights: ./AQUA_tests/weights
+              areas: ./AQUA_tests/weights
+          EOF
       - name: Run tests
         run: |
           # Produce the XML report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Removed:
 - `aqua.slurm` has been removed.
 
 AQUA core complete list:
+- Polytope support (#1893)
 - Additional stats for LRA and other refinements (#1886) 
 - New OutputSaver class (#1837)
 - Introduce a `Timstat()` module independent from the `Reader()` (#1832)

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -198,6 +198,26 @@ levels to use for each chunk.
 
 .. _lev-selection-regrid:
 
+Polytope access to Destination Earth data
+-----------------------------------------
+
+It is poossible to access ClimateDT data availble on the 'Databridge' for the DestinE ClimateDT also remotely, from other machines,
+using the 'polytope' access. to this end you will need to specify ``engine="polytope"`` when instantiating the `Reader` or adding
+the argument ``engine="polytope"`` as an additional argument in the intake data source.
+
+.. code-block:: python
+
+    reader = Reader(model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d", engine="polytope")
+    data = reader.retrieve(var='2t')
+
+This allows accessing ClimateDT data on the Databridge also remotely from other machines.
+
+In order for this to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
+Please follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ to 
+set up appropriate credential and create this file. 
+As a preliminary step, you will need to be registered on the `Destine Service Platform  <https://auth.destine.eu/>`_ 
+and have requested "upgraded access" to the data.
+
 Level selection and regridding
 ------------------------------
 

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -212,21 +212,21 @@ the argument ``engine: polytope`` as an additional argument in the intake catalo
 
 This allows accessing ClimateDT data on the Databridge also remotely from other machines.
 
-To access Destination Earth ClimateDT data you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
+To access Destination Earth ClimateDT data you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_
 and have requested "upgraded access" to the data (follow the link "Access policy upgrade" under your username at the top left corner of the page).
 
-In order for this to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
+In order for his to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
 You can create this file following two proceures:
 
-1. ** Using DestinE Service Platform credentials **: 
+1. **Using DestinE Service Platform credentials**: 
 
-Follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ 
+Follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_
 and the username and password which you defined for the Destine Service Platform to download the credentials into this file. 
 
-2. ** Using ECMWF credentials **:
+2. **Using ECMWF credentials**:
 
-You can also use your ECMWF credentials to access the data. You will find the email and key which you need by logging in to your `ECMWF account <https://www.ecmwf.int/>`_ 
-After logging in you will find your key at `https://api.ecmwf.int/v1/key/ <https://api.ecmwf.int/v1/key/>`_ 
+You can also use your ECMWF credentials to access the data. You will find the email and key which you need by logging in to your `ECMWF account <https://www.ecmwf.int/>`_.
+After logging in you will find your key at `https://api.ecmwf.int/v1/key/ <https://api.ecmwf.int/v1/key/>`_.
 
 A sample ``~/.polytopeapirc`` file will look like this:
 

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -213,8 +213,13 @@ the argument ``engine: polytope`` as an additional argument in the intake catalo
 This allows accessing ClimateDT data on the Databridge also remotely from other machines.
 
 In order for this to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
+
 Please follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ to 
 set up appropriate credential and create this file. 
+
+As an alternative, you will find the email and key which you need by logging in to your `ECMW account <https://www.ecmwf.int/>`_ . 
+After logging in you will find your key at `https://api.ecmwf.int/v1/key/ <https://api.ecmwf.int/v1/key/>`_ 
+
 A sample file will look like this:
 
 .. code-block:: text
@@ -224,7 +229,7 @@ A sample file will look like this:
         "user_key" : "<your.token>"
     }
 
-As a preliminary step, you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
+To access Destination Earth ClimateDT data you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
 and have requested "upgraded access" to the data (follow the link "Access policy upgrade" under your username at the top left corner of the page).
 
 Level selection and regridding

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -201,9 +201,9 @@ levels to use for each chunk.
 Polytope access to Destination Earth data
 -----------------------------------------
 
-It is poossible to access ClimateDT data availble on the 'Databridge' for the DestinE ClimateDT also remotely, from other machines,
-using the 'polytope' access. to this end you will need to specify ``engine="polytope"`` when instantiating the `Reader` or adding
-the argument ``engine="polytope"`` as an additional argument in the intake data source.
+It is possible to access ClimateDT data available on the 'Databridge' for the DestinE ClimateDT also remotely, from other machines,
+using the 'polytope' access. to this end you will need to specify ``engine="polytope"`` when instantiating the `Reader` or permanently, adding
+the argument ``engine: polytope`` as an additional argument in the intake catalog source entry in the corresponding yaml file, under `args:`.
 
 .. code-block:: python
 
@@ -215,8 +215,17 @@ This allows accessing ClimateDT data on the Databridge also remotely from other 
 In order for this to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
 Please follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ to 
 set up appropriate credential and create this file. 
-As a preliminary step, you will need to be registered on the `Destine Service Platform  <https://auth.destine.eu/>`_ 
-and have requested "upgraded access" to the data.
+A sample file will look like this:
+
+.. code-block:: text
+
+    {
+        "user_email" : "<your.email>",
+        "user_key" : "<your.token>"
+    }
+
+As a preliminary step, you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
+and have requested "upgraded access" to the data (follow the link "Access policy upgrade" under your username at the top left corner of the page).
 
 Level selection and regridding
 ------------------------------

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -212,15 +212,23 @@ the argument ``engine: polytope`` as an additional argument in the intake catalo
 
 This allows accessing ClimateDT data on the Databridge also remotely from other machines.
 
+To access Destination Earth ClimateDT data you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
+and have requested "upgraded access" to the data (follow the link "Access policy upgrade" under your username at the top left corner of the page).
+
 In order for this to work you will need to store an access token in the file ``~/.polytopeapirc`` in your home directory.
+You can create this file following two proceures:
 
-Please follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ to 
-set up appropriate credential and create this file. 
+1. ** Using DestinE Service Platform credentials **: 
 
-As an alternative, you will find the email and key which you need by logging in to your `ECMWF account <https://www.ecmwf.int/>`_ 
+Follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ 
+and the username and password which you defined for the Destine Service Platform to download the credentials into this file. 
+
+2. ** Using ECMWF credentials **:
+
+You can also use your ECMWF credentials to access the data. You will find the email and key which you need by logging in to your `ECMWF account <https://www.ecmwf.int/>`_ 
 After logging in you will find your key at `https://api.ecmwf.int/v1/key/ <https://api.ecmwf.int/v1/key/>`_ 
 
-A sample file will look like this:
+A sample ``~/.polytopeapirc`` file will look like this:
 
 .. code-block:: text
 
@@ -229,8 +237,8 @@ A sample file will look like this:
         "user_key" : "<your.token>"
     }
 
-To access Destination Earth ClimateDT data you will need to be registered on the `Destine Service Platform  <https://platform.destine.eu/>`_ 
-and have requested "upgraded access" to the data (follow the link "Access policy upgrade" under your username at the top left corner of the page).
+.. note::
+    Please notice that the two procedures use different tokens and that in the first case there will be no `"user_email"` in the polytope credentials file.
 
 Level selection and regridding
 ------------------------------

--- a/docs/sphinx/source/advanced_topics.rst
+++ b/docs/sphinx/source/advanced_topics.rst
@@ -217,7 +217,7 @@ In order for this to work you will need to store an access token in the file ``~
 Please follow the instructions in the `Polytope documentation <https://github.com/destination-earth-digital-twins/polytope-examples>`_ to 
 set up appropriate credential and create this file. 
 
-As an alternative, you will find the email and key which you need by logging in to your `ECMW account <https://www.ecmwf.int/>`_ . 
+As an alternative, you will find the email and key which you need by logging in to your `ECMWF account <https://www.ecmwf.int/>`_ 
 After logging in you will find your key at `https://api.ecmwf.int/v1/key/ <https://api.ecmwf.int/v1/key/>`_ 
 
 A sample file will look like this:

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -40,7 +40,7 @@ class GSVSource(base.DataSource):
                  hpc_expver=None, timestyle="date",
                  chunks="S", savefreq="h", timestep="h", timeshift=None,
                  startdate=None, enddate=None, var=None, metadata=None, level=None,
-                 switch_eccodes=False, loglevel='WARNING', **kwargs):
+                 switch_eccodes=False, loglevel='WARNING', engine='fdb', **kwargs):
         """
         Initializes the GSVSource class. These are typically specified in the catalog entry,
         but can also be specified upon accessing the catalog.
@@ -68,11 +68,13 @@ class GSVSource(base.DataSource):
             metadata (dict, optional): Metadata read from catalog. Contains path to FDB.
             level (int, float, list): optional level(s) to be read. Must use the same units as the original source.
             switch_eccodes (bool, optional): Flag to activate switching of eccodes path. Defaults to False.
+            engine (str, optional): Engine to be used. 'polytope' or 'fdb' (default).
             loglevel (string) : The loglevel for the GSVSource
             kwargs: other keyword arguments.
         """
 
         self.logger = log_configure(log_level=loglevel, log_name='GSVSource')
+        self.engine = engine
         self.gsv_log_level = _check_loglevel(self.logger.getEffectiveLevel())
         self.logger.debug("Init of the GSV source class")
 
@@ -533,8 +535,8 @@ class GSVSource(base.DataSource):
         # See https://github.com/DestinE-Climate-DT/AQUA/issues/1715
         # Notice also that for some mysterious reason this works only if the result is stored in self (even if then it is not used)
         if self.chk_type[i]:
-            self.gsv = GSVRetriever(logging_level=self.gsv_log_level)
-        gsv = GSVRetriever(logging_level=self.gsv_log_level)
+            self.gsv = GSVRetriever(engine=self.engine, logging_level=self.gsv_log_level)
+        gsv = GSVRetriever(engine=self.engine, logging_level=self.gsv_log_level)
 
         self.logger.debug('Request %s', request)
         dataset = gsv.request_data(request, use_stream_iterator=fstream_iterator,

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -121,10 +121,6 @@ class GSVSource(base.DataSource):
 
         GSVSource.first_run = False
 
-        # Now that checking of paths has been decided, we can set engine to fdb if None
-        if not self.engine:
-            self.engine = 'fdb'
-
         # set the timestyle
         self.timestyle = timestyle
         self.timeshift = timeshift

--- a/src/aqua/gsv/intake_gsv.py
+++ b/src/aqua/gsv/intake_gsv.py
@@ -344,7 +344,8 @@ class GSVSource(base.DataSource):
             '_var': self._var,
             'timeshift': self.timeshift,
             'gsv_log_level': self.gsv_log_level,
-            'logger': self.logger
+            'logger': self.logger,
+            'engine': self.engine
         }
 
     def __setstate__(self, state):
@@ -374,6 +375,7 @@ class GSVSource(base.DataSource):
         self._request = state['_request']
         self.gsv_log_level = state['gsv_log_level']
         self.logger = state['logger']
+        self.engine = state['engine']
 
     def _get_schema(self):
         """

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -139,6 +139,7 @@ class Reader(FixerMixin):
         machine_paths, intake_vars = configurer.get_machine_info()
 
         # load the catalog
+        aqua.gsv.GSVSource.first_run = True  # Hack needed to avoid double checking of paths (which would not work if on another machine using polytope)
         self.expcat = self.cat(**intake_vars)[self.model][self.exp]  # the top-level experiment entry
         self.esmcat = self.expcat[self.source](**kwargs) 
 

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -63,7 +63,7 @@ class Reader(FixerMixin):
             rebuild (bool, optional): Force rebuilding of area and weight files. Defaults to False.
             loglevel (str, optional): Level of logging according to logging module.
                                       Defaults to log_level_default of loglevel().
-            nproc (int,optional): Number of processes to use for weights generation. Defaults to 4.
+            nproc (int, optional): Number of processes to use for weights generation. Defaults to 4.
             aggregation (str, optional): the streaming frequency in pandas style (1M, 7D etc. or 'monthly', 'daily' etc.)
                                          Defaults to None (using default from catalog, recommended).
             chunks (str or dict, optional): chunking to be used for GSV access.
@@ -75,8 +75,12 @@ class Reader(FixerMixin):
             preproc (function, optional): a function to be applied to the dataset when retrieved. Defaults to None.
             convention (str, optional): convention to be used for reading data. Defaults to 'eccodes'.
                                         (Only one supported so far)
-            **kwargs: Arbitrary keyword arguments to be passed as additional parameters to the catalog entry.
-                      'zoom', meant for HEALPix grid, is a predefined one which will allow for multiple gridname definitions.
+
+        Keyword Args:
+            engine (str, optional): Engine to be used for GSV retrieval: 'polytope' or 'fdb'. Defaults to 'fdb'. 
+            zoom (int, optional): HEALPix grid zoom level (e.g. zoom=10 is h1024). Allows for multiple gridname definitions.
+            realization (int, optional): The ensemble realization number, included in the output filename.
+            **kwargs: Additional arbitrary keyword arguments to be passed as additional parameters to the intake catalog entry.
 
         Returns:
             Reader: A `Reader` class object.

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -39,7 +39,6 @@ class Reader(FixerMixin):
                  rebuild=False, loglevel=None, nproc=4,
                  aggregation=None, chunks=None,
                  preproc=None, convention='eccodes',
-                 engine='fdb',
                  **kwargs):
         """
         Initializes the Reader class, which uses the catalog
@@ -76,7 +75,6 @@ class Reader(FixerMixin):
             preproc (function, optional): a function to be applied to the dataset when retrieved. Defaults to None.
             convention (str, optional): convention to be used for reading data. Defaults to 'eccodes'.
                                         (Only one supported so far)
-            engine (str, optional): engine to be used for reading data from GSV retrievbe. Can be 'polytope' or 'fdb' (default).
             **kwargs: Arbitrary keyword arguments to be passed as additional parameters to the catalog entry.
                       'zoom', meant for HEALPix grid, is a predefined one which will allow for multiple gridname definitions.
 
@@ -142,7 +140,7 @@ class Reader(FixerMixin):
 
         # load the catalog
         self.expcat = self.cat(**intake_vars)[self.model][self.exp]  # the top-level experiment entry
-        self.esmcat = self.expcat[self.source](engine=engine, **kwargs) 
+        self.esmcat = self.expcat[self.source](**kwargs) 
 
         # Manual safety check for netcdf sources (see #943), we output a more meaningful error message
         if isinstance(self.esmcat, intake_xarray.netcdf.NetCDFSource):

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -39,6 +39,7 @@ class Reader(FixerMixin):
                  rebuild=False, loglevel=None, nproc=4,
                  aggregation=None, chunks=None,
                  preproc=None, convention='eccodes',
+                 engine='fdb',
                  **kwargs):
         """
         Initializes the Reader class, which uses the catalog
@@ -75,7 +76,8 @@ class Reader(FixerMixin):
             preproc (function, optional): a function to be applied to the dataset when retrieved. Defaults to None.
             convention (str, optional): convention to be used for reading data. Defaults to 'eccodes'.
                                         (Only one supported so far)
-            **kwargs: Arbitrary keyword arguments to be passed as parameters to the catalog entry.
+            engine (str, optional): engine to be used for reading data from GSV retrievbe. Can be 'polytope' or 'fdb' (default).
+            **kwargs: Arbitrary keyword arguments to be passed as additional parameters to the catalog entry.
                       'zoom', meant for HEALPix grid, is a predefined one which will allow for multiple gridname definitions.
 
         Returns:
@@ -139,8 +141,8 @@ class Reader(FixerMixin):
         machine_paths, intake_vars = configurer.get_machine_info()
 
         # load the catalog
-        self.esmcat = self.cat(**intake_vars)[self.model][self.exp][self.source](**kwargs)
         self.expcat = self.cat(**intake_vars)[self.model][self.exp]  # the top-level experiment entry
+        self.esmcat = self.expcat[self.source](engine=engine, **kwargs) 
 
         # Manual safety check for netcdf sources (see #943), we output a more meaningful error message
         if isinstance(self.esmcat, intake_xarray.netcdf.NetCDFSource):

--- a/src/aqua/util/config.py
+++ b/src/aqua/util/config.py
@@ -196,6 +196,8 @@ class ConfigPath():
         if 'paths' in self.config_dict:
             for path in ['areas', 'weights', 'grids']:
                 if path in self.config_dict['paths']:
+                    if 'paths' not in machine_paths:
+                        machine_paths['paths'] = {}
                     machine_paths['paths'][path] = self.config_dict['paths'][path]
         else:
             self.logger.warning('No paths found in the main configuration file %s', self.base_available)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,9 +9,9 @@ from aqua.reader.reader_utils import check_catalog_source
 loglevel = "DEBUG"
 
 @pytest.fixture(params=[(model, exp, source)
-                        for model in catalog()
-                        for exp in catalog()[model]
-                        for source in catalog()[model][exp]])
+                        for model in catalog(catalog_name="ci")  # there could also be other catalogues installed
+                        for exp in catalog(catalog_name="ci")[model]
+                        for source in catalog(catalog_name="ci")[model][exp]])
 def reader(request):
     """Reader instance fixture"""
     model, exp, source = request.param
@@ -36,9 +36,9 @@ def test_catalog_gsv():
         assert isinstance(data, xarray.Dataset)
 
 @pytest.fixture(params=[(model, exp, source)
-                        for model in catalog()
-                        for exp in catalog()[model]
-                        for source in catalog()[model][exp]])
+                        for model in catalog(catalog_name="ci")
+                        for exp in catalog(catalog_name="ci")[model]
+                        for source in catalog(catalog_name="ci")[model][exp]])
 def reader_regrid(request):
     """Reader instance fixture"""
     model, exp, source = request.param

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -202,25 +202,16 @@ class TestGsv():
         assert data.tcc.isel(time=0).values.mean() == pytest.approx(65.30221138649116)
         assert data.tcc.isel(time=-1).values.mean() == pytest.approx(66.79689864974151)
 
-    def test_reader_dask(self) -> None:
+    def test_reader_polytope(self) -> None:
         """
-        Reading in parallel with a dask cluster
+        Reading from a remote databridge using polytope
         """
 
-        cluster = LocalCluster(threads_per_worker=1, n_workers=2)
-        client = Client(cluster)
-
-        reader = Reader(model="IFS", exp="test-fdb", source="fdb-auto", loglevel=loglevel)
-        data = reader.retrieve()
-        # Test if the correct dates have been found
-        assert "1990-01-01T00:00" in str(data.time[0].values)
-        assert "1990-01-01T23:00" in str(data.time[-1].values)
-        # Test if the data can actually be read and contain the expected values
-        assert data.tcc.isel(time=0).values.mean() == pytest.approx(65.30221138649116)
-        assert data.tcc.isel(time=-1).values.mean() == pytest.approx(66.79689864974151)
-
-        client.shutdown()
-        cluster.close()
+        reader = Reader(catalog='climatedt-phase1', model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d",
+                        startdate="20210101T0000", enddate="20210101T2300", loglevel="debug", engine="polytope",
+                        chunking={'time': 'h'}) 
+        data = reader.retrieve(var='2t')
+        assert data.isel(time=1)['2t'].mean().values == pytest.approx(285.8661045)
 
     def test_fdb_from_file(self) -> None:
         """
@@ -246,13 +237,22 @@ class TestGsv():
         assert source.data_start_date == '19900101T0000'
         assert source.data_end_date == '19900103T2300'
 
-    def test_reader_polytope(self) -> None:
+        def test_reader_dask(self) -> None:
         """
-        Reading from a remote databridge using polytope
+        Reading in parallel with a dask cluster
         """
 
-        reader = Reader(catalog='climatedt-phase1', model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d",
-                        startdate="20210101T0000", enddate="20210101T2300", loglevel="debug", engine="polytope",
-                        chunking={'time': 'h'}) 
-        data = reader.retrieve(var='2t')
-        assert data.isel(time=1)['2t'].mean().values == pytest.approx(285.8661045)
+        cluster = LocalCluster(threads_per_worker=1, n_workers=2)
+        client = Client(cluster)
+
+        reader = Reader(model="IFS", exp="test-fdb", source="fdb-auto", loglevel=loglevel)
+        data = reader.retrieve()
+        # Test if the correct dates have been found
+        assert "1990-01-01T00:00" in str(data.time[0].values)
+        assert "1990-01-01T23:00" in str(data.time[-1].values)
+        # Test if the data can actually be read and contain the expected values
+        assert data.tcc.isel(time=0).values.mean() == pytest.approx(65.30221138649116)
+        assert data.tcc.isel(time=-1).values.mean() == pytest.approx(66.79689864974151)
+
+        client.shutdown()
+        cluster.close()

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -209,7 +209,7 @@ class TestGsv():
 
         reader = Reader(catalog='climatedt-phase1', model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d",
                         startdate="20210101T0000", enddate="20210101T2300", loglevel="debug", engine="polytope",
-                        chunks='H')
+                        chunks='h')
         data = reader.retrieve(var='2t')
         assert data.isel(time=1)['2t'].mean().values == pytest.approx(285.8661045)
 

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -245,3 +245,14 @@ class TestGsv():
         
         assert source.data_start_date == '19900101T0000'
         assert source.data_end_date == '19900103T2300'
+
+    def test_reader_polytope(self) -> None:
+        """
+        Reading from a remote databridge using polytope
+        """
+
+        reader = Reader(catalog='climatedt-phase1', model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d",
+                        startdate="20210101T0000", enddate="20210101T2300", loglevel="debug", engine="polytope",
+                        chunking={'time': 'h'}) 
+        data = reader.retrieve(var='2t')
+        assert data.isel(time=1)['2t'].mean().values == pytest.approx(285.8661045)

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -209,7 +209,7 @@ class TestGsv():
 
         reader = Reader(catalog='climatedt-phase1', model="IFS-NEMO", exp="ssp370", source="hourly-hpz7-atm2d",
                         startdate="20210101T0000", enddate="20210101T2300", loglevel="debug", engine="polytope",
-                        chunking={'time': 'h'}) 
+                        chunks='H')
         data = reader.retrieve(var='2t')
         assert data.isel(time=1)['2t'].mean().values == pytest.approx(285.8661045)
 

--- a/tests/test_gsv.py
+++ b/tests/test_gsv.py
@@ -236,8 +236,8 @@ class TestGsv():
         
         assert source.data_start_date == '19900101T0000'
         assert source.data_end_date == '19900103T2300'
-
-        def test_reader_dask(self) -> None:
+    
+    def test_reader_dask(self) -> None:
         """
         Reading in parallel with a dask cluster
         """


### PR DESCRIPTION
## PR description:

This adds polytope support with the new `engine` keyword (can be 'fdb' (default) or 'polytope'). The keyword can either be added to a catalog entry or be specified directly in the reader (it exploits the fact that the kwargs are passed directly to intake).

To be tested for speed and if remote functionality really works well. Please notice that the current implementation in the GSVRetriever uses a temporary grib file on disk for each message, so it has to be seen if this is ok in terms of speed.

The user will need credentials to access polytope. To this end get polytope credentials and create a `~/.polytopeapirc` file in your home with this content:

```
{
    "user_email" : "<your.mail>",
    "user_key" : "<your.key>"
}
```

I will add also some info on this in the docs.

## Issues closed by this pull request:

Close #1534 

----

 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
