### PR TITLE
Adjust seaice paths and other details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ AQUA core complete list:
 AQUA diagnostics complete list:
 - Boxplots: fix output dir (#2136) 
 - Boxplots: add tests and update docs (#2129)
-- Seaice: refactored `seaice` diagnostic with cli, relative `config_seaice.yaml` and `regions_definition.yaml` files. Add updated tests for the diagnostic. Introduce bias plot with custom projections. Extend some graphics functions features (e.g. `add_land` in `single_map.py` or fig,ax definition of `plot_seasonalcycle`  in `timeseries.py`). Enhance utils functions (e.g. `set_map_title`; add `merge_attrs` in `sci_util.py`). Add `int_month_name` in `time.py` and `strlist_to_phrase` for grammar-consistent descriptions (#1684)
+- Seaice: refactored `seaice` diagnostic with cli, relative `config_seaice.yaml` and `regions_definition.yaml` files. Add updated tests for the diagnostic. Introduce bias plot with custom projections. Extend some graphics functions features (e.g. `add_land` in `single_map.py` or fig,ax definition of `plot_seasonalcycle`  in `timeseries.py`). Enhance utils functions (e.g. `set_map_title`; add `merge_attrs` in `sci_util.py`). Add `int_month_name` in `time.py` and `strlist_to_phrase` for grammar-consistent descriptions (#1684, #2140)
 - Stratification: Stratification class to create density and mixed layer depth data, notebook and tests added. (#2093)
 - Radiation: complete refactor of the diagnostic, now based on the `Boxplots` diagnostic and the  `boxplot ` function in graphics (#2007)
 - SeasonalCycles: fix a bug which was preventing to plot when no reference data is provided (#2114)

--- a/config/diagnostics/seaice/config_seaice.yaml
+++ b/config/diagnostics/seaice/config_seaice.yaml
@@ -56,9 +56,9 @@ setup:
 output:
   outputdir: "./" # mandatory
   rebuild: true
-  save_netcdf: false # mandatory
-  save_pdf: false    # mandatory
-  save_png: false    # mandatory
+  save_netcdf: true # mandatory
+  save_pdf: true    # mandatory
+  save_png: true    # mandatory
   dpi: 300
 
 # =======  Config for timeseries Sea Ice  =======

--- a/src/aqua_diagnostics/core/util.py
+++ b/src/aqua_diagnostics/core/util.py
@@ -135,7 +135,6 @@ def load_diagnostic_config(diagnostic: str, config: str = None,
             get_diagnostic_configpath(diagnostic, loglevel), 
             default_config
         )
-    print(f"Using configuration file: {filename}")
 
     return load_yaml(filename)
 

--- a/src/aqua_diagnostics/seaice/cli_seaice.py
+++ b/src/aqua_diagnostics/seaice/cli_seaice.py
@@ -156,6 +156,7 @@ if __name__ == '__main__':
                                         startdate=reference.get('startdate', startdate), # Get specific start-end date for dataset if provided in config
                                         enddate=reference.get('enddate', enddate), 
                                         regrid=reference.get('regrid', None),
+                                        outputdir=outputdir,
                                         loglevel=config_dict['setup']['loglevel'])
 
                     if conf_dict_ts['calc_ref_std']:

--- a/src/aqua_diagnostics/seaice/cli_seaice.py
+++ b/src/aqua_diagnostics/seaice/cli_seaice.py
@@ -110,6 +110,7 @@ if __name__ == '__main__':
                                         startdate=dataset.get('startdate', None), 
                                         enddate=dataset.get('enddate', None), 
                                         regrid=dataset.get('regrid', None),
+                                        outputdir=outputdir,
                                         loglevel=config_dict['setup']['loglevel'])
 
                         monthly_mod[i] = seaice.compute_seaice(method=method, var=mod_var)
@@ -179,6 +180,8 @@ if __name__ == '__main__':
                              exp=datasets[0]['exp'], 
                              source=datasets[0]['source'],
                              loglevel=config_dict['setup']['loglevel'],
+                             outputdir=outputdir,
+                             rebuild=rebuild,
                              **plot_ts_seaice)
 
             psi.plot_seaice(plot_type='timeseries', save_pdf=False, save_png=True)
@@ -297,6 +300,8 @@ if __name__ == '__main__':
                              exp=datasets[0]['exp'], 
                              source=datasets[0]['source'],
                              loglevel=config_dict['setup']['loglevel'],
+                             outputdir=outputdir,
+                             rebuild=rebuild,
                              **plot_ts_seaice)
 
             psi.plot_seaice(plot_type='seasonal_cycle', save_pdf=False, save_png=True)
@@ -398,7 +403,7 @@ if __name__ == '__main__':
             psi = Plot2DSeaIce(ref=plot_bias_seaice.get('ref'),
                                models=plot_bias_seaice.get('models'),
                                regions_to_plot=longregs_indomain,
-                               outdir=outputdir,
+                               outputdir=outputdir,
                                rebuild=rebuild,
                                loglevel=config_dict['setup']['loglevel'])
 

--- a/src/aqua_diagnostics/seaice/cli_seaice.py
+++ b/src/aqua_diagnostics/seaice/cli_seaice.py
@@ -230,6 +230,7 @@ if __name__ == '__main__':
                                         startdate=dataset.get('startdate', None), 
                                         enddate=dataset.get('enddate', None), 
                                         regrid=dataset.get('regrid', None),
+                                        outputdir=outputdir,
                                         loglevel=config_dict['setup']['loglevel'])
 
                         monthly_mod[i] = seaice.compute_seaice(method=method, var=mod_var, 
@@ -276,6 +277,7 @@ if __name__ == '__main__':
                                         startdate=reference.get('startdate', startdate), # Get specific start-end date for reference if provided in config
                                         enddate=reference.get('enddate', enddate), 
                                         regrid=reference.get('regrid', None),
+                                        outputdir=outputdir,
                                         loglevel=config_dict['setup']['loglevel'])
 
                     if conf_dict_ts['calc_ref_std']:
@@ -345,6 +347,7 @@ if __name__ == '__main__':
                                     startdate=dataset.get('startdate', None), 
                                     enddate=dataset.get('enddate', None), 
                                     regrid=dataset.get('regrid', None),
+                                    outputdir=outputdir,
                                     loglevel=config_dict['setup']['loglevel'])
                     
                     # Compute 2D data for each region
@@ -386,6 +389,7 @@ if __name__ == '__main__':
                                         startdate=reference.get('startdate', startdate),
                                         enddate=reference.get('enddate', enddate),
                                         regrid=reference.get('regrid', None),
+                                        outputdir=outputdir,
                                         loglevel=config_dict['setup']['loglevel'])
 
                     clims_ref[i] = seaice_ref.compute_seaice(method=method, var=reference.get('varname'), stat='mean', freq='monthly')

--- a/src/aqua_diagnostics/seaice/cli_seaice.py
+++ b/src/aqua_diagnostics/seaice/cli_seaice.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
                              rebuild=rebuild,
                              **plot_ts_seaice)
 
-            psi.plot_seaice(plot_type='timeseries', save_pdf=False, save_png=True)
+            psi.plot_seaice(plot_type='timeseries', save_pdf=save_pdf, save_png=save_png)
 
     # ================ Sea Ice diagnostic - Seasonal Cycle ================
     # =====================================================================
@@ -307,7 +307,7 @@ if __name__ == '__main__':
                              rebuild=rebuild,
                              **plot_ts_seaice)
 
-            psi.plot_seaice(plot_type='seasonal_cycle', save_pdf=False, save_png=True)
+            psi.plot_seaice(plot_type='seasonal_cycle', save_pdf=save_pdf, save_png=save_png)
 
     # ================ Sea Ice diagnostic - 2D Bias Maps ================
     # ===================================================================
@@ -418,7 +418,7 @@ if __name__ == '__main__':
                                projkw=projkw,
                                plot_ref_contour= True if method == 'fraction' else False,
                                save_pdf=save_pdf, 
-                               save_png=True)
+                               save_png=save_png)
 
     close_cluster(client=client, cluster=cluster, private_cluster=private_cluster, loglevel=loglevel)
 

--- a/src/aqua_diagnostics/seaice/plot_2d_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_2d_seaice.py
@@ -4,7 +4,7 @@ import xarray as xr
 import cartopy.crs as ccrs
 import matplotlib.colors as mcolors
 from matplotlib import pyplot as plt
-from aqua.diagnostics.core import Diagnostic, OutputSaver
+from aqua.diagnostics.core import OutputSaver
 from aqua.graphics import plot_single_map, plot_single_map_diff, plot_maps
 from aqua.logger import log_configure, log_history
 from aqua.util import ConfigPath, get_projection, plot_box, to_list
@@ -23,7 +23,7 @@ class Plot2DSeaIce:
         models (list of xarray.DataArray or xarray.Dataset): List of models with sea ice data.
         regions_to_plot (list): List of strings with the region names to plot which must match 
                                 the 'AQUA_region' attribute in the data provided as input.
-        outdir (str): Output directory for saving plots.
+        outputdir (str): Output directory for saving plots.
         rebuild (bool): Whether to rebuild the plots if they already exist.
         dpi (int): Dots per inch for the saved figures.
         loglevel (str): Logging level for the logger. Default is 'WARNING'.
@@ -38,7 +38,7 @@ class Plot2DSeaIce:
     def __init__(self,
                  ref=None, models=None, 
                  regions_to_plot: list = ['Arctic', 'Antarctic'],
-                 outdir='./',
+                 outputdir='./',
                  rebuild=True,
                  dpi=300, 
                  loglevel='WARNING'):
@@ -54,7 +54,7 @@ class Plot2DSeaIce:
         if self.regions_to_plot is None:
             self._detect_common_regions([self.models, self.ref])
 
-        self.outdir  = outdir
+        self.outputdir = outputdir
         self.rebuild = rebuild
         self.dpi = dpi
 
@@ -578,7 +578,7 @@ class Plot2DSeaIce:
             exp=data.attrs.get('AQUA_exp',''),
             model_ref=data_ref.attrs.get('AQUA_model','') if data_ref is not None else None,
             exp_ref=data_ref.attrs.get('AQUA_exp','') if data_ref is not None else None,
-            outdir=self.outdir,
+            outdir=self.outputdir,
             loglevel=self.loglevel
         )
         metadata = {"Description": description}

--- a/src/aqua_diagnostics/seaice/plot_2d_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_2d_seaice.py
@@ -585,10 +585,10 @@ class Plot2DSeaIce:
 
         if format == 'pdf':
             outputsaver.save_pdf(fig, diagnostic_product=diagnostic_product,
-                                 extra_keys=extra_keys, metadata=metadata)
+                                 extra_keys=extra_keys, metadata=metadata, rebuild=self.rebuild)
         elif format == 'png':
             outputsaver.save_png(fig, diagnostic_product=diagnostic_product,
-                                 extra_keys=extra_keys, metadata=metadata)
+                                 extra_keys=extra_keys, metadata=metadata, rebuild=self.rebuild)
         else:
             raise ValueError(f'Format {format} not supported. Use png or pdf.')
 

--- a/src/aqua_diagnostics/seaice/plot_2d_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_2d_seaice.py
@@ -217,7 +217,7 @@ class Plot2DSeaIce:
             f"spanning from {monmod.attrs.get('AQUA_startdate', '')} to {monmod.attrs.get('AQUA_enddate', '')}. "
             f"The reference dataset is {monref.attrs.get('AQUA_model')} with experiment {monref.attrs.get('AQUA_exp')} "
             f"spanning from {monref.attrs.get('AQUA_startdate', '')} to {monref.attrs.get('AQUA_enddate', '')}. "
-            f"{'The red contour line represent the regional sea ice fraction equal to 0.2.' if self.method == 'fraction' else ''}"
+            f"{'The red contour line represents the regional sea ice fraction equal to 0.2.' if self.method == 'fraction' else ''}"
             )
         self._save_plots(fig=fig, data=monmod, data_ref=monref, diagnostic_product='bias', 
                          description=description, extra_keys={'method': self.method, 'region': region})

--- a/src/aqua_diagnostics/seaice/plot_2d_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_2d_seaice.py
@@ -357,7 +357,12 @@ class Plot2DSeaIce:
                           orientation=orientation, **cb_kwargs)
         cb.set_ticks(cbar_ticks)
         cb.ax.ticklabel_format(style='sci', axis='x', scilimits=(-3, 3))
-        cb.set_label(f"Sea ice {data.attrs.get('AQUA_method', '')} {data.attrs.get('units', '')}", fontsize=11)
+        units = data.attrs.get('units', '')
+        if units and not (units.startswith('[') and units.endswith(']')):
+            units = f'[{units}]'
+        if units:
+            units = ' ' + units
+        cb.set_label(f"Sea-ice {data.attrs.get('AQUA_method', '')}{units}", fontsize=11)
         return cb
 
     def _get_cmap(self, datarr):

--- a/src/aqua_diagnostics/seaice/plot_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_seaice.py
@@ -487,8 +487,8 @@ class PlotSeaIce:
                                                                                              ('PDF', save_pdf)] 
                                                                                              if flag)}")
             output_saver = OutputSaver(diagnostic='PlotSeaIce', catalog=self.catalog, model=self.model, exp=self.exp,
-                                        loglevel=self.loglevel, outdir=self.outputdir, rebuild=self.rebuild)
+                                        loglevel=self.loglevel, outdir=self.outputdir)
 
         product = f"seaice_{self.plot_type}_{self.method}_{'_'.join(region_dict.keys())}"
-        if save_pdf: output_saver.save_pdf(fig=fig, diagnostic_product=product, metadata=metadata)
-        if save_png: output_saver.save_png(fig=fig, diagnostic_product=product, metadata=metadata)
+        if save_pdf: output_saver.save_pdf(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)
+        if save_png: output_saver.save_png(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)

--- a/src/aqua_diagnostics/seaice/plot_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_seaice.py
@@ -489,6 +489,6 @@ class PlotSeaIce:
             output_saver = OutputSaver(diagnostic='PlotSeaIce', catalog=self.catalog, model=self.model, exp=self.exp,
                                         loglevel=self.loglevel, outdir=self.outputdir)
 
-        product = f"seaice_{self.plot_type}_{self.method}_{'_'.join(region_dict.keys())}"
-        if save_pdf: output_saver.save_pdf(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)
-        if save_png: output_saver.save_png(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)
+            product = f"seaice_{self.plot_type}_{self.method}_{'_'.join(region_dict.keys())}"
+            if save_pdf: output_saver.save_pdf(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)
+            if save_png: output_saver.save_png(fig=fig, diagnostic_product=product, metadata=metadata, rebuild=self.rebuild)

--- a/src/aqua_diagnostics/seaice/plot_seaice.py
+++ b/src/aqua_diagnostics/seaice/plot_seaice.py
@@ -3,10 +3,10 @@ import os
 import xarray as xr
 from matplotlib import pyplot as plt
 
-from aqua.diagnostics.core import Diagnostic
+from aqua.diagnostics.core import OutputSaver
 from aqua.exceptions import NoDataError, NotEnoughDataError
 from aqua.logger import log_configure, log_history
-from aqua.util import ConfigPath, OutputSaver
+from aqua.util import ConfigPath
 from aqua.graphics import plot_timeseries, plot_seasonalcycle
 from collections import defaultdict
 from .util import defaultdict_to_dict, extract_dates, _check_list_regions_type
@@ -21,7 +21,7 @@ class PlotSeaIce:
                  monthly_std_ref: str = None, annual_std_ref: str = None,
                  model: str = None, exp: str = None, source: str = None, catalog: str = None,
                  regions_to_plot: list = ['Arctic', 'Antarctic'], # this is a list of strings with the region names to plot
-                 outdir='./',
+                 outputdir='./',
                  rebuild=True,
                  filename_keys=None,  # List of keys to keep in the filename. Default is None, which includes all keys.
                  dpi=300, loglevel='WARNING'):
@@ -53,7 +53,7 @@ class PlotSeaIce:
             regions_to_plot (list, optional): 
                 List of region names to be plotted (e.g., `['arctic', 'antarctic']`). 
                 If None, all available regions are plotted. Defaults to None.
-            outdir (str, optional): 
+            outputdir (str, optional): 
                 Directory to save output plots. Defaults to './'.
             rebuild (bool, optional): 
                 Whether to rebuild (overwrite) figure outputs if they already exist. Defaults to True.
@@ -83,7 +83,7 @@ class PlotSeaIce:
                                                       monthly_std_ref=monthly_std_ref, 
                                                       annual_std_ref=annual_std_ref)
         # Output & saving settings
-        self.outdir  = outdir
+        self.outputdir = outputdir
         self.rebuild = rebuild
         self.dpi = dpi
     
@@ -487,8 +487,8 @@ class PlotSeaIce:
                                                                                              ('PDF', save_pdf)] 
                                                                                              if flag)}")
             output_saver = OutputSaver(diagnostic='PlotSeaIce', catalog=self.catalog, model=self.model, exp=self.exp,
-                                        diagnostic_product=f"seaice_{self.plot_type}_{self.method}_{'_'.join(region_dict.keys())}",
-                                        loglevel=self.loglevel, default_path=self.outdir, rebuild=self.rebuild)
+                                        loglevel=self.loglevel, outdir=self.outputdir, rebuild=self.rebuild)
 
-        if save_pdf: output_saver.save_pdf(fig=fig, path=self.outdir, metadata=metadata)
-        if save_png: output_saver.save_png(fig=fig, path=self.outdir, metadata=metadata)
+        product = f"seaice_{self.plot_type}_{self.method}_{'_'.join(region_dict.keys())}"
+        if save_pdf: output_saver.save_pdf(fig=fig, diagnostic_product=product, metadata=metadata)
+        if save_png: output_saver.save_png(fig=fig, diagnostic_product=product, metadata=metadata)

--- a/src/aqua_diagnostics/seaice/seaice.py
+++ b/src/aqua_diagnostics/seaice/seaice.py
@@ -245,7 +245,7 @@ class SeaIce(Diagnostic):
             masked_data_region = self._select_region(masked_data, region=region, diagnostic='seaice').get('data')
 
             if self.method in ['fraction','thickness']:
-                seaice_2d_result = self._calc_time_stat(masked_data_region, stat, freq)
+                seaice_2d_result = self._calc_time_stat(masked_data_region, stat=stat, freq=freq)
             else:
                 raise ValueError(f"Method '{self.method}' is not supported for 2D computation.")
 

--- a/src/aqua_diagnostics/seaice/seaice.py
+++ b/src/aqua_diagnostics/seaice/seaice.py
@@ -27,8 +27,9 @@ class SeaIce(Diagnostic):
         std_enddate   (str, optional): End date for standard deviation.
         regions     (list, optional): A list of regions to analyze. Default is ['arctic', 'antarctic'].
         regions_file (str, optional): The path to the regions definition file.
-        loglevel     (str, optional): The logging level. Default is 'WARNING'.
+        outputdir (str, optional): The output directory.
         regions_definition (dict): The loaded regions definition from the YAML file.
+        loglevel     (str, optional): The logging level. Default is 'WARNING'.
 
     Methods:
         load_regions(regions_file=None, regions=None):
@@ -53,9 +54,11 @@ class SeaIce(Diagnostic):
                  threshold=0.15,
                  regions=['arctic', 'antarctic'],
                  regions_file=None,
+                 outputdir: str = './',
                  loglevel: str = 'WARNING'
                  ):
 
+        self.outputdir = outputdir
         super().__init__(model=model, exp=exp, source=source,
                          regrid=regrid, catalog=catalog, 
                          startdate=startdate, enddate=enddate,
@@ -494,7 +497,7 @@ class SeaIce(Diagnostic):
 
     def save_netcdf(self, seaice_data, diagnostic: str, diagnostic_product: str = None,
                     rebuild: bool = True, output_file: str = None,
-                    output_dir: str = None, **kwargs):
+                    **kwargs):
         """ Save the computed sea ice data to a NetCDF file.
 
         Args:
@@ -503,9 +506,8 @@ class SeaIce(Diagnostic):
             diagnostic_product (str, optional): The diagnostic product. Can be used for namig the file more freely.
             rebuild (bool, optional): If True, rebuild (overwrite) the NetCDF file. Default is True.
             output_file (str, optional): The output file name.
-            output_dir (str, optional): The output directory.
             **kwargs: Additional keyword arguments for saving the data.
         """
         # Use parent method to handle saving, including metadata
         super().save_netcdf(seaice_data, diagnostic=diagnostic, diagnostic_product=diagnostic_product,
-                            rebuild=rebuild, **kwargs)
+                            outdir=self.outputdir, rebuild=rebuild, **kwargs)

--- a/tests/seaice/test_plot_2d_seaice.py
+++ b/tests/seaice/test_plot_2d_seaice.py
@@ -228,7 +228,7 @@ class TestPlot2DSeaIce:
     def test_plot_saves_outputs(self):
         p2d = Plot2DSeaIce(ref=[self.frac_ref_antarctic, self.frac_ref_arctic],
                            models=self.frac_model, 
-                           outdir=self.tmp_path, loglevel="INFO")
+                           outputdir=self.tmp_path, loglevel="INFO")
 
         p2d.plot_2d_seaice(plot_type="var", projkw=self.projkw, 
                            save_pdf=True, save_png=True, months=[3])

--- a/tests/seaice/test_plot_seaice.py
+++ b/tests/seaice/test_plot_seaice.py
@@ -3,7 +3,7 @@ import os, glob
 import numpy as np
 import xarray as xr
 from aqua.diagnostics import SeaIce, PlotSeaIce
-from aqua.util import OutputSaver
+from aqua.diagnostics.core import OutputSaver
 
 approx_rel = 1e-4
 loglevel = 'DEBUG'
@@ -227,7 +227,7 @@ class TestPlotSeaIce:
                          regions_to_plot=['Arctic', 'Antarctic'],
                          model=self.model, exp=self.exp, source=self.source,
                          catalog=self.catalog, loglevel=self.loglevel,
-                         outdir=self.tmp_path)
+                         outputdir=self.tmp_path)
 
         psi.plot_seaice(plot_type='timeseries', save_pdf=True, save_png=True)
 


### PR DESCRIPTION
## PR description:

This is an attempt to fix the output paths for the new seaice diagnostic.
Notice that the diagnostic was using the wrong `OutputSaver`  (the one in `aqua.util` instead of the one in `aqua.diagnostics.core`).
 
## Issues closed by this pull request:
Close #2138 

----

 - [x] Changelog is updated.