### PR TITLE
Refactor kwargs handling in Reader class to filter and validate parameters from intake catalog

### DIFF
--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -150,15 +150,15 @@ class Reader():
         # load the catalog
         aqua.gsv.GSVSource.first_run = True  # Hack needed to avoid double checking of paths (which would not work if on another machine using polytope)
         self.expcat = self.cat(**intake_vars)[self.model][self.exp]  # the top-level experiment entry
-        self.esmcat = self.expcat[self.source](**kwargs) 
+        # We open before without kwargs to filter kwargs which are not in the parameters allowed by the intake catalog entry
+        self.esmcat = self.expcat[self.source]()
+        self.kwargs = self._filter_kwargs(intake_vars, kwargs)
+        self.esmcat = self.expcat[self.source](**self.kwargs)
 
         # Manual safety check for netcdf sources (see #943), we output a more meaningful error message
         if isinstance(self.esmcat, intake_xarray.netcdf.NetCDFSource):
             if not files_exist(self.esmcat.urlpath):
                 raise NoDataError(f"No NetCDF files available for {self.model} {self.exp} {self.source}, please check the urlpath: {self.esmcat.urlpath}")  # noqa E501
-
-        # store the kwargs for further usage
-        self.kwargs = self._check_kwargs_parameters(kwargs, intake_vars)
 
         # extend the unit registry
         units_extra_definition()
@@ -556,36 +556,44 @@ class Reader():
     #                             name, list(drop_coords))
     #     return data.drop_vars(drop_coords)
 
-    def _check_kwargs_parameters(self, main_parameters, intake_parameters):
+    def _filter_kwargs(self, intake_vars: dict={}, kwargs: dict={}):
         """
-        Function to check if which parameters are included in the metadata of
-        the source and performs a few safety checks.
+        Uses the esmcat.describe() to remove the intake_vars, then check in the parameters if the kwargs are present.
+        Kwargs which are not present in the intake_vars will be removed.
 
         Args:
-            main_parameters: get them from kwargs
-            intake_parameters: get them from catalog machine specific file
+            intake_vars (dict): The intake variables from the catalog machine specific file.
+            kwargs (dict): The keyword arguments passed to the reader, which are intake parameters in the source.
 
         Returns:
-            kwargs after check has been processed
+            A dictionary of kwargs filtered to only include parameters that are present in the intake_vars.
         """
-        # join the kwargs
-        parameters = {**main_parameters, **intake_parameters}
+        esm_dict = self.esmcat.describe().get('user_parameters', {})
+        len_esmcat = len(esm_dict)
 
-        # remove null kwargs
-        parameters = {key: value for key, value in parameters.items() if value is not None}
+        # This contains both the intake_vars and the esmcat parameters
+        params = [esm_dict[i]['name'] for i in range(len_esmcat)]
 
-        user_parameters = self.esmcat.describe().get('user_parameters')
-        if user_parameters is not None:
-            if parameters is None:
-                parameters = {}
+        # List comprehension to filter out kwargs that are not in the params
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in params}
+        unfiltered_kwargs = {k: v for k, v in kwargs.items() if k not in params}
 
-            for param in user_parameters:
-                if param['name'] not in parameters:
-                    self.logger.warning('%s parameter is required but is missing, setting to default %s',
-                                        param['name'], param['default'])
-                    parameters[param['name']] = param['default']
+        # Log warnings for unfiltered kwargs
+        for key, _ in unfiltered_kwargs.items():
+            self.logger.warning('Unfiltered kwarg %s is not in intake_vars, removing it', key)
 
-        return parameters
+        # Check if all required parameters are present in the filtered kwargs and set defaults if not
+        filtered_list = list(filtered_kwargs.keys())
+        intake_vars_list = list(intake_vars.keys())
+        for param in params:
+            if param not in filtered_list and param not in intake_vars_list:
+                self.logger.warning('%s parameter is required but is missing, setting to default %s',
+                                    param, esm_dict[params.index(param)]['default'])
+                self.logger.warning('Available values for %s are: %s',
+                                    param, esm_dict[params.index(param)]['allowed'])
+                filtered_kwargs[param] = esm_dict[params.index(param)]['default']
+
+        return filtered_kwargs
 
     def vertinterp(self, data, levels=None, vert_coord='plev', units=None,
                    method='linear'):


### PR DESCRIPTION
## PR description:

With the current implementation if a kwarg is given to the reader and it is not in the intake parameters, it will not stop the code but it will be popped out from the list

## People involved:

Tag here relevant people to involve in the discussion:

@jhardenberg 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated. 
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
 - [ ] Diagnostic config files path are updated in the console if needed
