### PR TITLE
modularise function for circular boundary to cartopy geoaxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 Unreleased in the current development version (target v0.18.0): 
 
+AQUA core complete list:
+- `apply_circular_window()` utility function to apply a circular window to cartopy maps (#2100)
+
 ## [v0.17.0]
 
 Main changes are:

--- a/src/aqua/util/__init__.py
+++ b/src/aqua/util/__init__.py
@@ -6,6 +6,7 @@ from .units import normalize_units, convert_units, convert_data_units
 from .graphics import add_cyclic_lon, plot_box, minmax_maps
 from .graphics import evaluate_colorbar_limits, cbar_get_label, set_map_title
 from .graphics import coord_names, ticks_round, set_ticks, generate_colorbar_ticks
+from .graphics import apply_circular_window
 from .graphics import get_nside, get_npix, healpix_resample
 from .projections import get_projection
 from .realizations import format_realization
@@ -27,6 +28,7 @@ __all__ = ['ConfigPath',
            'add_cyclic_lon', 'plot_box', 'minmax_maps',
            'evaluate_colorbar_limits', 'cbar_get_label', 'set_map_title',
            'coord_names', 'ticks_round', 'set_ticks', 'generate_colorbar_ticks',
+           'apply_circular_window',
            'area_selection', 'check_coordinates', 'select_season',
            'generate_random_string', 'get_arg', 'create_folder', 'to_list',
            'files_exist',

--- a/src/aqua/util/graphics.py
+++ b/src/aqua/util/graphics.py
@@ -9,6 +9,7 @@ import numpy as np
 import healpy as hp
 from scipy.interpolate import griddata
 import matplotlib.pyplot as plt
+import matplotlib.path as mpath
 
 from aqua.logger import log_configure
 from .sci_util import check_coordinates
@@ -386,6 +387,38 @@ def generate_colorbar_ticks(vmin, vmax, nlevels=11, sym=False,
 
     return cbar_ticks
 
+def apply_circular_boundary(ax, extent=None, apply_black_circle=False):
+    """
+    Apply a circular boundary mask to a Cartopy GeoAxes and set geographic extent
+    to avoid the default rectangular plotting window with some projections.
+
+    Args:
+        ax (GeoAxes): Cartopy axes object to modify.
+        extent (list or None): Geographic extent [west, east, south, north]. Default is Arctic region.
+
+    Returns:
+        ax (GeoAxes): Modified axes with circular boundary and extent.
+    """
+    if extent is None:
+        extent = [-180, 180, 10, 90] # [west, east, south, north]
+
+    # create circular boundary path
+    theta = np.linspace(0, 2 * np.pi, 100)
+    center, radius = [0.5, 0.5], 0.5
+    verts = np.vstack([np.sin(theta), np.cos(theta)]).T
+    circle = mpath.Path(verts * radius + center)
+
+    # apply circle to axis
+    ax.set_boundary(circle, transform=ax.transAxes)
+    ax.set_extent(extent, crs=ccrs.PlateCarree())
+
+    if apply_black_circle:
+        # overlay a more visible black circle outline (drawn in axes coordinates)
+        circle_patch = mpatches.Circle(
+            center, radius=radius, transform=ax.transAxes,
+            fill=False, color='black', linewidth=1.5, zorder=10)
+        ax.add_patch(circle_patch)
+    return ax
 """
 Following functions are taken and adjusted from the easygems package,
 on this repository:

--- a/src/aqua/util/graphics.py
+++ b/src/aqua/util/graphics.py
@@ -419,6 +419,7 @@ def apply_circular_boundary(ax, extent=None, apply_black_circle=False):
             fill=False, color='black', linewidth=1.5, zorder=10)
         ax.add_patch(circle_patch)
     return ax
+    
 """
 Following functions are taken and adjusted from the easygems package,
 on this repository:

--- a/src/aqua/util/graphics.py
+++ b/src/aqua/util/graphics.py
@@ -10,6 +10,7 @@ import healpy as hp
 from scipy.interpolate import griddata
 import matplotlib.pyplot as plt
 import matplotlib.path as mpath
+import matplotlib.patches as mpatches
 
 from aqua.logger import log_configure
 from .sci_util import check_coordinates
@@ -416,7 +417,7 @@ def apply_circular_boundary(ax, extent=None, apply_black_circle=False):
         # overlay a more visible black circle outline (drawn in axes coordinates)
         circle_patch = mpatches.Circle(
             center, radius=radius, transform=ax.transAxes,
-            fill=False, color='black', linewidth=1.5, zorder=10)
+            fill=False, color='darkgrey', linewidth=1.5, zorder=10)
         ax.add_patch(circle_patch)
     return ax
     

--- a/src/aqua/util/graphics.py
+++ b/src/aqua/util/graphics.py
@@ -388,7 +388,7 @@ def generate_colorbar_ticks(vmin, vmax, nlevels=11, sym=False,
 
     return cbar_ticks
 
-def apply_circular_boundary(ax, extent=None, apply_black_circle=False):
+def apply_circular_window(ax, extent=None, apply_black_circle=False):
     """
     Apply a circular boundary mask to a Cartopy GeoAxes and set geographic extent
     to avoid the default rectangular plotting window with some projections.

--- a/src/aqua_diagnostics/teleconnections/plot_nao.py
+++ b/src/aqua_diagnostics/teleconnections/plot_nao.py
@@ -6,6 +6,7 @@ import matplotlib.path as mpath
 from cartopy.crs import NorthPolarStereo
 from aqua.logger import log_configure
 from aqua.graphics import indexes_plot, plot_single_map, plot_single_map_diff
+from aqua.util import apply_circular_boundary
 from .base import PlotBaseMixin, _homogeneize_maps
 
 

--- a/src/aqua_diagnostics/teleconnections/plot_nao.py
+++ b/src/aqua_diagnostics/teleconnections/plot_nao.py
@@ -6,7 +6,7 @@ import matplotlib.path as mpath
 from cartopy.crs import NorthPolarStereo
 from aqua.logger import log_configure
 from aqua.graphics import indexes_plot, plot_single_map, plot_single_map_diff
-from aqua.util import apply_circular_boundary
+from aqua.util import apply_circular_window
 from .base import PlotBaseMixin, _homogeneize_maps
 
 
@@ -92,7 +92,7 @@ class PlotNAO(PlotBaseMixin):
         fig = plt.figure(figsize=(11, 8.5))
         ax = fig.add_subplot(111, projection=proj)
 
-        ax = apply_circular_boundary(ax, extent=extent)
+        ax = apply_circular_window(ax, extent=extent)
 
         # Case 1: no reference maps
         if maps is not None and ref_maps is None:

--- a/src/aqua_diagnostics/teleconnections/plot_nao.py
+++ b/src/aqua_diagnostics/teleconnections/plot_nao.py
@@ -84,14 +84,14 @@ class PlotNAO(PlotBaseMixin):
         fig = plt.figure(figsize=(11, 8.5))
         ax = fig.add_subplot(111, projection=proj)
 
-        theta = np.linspace(0, 2*np.pi, 100)
-        center, radius = [0.5, 0.5], 0.5
-        verts = np.vstack([np.sin(theta), np.cos(theta)]).T
-        circle = mpath.Path(verts * radius + center)
+        # Plot details
+        proj = NorthPolarStereo(central_longitude=-20.0)
+        extent = [-180, 180, 10, 90]
 
-        # Fix the axes with the circle
-        ax.set_boundary(circle, transform=ax.transAxes)
-        ax.set_extent(extent, crs=ccrs.PlateCarree())
+        fig = plt.figure(figsize=(11, 8.5))
+        ax = fig.add_subplot(111, projection=proj)
+
+        ax = apply_circular_boundary(ax, extent=extent)
 
         # Case 1: no reference maps
         if maps is not None and ref_maps is None:


### PR DESCRIPTION
## PR description:

This PR introduces the modularization of the function that enables switching the axes box from a square to a circular shape. This enhancement improves visualization for specific map projections where a circular domain is more appropriate, such as polar stereographic views.

## Issues closed by this pull request:

Close #2099 

----

 - [x] Docstrings are updated if needed.
