### PR TITLE
fldstat fix for radiation timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Workflow modifications:
 
 AQUA core complete list:
 
+- Fix fldstat coordinate treatment (#2147)
 - Update aqua-analysis config for refactored diagnostics (#2144)
 - Fixed incompatible coordinate transformatiosn (#2137)
 - Added Nord4 support in the `load-aqua-container.sh` script (#2130)

--- a/src/aqua/fldstat/fldstat.py
+++ b/src/aqua/fldstat/fldstat.py
@@ -5,7 +5,7 @@ import numpy as np
 from smmregrid import GridInspector
 
 from aqua.logger import log_configure, log_history
-from aqua.util import area_selection
+from aqua.util import area_selection, to_list
 
 
 class FldStat():
@@ -171,12 +171,12 @@ class FldStat():
 
         # area.coords should be only lon-lat
         for coord in self.area.coords:
-            if coord in data.coords:
+            if coord in data.coords and coord != "time":
                 area_coord = self.area[coord]
                 data_coord = data[coord]
 
                 # verify coordinates has the same sizes
-                if len(area_coord) != len(data_coord):
+                if len(to_list(area_coord)) != len(to_list(data_coord)):
                     raise ValueError(f"{coord} has a mismatch in length!")
 
                 # Fast check if coordinates are already aligned


### PR DESCRIPTION
## PR description:

This is a simpler patch for fldstat addressing the problem in #2120. The real problem is that for some reason we encounter a grid area file which has an additional singleton 'time' coordinate, so the coordinates in `align_area_coordinates()` are not only lon and lat as expected. In a more general refactor we may wish to make this more robust, but for now this works and diagnostic radiation-timeseries works. 
The alternative which I discussed in #2120 (dropping coordinates which are not also dimensions when reading the grid areas) also works but I am not sure if it may not fail in some more general cases ... so I would stick with this simpler patch for now.

## Issues closed by this pull request:

Close #2120 
Close #2103

----

 - [x] Changelog is updated.
 