### PR TITLE
Upgrade `trender` class to provide also coefficients and normalize them

### DIFF
--- a/docs/sphinx/source/other_components.rst
+++ b/docs/sphinx/source/other_components.rst
@@ -31,12 +31,11 @@ Some extra options are available:
     Otherwise, the time coordinate will be the first timestamp of the time window.
 - ``time_bounds=True``: this flag can be activated to build time bounds in a similar way to CMOR-like standard.
 
-
-Trend and Detrend
+Detrend
 -----------------
 
 For some analysis, computing or removing a linear (or polynominial) trend can be helpful to highlight the internal variability.
-The ``trend`` and ``detrend`` method can be used as a high-level wrapper of xarray polyfit functionalities to achieve this goal.
+The ``detrend`` method can be used as a high-level wrapper of xarray polyfit functionalities to achieve this goal.
 
 .. code-block:: python
 
@@ -47,12 +46,6 @@ The ``trend`` and ``detrend`` method can be used as a high-level wrapper of xarr
 In this way, linear trend is removed from each grid point of the original dataset along the time dimension. 
 Other dimension can be targeted too, although with limited physical meaning. 
 Of course, it can be used in collaboration with temporal and spatial averaging. Higher order polynominial fits are available too.
-
-Similary, multidmensional trends can be computed with the ``trend()`` method, which will return a new dataset with the trend values.
-
-... code-block:: python
-
-    trend = reader.trend(data['2t'], dim='time')
 
 Some options includes:
 

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -471,22 +471,22 @@ class Reader():
         out = set_attrs(out, {"AQUA_regridded": 1})
         return out
     
-    def trend(self, data, dim='time', degree=1, skipna=False):
-        """
-        Estimate the trend of an xarray object using polynomial fitting.
+    # def trend(self, data, dim='time', degree=1, skipna=False):
+    #     """
+    #     Estimate the trend of an xarray object using polynomial fitting.
 
-        Args:
-            data (DataArray or Dataset): The input data.
-            dim (str): Dimension to apply trend along. Defaults to 'time'.
-            degree (int): Degree of the polynomial. Defaults to 1.
-            skipna (bool): Whether to skip NaNs. Defaults to False.
+    #     Args:
+    #         data (DataArray or Dataset): The input data.
+    #         dim (str): Dimension to apply trend along. Defaults to 'time'.
+    #         degree (int): Degree of the polynomial. Defaults to 1.
+    #         skipna (bool): Whether to skip NaNs. Defaults to False.
 
-        Returns:
-            DataArray or Dataset: The trend component.
-        """
-        final = self.trender.trend(data, dim=dim, degree=degree, skipna=skipna)
-        final.aqua.set_default(self)
-        return final
+    #     Returns:
+    #         DataArray or Dataset: The trend component.
+    #     """
+    #     final = self.trender.trend(data, dim=dim, degree=degree, skipna=skipna)
+    #     final.aqua.set_default(self)
+    #     return final
 
     def detrend(self, data, dim='time', degree=1, skipna=False):    
         """

--- a/src/aqua/reader/trender.py
+++ b/src/aqua/reader/trender.py
@@ -1,7 +1,10 @@
 """Class for handling trend and detrending of xarray objects."""
 
 import xarray as xr
+import numpy as np
+import pandas as pd
 from aqua.logger import log_configure, log_history
+
 
 
 class Trender:
@@ -50,8 +53,64 @@ class Trender:
             DataArray or Dataset: The detrended data.
         """
         return self._apply_trend_or_detrend(data, self._detrend, dim, degree, skipna)
+    
+    def coeffs(self, data: xr.DataArray | xr.Dataset, dim: str = 'time',
+               degree: int = 1, skipna: bool = False, normalize: bool = False) -> xr.DataArray | xr.Dataset:
+        """"
+        Compute the polynomial coefficients for the trend.
+        """
 
-    def _apply_trend_or_detrend(self, data, func, dim, degree, skipna):
+        return self._apply_trend_or_detrend(data, self._coeffs, dim, degree, skipna, normalize=normalize)
+
+    def _coeffs(self, data: xr.DataArray | xr.Dataset, dim: str, degree: int, skipna: bool, normalize: bool) -> xr.DataArray | xr.Dataset:
+        """
+        Compute the polynomial coefficients for the trend, adjusted to the input data.
+
+        Args:
+            data (DataArray or Dataset): Input data.
+            dim (str): Dimension to apply fit along.
+            degree (int): Polynomial degree.
+            skipna (bool): Whether to skip NaNs.
+            normalize (bool): Whether to normalize coefficients for the 'time' dimension.
+                              This applies a scaling factor based on the inferred frequency of the time dimension.
+                              It is applied only if `dim` is 'time' and it is scaled to all degrees of the polynomial.
+
+        Returns:
+            DataArray or Dataset: Coefficients of the polynomial fit adjusted to the input data.
+        """
+        coeffs = data.polyfit(dim=dim, deg=degree, skipna=skipna)
+
+        # time axis are scaled to nanoseconds, which is not very user-friendly.
+        # we try to adjust the coefficients to the input data frequency
+        if dim == 'time' and normalize:
+            self.logger.debug('Normalizing coefficients for time dimension.')
+            # get the inferred frequency of the time dimension and convert to pandas offset
+            time_values = data[dim].to_index()
+            inferred_freq = time_values.inferred_freq
+            self.logger.debug("Inferred frequency for 'time' dimension: %s", inferred_freq)
+            if inferred_freq is None:
+                raise ValueError("Inferred frequency for 'time' dimension is None. "
+                                 "Ensure that the time dimension has a pandas compatible frequency.")
+            offset = pd.tseries.frequencies.to_offset(inferred_freq)
+            self.logger.debug("Offset for normalization: %s", offset)
+
+            # offset cannot be converted to timedelta, so we use the mean of the time values
+            delta = ((time_values + offset) - time_values).mean()
+            factor = delta.value # convert to nanoscend
+
+            self.logger.debug("Time normalization factor: %s", factor)
+
+            # create an array of factor for each degree and convert to DataArray
+            factor_scales = np.array([factor**(degree - i) for i in range(degree + 1)])
+            self.logger.debug("Factor scales for polynomial degrees: %s", factor_scales)
+            factor_da = xr.DataArray(factor_scales, dims="degree", coords={"degree": coeffs.coords["degree"]})
+
+            # adjust the coefficients by the factor
+            coeffs = coeffs * factor_da
+
+        return coeffs.polyfit_coefficients
+
+    def _apply_trend_or_detrend(self, data, func, dim, degree, skipna, **kwargs):
         """
         Internal dispatcher for trend/detrend logic.
         """
@@ -62,12 +121,12 @@ class Trender:
         )
 
         if isinstance(data, xr.DataArray):
-            final = func(data=data, dim=dim, degree=degree, skipna=skipna)
+            final = func(data=data, dim=dim, degree=degree, skipna=skipna, **kwargs)
 
         elif isinstance(data, xr.Dataset):
             selected_vars = [da for da in data.data_vars if dim in data[da].coords]
             final = data[selected_vars].map(func, keep_attrs=True,
-                                            dim=dim, degree=degree, skipna=skipna)
+                                            dim=dim, degree=degree, skipna=skipna, **kwargs)
         else:
             raise ValueError("Input must be an xarray DataArray or Dataset.")
 
@@ -90,8 +149,7 @@ class Trender:
 
         """
         coeffs = data.polyfit(dim=dim, deg=degree, skipna=skipna)
-        fit = xr.polyval(data[dim], coeffs.polyfit_coefficients)
-        return fit
+        return xr.polyval(data[dim], coeffs.polyfit_coefficients)
 
     def _detrend(self, data: xr.DataArray, dim: str, degree: int, skipna: bool) -> xr.DataArray:
         """

--- a/tests/test_trender.py
+++ b/tests/test_trender.py
@@ -16,7 +16,7 @@ class TestTrender:
         data = reader.retrieve()
 
         block1 = data['2t'].isel(time=slice(0, 1000))
-        trend1 = reader.trend(block1).aqua.fldmean()
+        trend1 = reader.trender.trend(block1).aqua.fldmean()
 
         assert trend1.shape == (1000,)
         assert pytest.approx(trend1.values[300]) == 285.908


### PR DESCRIPTION
## PR description:

This extends the Trender class, removing a the reader call to `trend` since it is useless and adding a `coeffs` class that also handle time conversion


## People involved:

@sushovan77ghosh 

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Changelog is updated.

