### PR TITLE
Update h5py dependency to avoid broken test and increase environment flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Workflow modifications:
   are not correct.
 
 AQUA core complete list:
+- `h5py` installed from pypi. Hard pin to version 3.12.1 removed in favor of a lower limit to the version (#2002)
 - `aqua-analysis` can accept a `--regrid` argument in order to activate the regrid on each diagnostics supporting it (#1947)
 - `--no-mount /etc/localtime` option added to the `load_aqua_container.sh` script for all HPC (#1975)
 - Upgrade to eccodes==2.41.0 (#1890)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "sparse",
     "xarray>=2025.01.2", # Version 2025.01.2 is the first version introducing the CFDatetimeCoder
     "kerchunk",
-    "h5py@git+https://github.com/h5py/h5py.git@3.12.1", #specific github pin to avoid installation of binaries
+    "h5py>=3.12.1", #specific github pin to avoid installation of binaries
     "fastparquet",
     "pyfdb==0.1.1",
     "gsv-interface==2.9.0",


### PR DESCRIPTION
## PR description:

Removing the hard pin to the h5py installation, which is breaking the test, in favor of a softer lower version limit.
HDF5 is kept explicit in the environment file, while the h5py is now installed trough the available pipy package.

## Issues closed by this pull request:

Close #2001

## People involved:

cc @jhardenberg if you agree with the modification I'd merge it (once tests are done) in order to keep the tests working in the other branches.

 - [x] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
