### PR TITLE
[OP] Hotfix for push_analysis not finding config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 
+- Fix for make_content failing to accept expected argument [#1898]
+
 ## [v0.13.5]
 
 Hotfixes:

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -174,15 +174,17 @@ def make_content(catalog, model, exp, diagnostics, config_experiments, force):
             file.write(content_json)
 
 
-def main(force=False, experiment=None):
+def main(force=False, experiment=None, configfile="config.yaml"):
     """
     Main function to create content.yaml and content.json files for each experiment in the content/png directory.
 
     Args:
         force (bool): Create content.yaml and content.json even if they exist already
+        experiment (str): Specific experiment for which to create content (in format "$catalog/$model/$experiment")
+        configfile (str): Alternate confg file path (default "config.yaml" - used by aqua-web)
     """
         
-    with open("config.yaml", "r") as file:
+    with open(configfile, "r") as file:
         config = yaml.safe_load(file)
 
     os.chdir("content/png")
@@ -210,7 +212,9 @@ def parse_arguments(arguments):
     parser.add_argument('-f', '--force', action="store_true",
                         help='create content.yaml and content.json even if they exist already')
     parser.add_argument('-e', '--experiment', type=str,
-                        help='specific experiment for which to create content')
+                        help='specific experiment for which to create content in format $catalog/$model/$experiment')
+    parser.add_argument('-c', '--config', type=str, default="config.yaml",
+                        help='alternate confg file')
     
     return parser.parse_args(arguments)
     
@@ -219,4 +223,5 @@ if __name__ == "__main__":
     args = parse_arguments(sys.argv[1:])
     force = args.force
     experiment = args.experiment
-    main(force=force, experiment=experiment)
+    config = args.config
+    main(force=force, experiment=experiment, configfile=config)


### PR DESCRIPTION
## PR description:

Somehow the version of `make_content.py` was never updated and did not accept the `-c` option, despite `push_analysis.sh` expecting it.

## Issues closed by this pull request:

Close #1898 

----

 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
 
