### PR TITLE
Refactor `load_diagnostic_config` to load multiple configuration files

### DIFF
--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -97,7 +97,7 @@ def close_cluster(client, cluster, private_cluster, loglevel: str = 'WARNING'):
         logger.debug("Dask cluster closed.")
 
 
-def load_diagnostic_config(diagnostic: str, args: argparse.Namespace,
+def load_diagnostic_config(diagnostic: str, config: str = None,
                            default_config: str = "config.yaml",
                            loglevel: str = 'WARNING'):
     """
@@ -105,15 +105,15 @@ def load_diagnostic_config(diagnostic: str, args: argparse.Namespace,
 
     Args:
         diagnostic (str): diagnostic name
-        args (argparse.Namespace): arguments of the CLI. "config" argument can modify the default configuration file.
+        config (str): config argument can modify the default configuration file.
         default_config (str): default name configuration file (yaml format)
         loglevel (str): logging level. Default is 'WARNING'.
 
     Returns:
         dict: configuration dictionary
     """
-    if args.config:
-        filename = args.config
+    if config:
+        filename = config
     else:
         configdir = ConfigPath(loglevel=loglevel).configdir
         filename = os.path.join(configdir, "diagnostics", diagnostic, default_config)

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -30,7 +30,7 @@ def template_parse_arguments(parser: argparse.ArgumentParser):
                         required=False, help="experiment name")
     parser.add_argument("--source", type=str,
                         required=False, help="source name")
-    parser.add_argument("--config", "-c", type=str,
+    parser.add_argument("--config", "-c", type=str, default=None,
                         help='yaml configuration file')
     parser.add_argument("--nworkers", "-n", type=int,
                         required=False, help="number of workers")

--- a/src/aqua_diagnostics/global_biases/cli_global_biases.py
+++ b/src/aqua_diagnostics/global_biases/cli_global_biases.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     client, cluster, private_cluster, = open_cluster(nworkers=nworkers, cluster=cluster, loglevel=loglevel)
 
     # Load the configuration file and then merge it with the command-line arguments
-    config_dict = load_diagnostic_config(diagnostic='globalbiases', args=args,
+    config_dict = load_diagnostic_config(diagnostic='globalbiases', config=args.config,
                                          default_config='config_global_biases.yaml',
                                          loglevel=loglevel)
     config_dict = merge_config_args(config=config_dict, args=args, loglevel=loglevel)

--- a/src/aqua_diagnostics/teleconnections/cli_teleconnections.py
+++ b/src/aqua_diagnostics/teleconnections/cli_teleconnections.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     # Load the configuration file and then merge it with the command-line arguments,
     # overwriting the configuration file values with the command-line arguments.
-    config_dict = load_diagnostic_config(diagnostic='teleconnections', args=args,
+    config_dict = load_diagnostic_config(diagnostic='teleconnections', config=args.config,
                                          default_config='config_teleconnections.yaml',
                                          loglevel=loglevel)
     config_dict = merge_config_args(config=config_dict, args=args, loglevel=loglevel)

--- a/src/aqua_diagnostics/timeseries/cli_timeseries.py
+++ b/src/aqua_diagnostics/timeseries/cli_timeseries.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 
     # Load the configuration file and then merge it with the command-line arguments,
     # overwriting the configuration file values with the command-line arguments.
-    config_dict = load_diagnostic_config(diagnostic='timeseries', args=args,
+    config_dict = load_diagnostic_config(diagnostic='timeseries', config=args.config,
                                          default_config='config_timeseries_atm.yaml',
                                          loglevel=loglevel)
     config_dict = merge_config_args(config=config_dict, args=args, loglevel=loglevel)

--- a/tests/diagnostic_core/test_core_util.py
+++ b/tests/diagnostic_core/test_core_util.py
@@ -32,7 +32,7 @@ def test_template_parse_arguments():
     assert args.nworkers == 2
 
     with pytest.raises(ValueError):
-        load_diagnostic_config(diagnostic='pippo', args=args, loglevel=loglevel)
+        load_diagnostic_config(diagnostic='pippo', config=args.config, loglevel=loglevel)
 
 @pytest.mark.aqua
 @patch("aqua.diagnostics.core.util.Client")
@@ -70,7 +70,7 @@ def test_load_diagnostic_config():
     args = parser.parse_args(["--loglevel", "DEBUG"])
     ts_dict = load_diagnostic_config(diagnostic='timeseries',
                                      default_config='config_timeseries_atm.yaml',
-                                     args=args, loglevel=loglevel)
+                                     config=args.config, loglevel=loglevel)
 
     assert ts_dict['datasets'] == [{'catalog': None, 'exp': None, 'model': None, 'source': 'lra-r100-monthly', 'regrid': None}]
 


### PR DESCRIPTION
Small change, to be tested, so that `load_diagnostic_config` does not receive a generic args but rather a specific configuration file to be loaded. I am pretty sure it is going to break if config has no default. 
