### PR TITLE
Test file update (v6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,13 +24,8 @@ docs/sphinx/build/*
 
 # tests
 AQUA_tests/
-AQUA_tests.tar.gz
-AQUA_testsv2.tar.gz
-AQUA_testsv3.tar.gz
-AQUA_testsv4.tar.gz
-AQUA_tests_teleconnectionsv3.tar.gz
-AQUA_testsv5.tar.gz
-AQUA_tests_teleconnectionsv3.tar.gz
+AQUA_testsv*
+AQUA_tests_teleconnections*
 *.bak
 
 # coverage and vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Workflow modifications:
   are not correct.
 
 AQUA core complete list:
+- Support for CDO 2.5.0, modified test files accordingly (v6) (#1987)
 - Remove DOCKER secrets and prepare ground for dependabot action e.g introduce AQUA_GITHUB_PAT (#1983)
 - `Trender()` class to include both `trend()` and `detrend()` method (#1980)
 - `cartopy_offlinedata` is added on container and path is set in cli call, to support MN5 no internet for coastlines download (#1960)

--- a/download_data_for_tests.sh
+++ b/download_data_for_tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-file_url="https://swift.dkrz.de/v1/dkrz_a973e394-5f24-4f4d-8bbf-1a83bd387ccb/AQUA/framework/AQUA_testsv5.tar.gz?temp_url_sig=0738c078c9d994c3cee25ceae4f739a47844ee8d&temp_url_expires=2026-11-16T16:31:15Z"
-file_path="AQUA_testsv5.tar.gz"
-#file_url="https://swift.dkrz.de/v1/dkrz_a973e394-5f24-4f4d-8bbf-1a83bd387ccb/AQUA/framework/AQUA_testsv4.tar.gz?temp_url_sig=0edd32127555f6c9ff3e0eb750746d622d1d8d4f&temp_url_expires=2025-01-06T11:35:45Z"
-#file_path="AQUA_testsv4.tar.gz"
+file_url="https://swift.dkrz.de/v1/dkrz_a973e394-5f24-4f4d-8bbf-1a83bd387ccb/AQUA/framework/AQUA_testsv6.tar.gz?temp_url_sig=38bfddb3ff0b9584db673f695167895896e6a2d6&temp_url_expires=2027-05-06T09:26:02Z"
+file_path="AQUA_testsv6.tar.gz"
+# file_url="https://swift.dkrz.de/v1/dkrz_a973e394-5f24-4f4d-8bbf-1a83bd387ccb/AQUA/framework/AQUA_testsv5.tar.gz?temp_url_sig=0738c078c9d994c3cee25ceae4f739a47844ee8d&temp_url_expires=2026-11-16T16:31:15Z"
+# file_path="AQUA_testsv5.tar.gz"
 
 if [ ! -f "$file_path" ]; then
     echo "Downloading file..."
@@ -15,12 +15,6 @@ else
     echo "File already exists."
 fi
 
-# if [ -f "./config/config-aqua.yaml" ] ; then
-#     cp ./config/config-aqua.yaml ./config/config-aqua.yaml.bak
-# else
-#     cp ./config/config-aqua.tmpl ./config/config-aqua.yaml
-# fi
-
 # if [[ "$OSTYPE" == "darwin"* ]]; then
 #   # Mac OSX
 #   sed -i '' "/^catalog:/c\\
@@ -31,4 +25,3 @@ fi
 # fi
 
 #python -m pytest ./tests/test_basic.py
-#mv ./config/config.yaml.bak ./config/config.yaml

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ channels:
 # please note that some of these dependencies are made explicit on purpose, but are not directly required by conda/mamba
 dependencies:
   - python>=3.10,<3.13
-  - cdo>=2.2.0,<2.5.0 #for healpix support, avoid 2.5.0 which is currently broken
+  - cdo>=2.2.0 #for healpix support
   - eccodes==2.40.0
   # for eccodes see issues #252, #634, #870, #1282
   # PR #36 catalog repo


### PR DESCRIPTION
## PR description:

Due to the recent changes in CDO #1971 we're trying to accomodate the missing attributes in the file needed for test with an update of the tests tar.gz on swift.
The PR is updating the download link used in tests and generalizing the gitignore file so that no further modifications of it will be needed for tests.

## Issues closed by this pull request:

Close #1971 (if we remove the CDO pin in this PR as well)

## People involved:

cc @oloapinivad 

 - [x] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi and hpc2020 installation tool. 
