### PR TITLE
Raise an error if retrieve() in core diagnostic returns an empty dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Workflow modifications:
   are not correct.
 
 AQUA core complete list:
+- Raise an error if retrieve() returns an empty dataset (#1997)
 - Fix HPC2020 (ECMWF) installation (#1994)
 - `plot_timeseries` can handle multiple references and ensemble mean and std (#1988)
 - Support for CDO 2.5.0, modified test files accordingly (v6) (#1987)

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -386,6 +386,10 @@ class Reader():
                          'AQUA_version': aqua_version}
         data = set_attrs(data, info_metadata)
 
+        # If the data is empty, raise an error
+        if not data:
+            raise NoDataError(f"No data found for {self.model} {self.exp} {self.source} with variable {var}")
+
         return data
 
     def _add_index(self, data):

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -386,12 +386,6 @@ class Reader():
                          'AQUA_version': aqua_version}
         data = set_attrs(data, info_metadata)
 
-        # If the data is empty, raise an error
-        if not data:
-            raise NoDataError(f"No data found for {self.model} {self.exp} {self.source} with variable {var}")
-
-        return data
-
     def _add_index(self, data):
 
         """

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -385,6 +385,8 @@ class Reader():
                          'AQUA_source': self.source, 'AQUA_catalog': self.catalog,
                          'AQUA_version': aqua_version}
         data = set_attrs(data, info_metadata)
+        
+        return data
 
     def _add_index(self, data):
 

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -128,7 +128,7 @@ class Diagnostic():
 
         # If the data is empty, raise an error
         if not data:
-            raise ValueError(f"No data found for {self.model} {self.exp} {self.source} with variable {var}")
+            raise ValueError(f"No data found for {model} {exp} {source} with variable {var}")
 
         if catalog is None:
             catalog = reader.catalog

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -126,6 +126,12 @@ class Diagnostic():
 
         data = reader.retrieve(var=var)
 
+        # If the data is empty, raise an error
+        if not data:
+            raise ValueError(f"No data found for {self.model} {self.exp} {self.source} with variable {var}")
+
+        return data
+
         if catalog is None:
             catalog = reader.catalog
 

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -130,8 +130,6 @@ class Diagnostic():
         if not data:
             raise ValueError(f"No data found for {self.model} {self.exp} {self.source} with variable {var}")
 
-        return data
-
         if catalog is None:
             catalog = reader.catalog
 


### PR DESCRIPTION
## PR description:

During testing, I noticed that the retrieve() method does not raise an error when an empty dataset is returned—for example, when a non-existent variable name is requested.

 - [x] Changelog is updated.

