### PR TITLE
Scientific notation in cbar in multiple maps plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ AQUA core complete list:
 
 AQUA diagnostics complete list:
 - Timeseries: Use new OutputSaver in Timeseries diagnostics (#1948)
+- Use scientific notation in multiple maps plotting to avoid label overlapping (#1953)
 
 
 ## [v0.15.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ AQUA core complete list:
 
 AQUA diagnostics complete list:
 - Timeseries: Use new OutputSaver in Timeseries diagnostics (#1948)
-- Use scientific notation in multiple maps plotting to avoid label overlapping (#1953)
+- Use scientific notation in multiple maps plotting to avoid label overlapping (#1953) 
 
 
 ## [v0.15.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.16.0):
 
 AQUA core complete list:
+- Use scientific notation in multiple maps plotting to avoid label overlapping (#1953)
 
 AQUA diagnostics complete list:
 - Timeseries: Use new OutputSaver in Timeseries diagnostics (#1948)
-- Use scientific notation in multiple maps plotting to avoid label overlapping (#1953) 
 
 
 ## [v0.15.0]

--- a/src/aqua/graphics/multiple_maps.py
+++ b/src/aqua/graphics/multiple_maps.py
@@ -108,6 +108,8 @@ def plot_maps(maps: list,
     else:
         cbar.set_ticks(np.linspace(vmin, vmax, nlevels + 1))
 
+    cbar.ax.ticklabel_format(style='sci', axis='x', scilimits=(-3, 3))
+
     # Add a super title
     if title:
         logger.debug('Setting super title to %s', title)
@@ -229,6 +231,8 @@ def plot_maps_diff(maps: list,
         cbar.set_ticks(np.linspace(-vmax_fill, vmax_fill, nlevels + 1))
     else:
         cbar.set_ticks(np.linspace(vmin_fill, vmax_fill, nlevels + 1))
+
+    cbar.ax.ticklabel_format(style='sci', axis='x', scilimits=(-3, 3))
 
     # Add a super title
     if title:


### PR DESCRIPTION
## PR description:

This PR updates the colorbar to use scientific notation in multiiple maps plots, preventing label overlap when very small values are present (e.g., in seasonal plots for the GlobalBiases diagnostic).


## Issues closed by this pull request:

Close #1952

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [x] Changelog is updated.

