### PR TITLE
Fixes for ICON `o001` run

### DIFF
--- a/config/fixes/climatedt-phase2.yaml
+++ b/config/fixes/climatedt-phase2.yaml
@@ -21,3 +21,14 @@ fixer_name:
         vars:
             tcc:
                 src_units: frac
+
+    climatedt-phase2-ICON-esuite:
+        convention: eccodes
+        deltat: 3600
+        vars:
+            tcc:
+                src_units: frac
+            iews:
+                src_units: N m**-2 s
+            inss:
+                src_units: N m**-2 s


### PR DESCRIPTION
## PR description:

Following what has been discussed in https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-660 I introduce two small fixes for the ICON esuite run o000. 
This triggers the decumulation for wind stresses and the correct unit for cloud cover.

Of course, this is not enough, since we need to 
- Port this change to the operational branch, and make a new a release
- Update the catalog generator (and therefore the branch) so that the fix is used actively.  

