### PR TITLE
Preparation to v0.13.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.13.6
       - v0.13.5
       - v0.13.4
       - v0.13.3

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -82,6 +82,8 @@ jobs:
       - name: Clone GitLab data-portfolio repository
         run: |
           git clone https://oauth2:${{ secrets.BSC_GITLAB }}@earth.bsc.es/gitlab/digital-twins/de_340-2/data-portfolio data-portfolio
+          cd data-portfolio
+          git checkout tags/v1.2.1
       - name: List Workspace Contents
         run: |
           echo "Current Directory: $PWD"

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --select=E9,F63,F7,F82 --ignore=F824 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=__init__.py
       - name: Download and set up tests

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -39,6 +39,8 @@ jobs:
       GRID_DEFINITION_PATH: /tmp
       # This is needed for the FDB tests.
       FDB5_CONFIG_FILE: /app/etc/fdb/config.yaml
+      # github token
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     # This option applies to the individual job of a matrix.
     continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 
+## [v0.13.6]
+
+Hotfixes:
 - Hardcode regrid='r100' in setup_checker (#1945)
 - Fix for make_content failing to accept expected argument (#1898)
 - Update experiments.yaml needed by the dashboard (#1951)
@@ -847,7 +850,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.5...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.6...HEAD
+[v0.13.6]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.5...v0.13.6
 [v0.13.5]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.4...v0.13.5
 [v0.13.4]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.2...v0.13.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased in the current development version:
 ## [v0.13.6]
 
 Hotfixes:
+- Cartopy offline maps available due to MN5 missing internet connection (#1954)
 - Hardcode regrid='r100' in setup_checker (#1945)
 - Fix for make_content failing to accept expected argument (#1898)
 - Update experiments.yaml needed by the dashboard (#1951)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased in the current development version:
 ## [v0.13.6]
 
 Hotfixes:
+- Data Portfolio tag specified in tests in order to keep testing the operational tag (#1954)
 - Cartopy offline maps available due to MN5 missing internet connection (#1954)
 - Hardcode regrid='r100' in setup_checker (#1945)
 - Fix for make_content failing to accept expected argument (#1898)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased in the current development version:
 ## [v0.13.6]
 
 Hotfixes:
+- AQUA console uses token as in main to access the catalog repository without authentication (#1954)
 - Data Portfolio tag specified in tests in order to keep testing the operational tag (#1954)
 - Cartopy offline maps available due to MN5 missing internet connection (#1954)
 - Hardcode regrid='r100' in setup_checker (#1945)

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - eccodes==2.39.0
   # for eccodes see issues #252, #634, #870, #1282
   # PR #36 catalog repo
+  - cartopy_offlinedata # this is needed for MN5 HPC
   - pandas      
   - pandoc
   - pip

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.13.5'
+__version__ = '0.13.6'


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `src/aqua/version.py`
- [x] quick check gsv pin
- [x] if a major operational release, update Dockerfiles and relative action
- [x] if it's an operational release, be sure the bug report menu is updated in the main as well
