### PR TITLE
Improving the eccodes shortname guessing using WMO tables 

### DIFF
--- a/src/aqua/util/eccodes.py
+++ b/src/aqua/util/eccodes.py
@@ -16,9 +16,9 @@ from aqua.logger import log_configure
 from aqua.exceptions import NoEcCodesShortNameError
 
 # some eccodes shortnames are not unique: we need a manual mapping
-NOT_UNIQUE_SHORTNAMES = {
-    'tcc': [228164, 164]
-}
+#NOT_UNIQUE_SHORTNAMES = {
+#    'tcc': [228164, 164]
+#}
 
 
 @functools.cache
@@ -33,14 +33,19 @@ def _get_attrs_from_shortname(sn, grib_version="GRIB2"):
     """
 
     gid = codes_grib_new_from_samples(grib_version)
-    if sn in NOT_UNIQUE_SHORTNAMES:
-        # If the short name is special, we need to handle it differently
-        # by using the first paramId in the list of not unique ones
-        pid = NOT_UNIQUE_SHORTNAMES[sn][0]
-        codes_set(gid, "paramId", pid)
-    else:
-        codes_set(gid, "shortName", sn)
-        pid = codes_get(gid, "paramId", ktype=str)
+    #if sn in NOT_UNIQUE_SHORTNAMES:
+    #    # If the short name is special, we need to handle it differently
+    #    # by using the first paramId in the list of not unique ones
+    #    pid = NOT_UNIQUE_SHORTNAMES[sn][0]
+    #    codes_set(gid, "paramId", pid)
+    #else:
+    #    codes_set(gid, "shortName", sn)
+    #    pid = codes_get(gid, "paramId", ktype=str)
+
+    # setting cetre to 0 bring the WMO table on top of everything
+    codes_set(gid, "centre", 0)
+    codes_set(gid, "shortName", sn)
+    pid = codes_get(gid, "paramId")
     nm = codes_get(gid, "name")
     un = codes_get(gid, "units")
     #cf = codes_get(gid, "cfName")
@@ -94,9 +99,9 @@ def get_eccodes_attr(sn, loglevel='WARNING'):
         sn = _get_shortname_from_paramid(sn[3:])
 
     #warning at wrapper level to avoid duplication of logger
-    if sn in NOT_UNIQUE_SHORTNAMES:
-        logger.warning('Short name %s is not unique, using the first paramId in the list: %s',
-                       sn, NOT_UNIQUE_SHORTNAMES[sn][0])
+    #if sn in NOT_UNIQUE_SHORTNAMES:
+    #    logger.warning('Short name %s is not unique, using the first paramId in the list: %s',
+    #                   sn, NOT_UNIQUE_SHORTNAMES[sn][0])
 
     # Try to get attributes from GRIB2 first
     try:


### PR DESCRIPTION
As per title, I have been told that is possible to force the eccodes guessing toward WMO tables and avoid ECMWF tables. This can be done with `codes_set(gid, "centre", 0)`. I think that in the same we can explore ECMWF tables if needed

----

 - [ ] Tests are included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.

