### PR TITLE
Fix legacy seaice extent and volume diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ AQUA core complete list:
 - `Trender()` class provide also coefficients and normalize them (#1991)
 
 AQUA diagnostics complete list:
+- Sea-ice extent and volume: bugs related to use of legacy reader functionality (#2111)
 - Ocean Trends: Trends class to create trend data along with zonal trend, notebook and tests added. (#1990)
 - Global Biases: allow GlobalBias to take projection as argument (#2036)
 - ECmean: diagnostics refactored to use `OutputSaver` and new common configuration file (#2012)

--- a/diagnostics/seaice/seaice/seaice_class.py
+++ b/diagnostics/seaice/seaice/seaice_class.py
@@ -222,6 +222,9 @@ class SeaIceExtent:
            
                 myExtent.attrs["units"] = "million km^2"
                 myExtent.attrs["long_name"] = "Sea ice extent"
+
+                myExtent = myExtent.to_dataarray()
+
                 self.regionExtents.append(myExtent)
 
             # Save set of diagnostics for that setup
@@ -268,13 +271,13 @@ class SeaIceExtent:
                     self.logger.debug("Not plotting osisaf nh in the south and conversely")
                     pass
                 else:
-                    ax1[jr].plot(extent.time, extent, label=label, color=color_plot)
+                    ax1[jr].plot(extent.time, extent.squeeze(), label=label, color=color_plot)
                     ax2[jr].plot(monthsNumeric, extentCycle, label=label, lw=3, color=color_plot)
 
                     # Plot ribbon of uncertainty
                     if setup["model"] == "OSI-SAF":
                         mult = 2.0
-                        ax2[jr].fill_between(monthsNumeric, extentCycle - mult * extentStd, extentCycle + mult * extentStd,
+                        ax2[jr].fill_between(monthsNumeric, (extentCycle - mult * extentStd).flatten(), (extentCycle + mult * extentStd).flatten(),
                                              alpha=0.5, zorder=0, color=color_plot, lw=0)
 
                 ax1[jr].set_title("Sea ice extent: region " + region)
@@ -536,9 +539,11 @@ class SeaIceVolume:
 
                 myVolume = (sivol_mask * areacello.where(regionMask)).sel(time=slice(timespan[0], timespan[1])).sum(dim=spacecoord,
                                                                               skipna = True, min_count = 1) / 1e12
-                               
+               
                 myVolume.attrs["units"] = "thousands km^3"
                 myVolume.attrs["long_name"] = "Sea ice volume"
+
+                myVolume = myVolume.to_dataarray()
 
                 self.regionVolumes.append(myVolume)
 
@@ -584,13 +589,13 @@ class SeaIceVolume:
                     self.logger.debug("Not plotting PIOMAS in the SH and GIOMAS in the NH")
                     pass
                 else:
-                    ax1[jr].plot(volume.time, volume, label=label, color=color_plot)
+                    ax1[jr].plot(volume.time, volume.squeeze(), label=label, color=color_plot)
                     ax2[jr].plot(monthsNumeric, volumeCycle, label=label, lw=3, color=color_plot)
 
                     # Plot ribbon of uncertainty
                     if setup["model"] == "PSC":
                         mult = 2.0
-                        ax2[jr].fill_between(monthsNumeric, volumeCycle - mult * volumeStd, volumeCycle + mult * volumeStd,
+                        ax2[jr].fill_between(monthsNumeric, (volumeCycle - mult * volumeStd).flatten(), (volumeCycle + mult * volumeStd).flatten(),
                                              alpha=0.5, zorder=0, color=color_plot, lw=0)
 
                 ax1[jr].set_title("Sea ice volume: region " + region)

--- a/diagnostics/seaice/seaice/seaice_class.py
+++ b/diagnostics/seaice/seaice/seaice_class.py
@@ -159,8 +159,12 @@ class SeaIceExtent:
             if regrid:
                 self.logger.info("Regridding data")
                 data = reader.regrid(data)
+                areacello = reader.tgt_grid_area
+                spacecoord = reader.tgt_space_coord
+            else:
+                areacello = reader.src_grid_area
+                spacecoord = reader.src_space_coord
 
-            areacello = reader.grid_area
             try:
                 lat = data.coords["lat"]
                 lon = data.coords["lon"]
@@ -214,7 +218,7 @@ class SeaIceExtent:
                         & (lon <= lonE)
                     )
        
-                myExtent = areacello.where(regionMask).where(ci_mask.notnull()).sel(time=slice(timespan[0], timespan[1])).sum(skipna = True, min_count = 1, dim=reader.space_coord) / 1e12
+                myExtent = areacello.where(regionMask).where(ci_mask.notnull()).sel(time=slice(timespan[0], timespan[1])).sum(skipna = True, min_count = 1, dim=spacecoord) / 1e12
            
                 myExtent.attrs["units"] = "million km^2"
                 myExtent.attrs["long_name"] = "Sea ice extent"
@@ -475,8 +479,12 @@ class SeaIceVolume:
             if regrid:
                 self.logger.info("Regridding data")
                 data = reader.regrid(data)
+                areacello = reader.tgt_grid_area
+                spacecoord = reader.tgt_space_coord
+            else:
+                areacello = reader.src_grid_area
+                spacecoord = reader.src_space_coord
 
-            areacello = reader.grid_area
             try:
                 lat = data.coords["lat"]
                 lon = data.coords["lon"]
@@ -526,7 +534,7 @@ class SeaIceVolume:
                 sivol_mask = data.sivol.where((data.sivol > 0) &
                                         (data.sivol < 99.0))
 
-                myVolume = (sivol_mask * areacello.where(regionMask)).sel(time=slice(timespan[0], timespan[1])).sum(dim=reader.space_coord, 
+                myVolume = (sivol_mask * areacello.where(regionMask)).sel(time=slice(timespan[0], timespan[1])).sum(dim=spacecoord,
                                                                               skipna = True, min_count = 1) / 1e12
                                
                 myVolume.attrs["units"] = "thousands km^3"


### PR DESCRIPTION
## PR description:

This fixes the seaice volume and extend diagnostics which are currently failing as described in #2110
Indeed these diagnostics accumulated a quite impressive collection of bugs. The main one is their reference to a now not supported `grid_area` reader class property (we have only `src_grid_area` and `tgt_grid_area`). 
Then there were some issues with plotting and Dataset shapes (more mysterious where these come from)

Btw: I noticed that the reader initializes `grid_area` to Null but then never changes it again. Should we support it or remove it entirely?

## Issues closed by this pull request:

Close #2110 
Relevant for #2103 

----

 - [x] Changelog is updated.