### PR TITLE
Cli set grids path

### DIFF
--- a/src/aqua/cli/parser.py
+++ b/src/aqua/cli/parser.py
@@ -89,7 +89,7 @@ def parse_arguments():
 def file_subparser(main_parser, name):
     """Compact subparsers for file handling - fixes and grids"""
 
-    # subparsers for fixes
+    # subparsers for fixe and grids
     parser = main_parser.add_parser(name, help=f'{name} related commands')
     subparsers = parser.add_subparsers(dest='nested_command')
 
@@ -99,5 +99,11 @@ def file_subparser(main_parser, name):
                                   help=f"Add a {name} file in editable mode from the original path")
     parser_remove = subparsers.add_parser('remove', help=f'Remove a {name} file')
     parser_remove.add_argument('file', help=f'The {name} file to remove')
+
+    # We have for the grids the possibility to set a default path to overwrite the individual catalog one
+    # This will create a block in the config-aqua.yaml file for grids, areas and weights.
+    if name == 'grids':
+        parser_list = subparsers.add_parser('set', help=f'Set a {name} path as the default in config-aqua.yaml')
+        parser_list.add_argument('path', help=f'The {name} path to set as default')
 
     return parser

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -360,6 +360,28 @@ class TestAquaConsole():
             run_aqua(['-v', 'fixes', 'remove', 'ciccio.yaml'])
             assert excinfo.value.code == 1
 
+        # set the grids path in the config-aqua.yaml
+        run_aqua(['-v', 'grids', 'set', os.path.join(mydir, 'pippo')])
+        assert os.path.exists(os.path.join(mydir, 'pippo', 'grids'))
+        assert os.path.exists(os.path.join(mydir, 'pippo', 'areas'))
+        assert os.path.exists(os.path.join(mydir, 'pippo', 'weights'))
+        config_file = load_yaml(os.path.join(mydir, '.aqua', 'config-aqua.yaml'))
+        assert config_file['paths'] == {
+            'grids': os.path.join(mydir, 'pippo', 'grids'),
+            'areas': os.path.join(mydir, 'pippo', 'areas'),
+            'weights': os.path.join(mydir, 'pippo', 'weights')
+        }
+        
+        # set the grids path in the config-aqua.yaml with the block already existing
+        run_aqua(['-v', 'grids', 'set', os.path.join(mydir, 'pluto')])
+        assert os.path.exists(os.path.join(mydir, 'pluto', 'grids'))
+        config_file = load_yaml(os.path.join(mydir, '.aqua', 'config-aqua.yaml'))
+        assert config_file['paths'] == {
+            'grids': os.path.join(mydir, 'pluto', 'grids'),
+            'areas': os.path.join(mydir, 'pluto', 'areas'),
+            'weights': os.path.join(mydir, 'pluto', 'weights')
+        }
+
         # uninstall everything
         run_aqua_console_with_input(['uninstall'], 'yes')
         assert not os.path.exists(os.path.join(mydir, '.aqua'))


### PR DESCRIPTION
## PR description:

We introduce a new aqua grids set <path> that will build the paths block with the three paths based on the main path provided. This will simplify the requirements on new machine deployment.

## Issues closed by this pull request:

Close #1904 

## People involved:

cc @jhardenberg this is useful for other HPC deployment

----

 - [x] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
