### PR TITLE
Add gridline option to plot_single_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v0.18.0): 
 
 AQUA core complete list:
+- `draw_manual_gridlines()` utility function to draw gridlines on cartopy maps (#2105)
 - `apply_circular_window()` utility function to apply a circular window to cartopy maps (#2100)
 
 ## [v0.17.0]

--- a/src/aqua/graphics/gridlines.py
+++ b/src/aqua/graphics/gridlines.py
@@ -1,0 +1,38 @@
+"""Module to handle gridlines in Cartopy maps"""
+import numpy as np
+import cartopy.crs as ccrs
+
+def draw_manual_gridlines(ax, lon_interval=30, lat_interval=30, 
+                          lon_range=(-180, 180), lat_range=(-90, 90),
+                          linestyle='--', color='gray', linewidth=1,
+                          alpha=0.5, zorder=50):
+    """
+    Draw manual gridlines over a Cartopy map using ax.plot, with full zorder control.
+
+    Args:
+        ax (GeoAxes): The Cartopy axis to draw on.
+        lon_interval (int): Interval for longitude lines (degrees).
+        lat_interval (int): Interval for latitude lines (degrees).
+        lon_range (tuple): Min/max longitudes to span.
+        lat_range (tuple): Min/max latitudes to span.
+        linestyle (str): Line style for gridlines.
+        color (str): Color of the gridlines.
+        linewidth (float): Width of the lines.
+        alpha (float): Opacity.
+        zorder (int): Z-order for rendering.
+    """
+    # Meridians (vertical lines)
+    lons = np.arange(lon_range[0], lon_range[1] + lon_interval, lon_interval)
+    lats = np.arange(lat_range[0], lat_range[1] + 1, 1)
+    for lon in lons:
+        ax.plot([lon] * len(lats), lats, transform=ccrs.PlateCarree(),
+                linestyle=linestyle, color=color, linewidth=linewidth,
+                alpha=alpha, zorder=zorder)
+
+    # Parallels (horizontal lines)
+    lats = np.arange(lat_range[0], lat_range[1] + lat_interval, lat_interval)
+    lons = np.arange(lon_range[0], lon_range[1] + 1, 1)
+    for lat in lats:
+        ax.plot(lons, [lat] * len(lons), transform=ccrs.PlateCarree(),
+                linestyle=linestyle, color=color, linewidth=linewidth,
+                alpha=alpha, zorder=zorder)

--- a/src/aqua/graphics/single_map.py
+++ b/src/aqua/graphics/single_map.py
@@ -15,14 +15,14 @@ import xarray as xr
 import healpy as hp
 from aqua.logger import log_configure
 from aqua.util import add_cyclic_lon, evaluate_colorbar_limits
-from aqua.util import healpix_resample, coord_names, set_ticks, ticks_round
+from aqua.util import healpix_resample, coord_names, set_ticks
 from aqua.util import cbar_get_label, set_map_title, generate_colorbar_ticks
-from aqua.exceptions import NoDataError
+from .gridlines import draw_manual_gridlines
 from .styles import ConfigStyle
 
 def plot_single_map(data: xr.DataArray,
-                    contour=True, sym=False,
-                    proj: ccrs.Projection = ccrs.Robinson(), gridlines=False,
+                    contour: bool = True, sym: bool = False,
+                    proj: ccrs.Projection = ccrs.Robinson(), gridlines: bool = False,
                     extent=None, coastlines=True,
                     style=None, figsize=(11, 8.5), nlevels=11,
                     vmin=None, vmax=None, cmap='RdBu_r',
@@ -38,6 +38,8 @@ def plot_single_map(data: xr.DataArray,
         data (xr.DataArray):         Data to plot.
         contour (bool, optional):    If True, plot a contour map, otherwise a pcolormesh. Defaults to True.
         sym (bool, optional):        If True, set the colorbar to be symmetrical. Defaults to False.
+        proj (cartopy.crs.Projection, optional): Projection to use. Defaults to ccrs.Robinson().
+        gridlines (bool, optional):  If True, add gridlines. Defaults to False
         extent (list, optional):     Extent of the map to limit the projection. Defaults to None.
         coastlines (bool, optional): If True, add coastlines. Defaults to True.
         style (str, optional):       Style to use. Defaults to None (aqua style).
@@ -214,40 +216,6 @@ def plot_single_map(data: xr.DataArray,
         logger.debug("Returning figure and axes")
         return fig, ax
 
-def draw_manual_gridlines(ax, lon_interval=30, lat_interval=30, 
-                          lon_range=(-180, 180), lat_range=(-90, 90),
-                          linestyle='--', color='gray', linewidth=1,
-                          alpha=0.5, zorder=50):
-    """
-    Draw manual gridlines over a Cartopy map using ax.plot, with full zorder control.
-
-    Args:
-        ax (GeoAxes): The Cartopy axis to draw on.
-        lon_interval (int): Interval for longitude lines (degrees).
-        lat_interval (int): Interval for latitude lines (degrees).
-        lon_range (tuple): Min/max longitudes to span.
-        lat_range (tuple): Min/max latitudes to span.
-        linestyle (str): Line style for gridlines.
-        color (str): Color of the gridlines.
-        linewidth (float): Width of the lines.
-        alpha (float): Opacity.
-        zorder (int): Z-order for rendering.
-    """
-    # Meridians (vertical lines)
-    lons = np.arange(lon_range[0], lon_range[1] + lon_interval, lon_interval)
-    lats = np.arange(lat_range[0], lat_range[1] + 1, 1)
-    for lon in lons:
-        ax.plot([lon] * len(lats), lats, transform=ccrs.PlateCarree(),
-                linestyle=linestyle, color=color, linewidth=linewidth,
-                alpha=alpha, zorder=zorder)
-
-    # Parallels (horizontal lines)
-    lats = np.arange(lat_range[0], lat_range[1] + lat_interval, lat_interval)
-    lons = np.arange(lon_range[0], lon_range[1] + 1, 1)
-    for lat in lats:
-        ax.plot(lons, [lat] * len(lons), transform=ccrs.PlateCarree(),
-                linestyle=linestyle, color=color, linewidth=linewidth,
-                alpha=alpha, zorder=zorder)
 
 def plot_single_map_diff(data: xr.DataArray, data_ref: xr.DataArray,
                          proj: ccrs.Projection = ccrs.Robinson(), extent: list = None,

--- a/src/aqua/graphics/single_map.py
+++ b/src/aqua/graphics/single_map.py
@@ -8,6 +8,7 @@ Contains the following functions:
 Author: Matteo Nurisso
 Date: Feb 2024
 """
+from typing import Optional
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,12 +24,12 @@ from .styles import ConfigStyle
 def plot_single_map(data: xr.DataArray,
                     contour: bool = True, sym: bool = False,
                     proj: ccrs.Projection = ccrs.Robinson(), gridlines: bool = False,
-                    extent=None, coastlines=True,
-                    style=None, figsize=(11, 8.5), nlevels=11,
-                    vmin=None, vmax=None, cmap='RdBu_r',
-                    cbar: bool = True, cbar_label=None,
-                    title=None, transform_first=False, cyclic_lon=True,
-                    fig: plt.Figure = None, ax: plt.Axes = None,
+                    extent: Optional[list] = None, coastlines: bool = True,
+                    style: Optional[str] = None, figsize: tuple = (11, 8.5), nlevels: int = 11,
+                    vmin: Optional[float] = None, vmax: Optional[float] = None, cmap: str = 'RdBu_r',
+                    cbar: bool = True, cbar_label: Optional[str] = None,
+                    title: Optional[str] = None, transform_first: bool = False, cyclic_lon: bool = True,
+                    fig: Optional[plt.Figure] = None, ax: Optional[plt.Axes] = None,
                     ax_pos: tuple = (1, 1, 1),
                     return_fig=False, loglevel='WARNING',  **kwargs):
     """
@@ -218,13 +219,13 @@ def plot_single_map(data: xr.DataArray,
 
 
 def plot_single_map_diff(data: xr.DataArray, data_ref: xr.DataArray,
-                         proj: ccrs.Projection = ccrs.Robinson(), extent: list = None,
-                         vmin_fill: float = None, vmax_fill: float = None,
-                         vmin_contour: float = None, vmax_contour: float = None,
+                         proj: ccrs.Projection = ccrs.Robinson(), extent: Optional[list] = None,
+                         vmin_fill: Optional[float] = None, vmax_fill: Optional[float] = None,
+                         vmin_contour: Optional[float] = None, vmax_contour: Optional[float] = None,
                          sym_contour: bool = False, sym: bool = True,
                          cyclic_lon: bool = True, return_fig: bool = False,
-                         fig: plt.Figure = None, ax: plt.Axes = None,
-                         title: str = None, loglevel: str = 'WARNING', **kwargs):
+                         fig: Optional[plt.Figure] = None, ax: Optional[plt.Axes] = None,
+                         title: Optional[str] = None, loglevel: str = 'WARNING', **kwargs):
     """
     Plot the difference of data-data_ref as map and add the data
     as a contour plot.

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -71,6 +71,7 @@ class TestMaps:
                                        dpi=100,
                                        nxticks=5,
                                        nyticks=5,
+                                       gridlines=True,
                                        loglevel=loglevel)
         assert fig is not None
         assert ax is not None


### PR DESCRIPTION
This PR aims to reintroduce gridlines in plot_single_map.py, with a focus on maximizing flexibility while maintaining a sensible approach given the potential visualization issues associated with different map projections. The original functionalities remain unchanged; this is simply an optional extension to enhance visualization capabilities.

## Issues closed by this pull request:

Close #2104 

----

 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
