### PR TITLE
Preparation to release 0.16

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.16.0
       - v0.15.0
       - v0.14.0
       - v0.13.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
-Unreleased in the current development version (target v0.16.0): 
+Unreleased in the current development version (target v0.17.0): 
+
+## [v0.16.0]
 
 Removed:
 - Removed source or experiment specific fixes; only the `fixer_name` is now supported.
@@ -967,7 +969,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.15.0...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.16.0...HEAD
+[v0.16.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.15.0...v0.16.0
 [v0.15.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.14.0...v0.15.0
 [v0.14.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.1...v0.14.0
 [v0.13.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.0...v0.13.1

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.16.0-alpha'
+__version__ = '0.16.0'


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `src/aqua/version.py`
- [x] quick check gsv pin