### PR TITLE
Show a logging error instead a raise for empty data reader retrival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Workflow modifications:
 - `aqua-analysis.py` is now an entry point `aqua analysis` in the AQUA console, with the same syntax as before.
 
 AQUA core complete list:
+- Show error message if empty data are retrieved by in `reader` (#2170)
 - Few graphical adjustments in multiple_maps (#2159)
 - Fix fldstat coordinate treatment (#2147)
 - Fixer applied when units name changes is required and no factor is found (#2128)

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -375,10 +375,12 @@ class Reader():
         else:
             if data is None or len(data.data_vars) == 0:
                 self.logger.error(f"Retrieved empty dataset for {var=}. First, check its existence in the data catalog.")
-                return None
 
-            if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
-                data = data.sel(time=slice(startdate, enddate))
+            if 'time' in data.coords:
+                if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
+                    data = data.sel(time=slice(startdate, enddate))
+            else:
+                self.logger.debug(f"Variable {var} has no time coordinate, skipping time selection.")
 
         if isinstance(data, xr.Dataset):
             data.aqua.set_default(self)  # This links the dataset accessor to this instance of the Reader class

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -377,7 +377,7 @@ class Reader():
                 self.logger.error(f"Retrieved empty dataset for {var=}. First, check its existence in the data catalog.")
 
             if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
-                    data = data.sel(time=slice(startdate, enddate))
+                data = data.sel(time=slice(startdate, enddate))
 
         if isinstance(data, xr.Dataset):
             data.aqua.set_default(self)  # This links the dataset accessor to this instance of the Reader class

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -374,7 +374,8 @@ class Reader():
             data = self.streamer.stream(data)
         else:
             if data is None or len(data.data_vars) == 0:
-                raise NoDataError("Retrieved empty dataset. Check varname used as first step.")
+                self.logger.error("Retrieved empty dataset. Check varname used as first step.")
+                return None
 
             if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
                 data = data.sel(time=slice(startdate, enddate))

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -374,7 +374,7 @@ class Reader():
             data = self.streamer.stream(data)
         else:
             if data is None or len(data.data_vars) == 0:
-                self.logger.error("Retrieved empty dataset. Check varname used as first step.")
+                self.logger.error(f"Retrieved empty dataset for {var=}. First, check its existence in the data catalog.")
                 return None
 
             if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)

--- a/src/aqua/reader/reader.py
+++ b/src/aqua/reader/reader.py
@@ -376,11 +376,8 @@ class Reader():
             if data is None or len(data.data_vars) == 0:
                 self.logger.error(f"Retrieved empty dataset for {var=}. First, check its existence in the data catalog.")
 
-            if 'time' in data.coords:
-                if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
+            if startdate and enddate and not ffdb:  # do not select if data come from FDB (already done)
                     data = data.sel(time=slice(startdate, enddate))
-            else:
-                self.logger.debug(f"Variable {var} has no time coordinate, skipping time selection.")
 
         if isinstance(data, xr.Dataset):
             data.aqua.set_default(self)  # This links the dataset accessor to this instance of the Reader class

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -130,6 +130,10 @@ class Diagnostic():
 
         data = reader.retrieve(var=var)
 
+        if hasattr(data, 'data_vars') and len(data.data_vars) == 0:
+            logger = log_configure(log_name='Diagnostic_reader', log_level=loglevel)
+            logger.error(f"Variable '{var}' contains no data for {model} {exp} {source}.")
+
         # If the data is empty, raise an error
         if not data:
             raise ValueError(f"No data found for {model} {exp} {source} with variable {var}")

--- a/src/aqua_diagnostics/core/diagnostic.py
+++ b/src/aqua_diagnostics/core/diagnostic.py
@@ -130,10 +130,6 @@ class Diagnostic():
 
         data = reader.retrieve(var=var)
 
-        if hasattr(data, 'data_vars') and len(data.data_vars) == 0:
-            logger = log_configure(log_name='Diagnostic_reader', log_level=loglevel)
-            logger.error(f"Variable '{var}' contains no data for {model} {exp} {source}.")
-
         # If the data is empty, raise an error
         if not data:
             raise ValueError(f"No data found for {model} {exp} {source} with variable {var}")

--- a/tests/seaice/test_seaice.py
+++ b/tests/seaice/test_seaice.py
@@ -33,12 +33,12 @@ class TestSeaIce:
 
         # Invalid cases (Errors expected)
         ('wrong_method', 'antarctic',   None, None, 'siconc',   None, ValueError, "Invalid method"),
-        ('extent',       'weddell_sea', None, None, 'errorvar', None, (KeyError, NoDataError),   None),
-        ('volume',       'antarctic',   None, None, 'errorvar', None, (KeyError, NoDataError),   None),
+        ('extent',       'weddell_sea', None, None, 'errorvar', None, ValueError,   None),
+        ('volume',       'antarctic',   None, None, 'errorvar', None, ValueError,   None),
 
         # Invalid standard deviation cases
-        ('extent', 'weddell_sea', None, None, 'errorvar', None, (KeyError, NoDataError), None),
-        ('volume', 'antarctic',   None, None, 'errorvar', None, (KeyError, NoDataError), None)
+        ('extent', 'weddell_sea', None, None, 'errorvar', None, ValueError, None),
+        ('volume', 'antarctic',   None, None, 'errorvar', None, ValueError, None)
         ]
     )
     def test_seaice_compute_with_std(self, method, region, value, expected_units, variable,

--- a/tests/seaice/test_seaice.py
+++ b/tests/seaice/test_seaice.py
@@ -171,7 +171,3 @@ class TestSeaIce:
         meanres = result_data.mean(skipna=True).values
 
         assert meanres == pytest.approx(value, rel=approx_rel, abs=abs_rel)
-
-
-
-

--- a/tests/seaice/test_seaice.py
+++ b/tests/seaice/test_seaice.py
@@ -33,12 +33,12 @@ class TestSeaIce:
 
         # Invalid cases (Errors expected)
         ('wrong_method', 'antarctic',   None, None, 'siconc',   None, ValueError, "Invalid method"),
-        ('extent',       'weddell_sea', None, None, 'errorvar', None, ValueError,   None),
-        ('volume',       'antarctic',   None, None, 'errorvar', None, ValueError,   None),
+        ('extent',       'weddell_sea', None, None, 'errorvar', None, KeyError,   None),
+        ('volume',       'antarctic',   None, None, 'errorvar', None, KeyError,   None),
 
         # Invalid standard deviation cases
-        ('extent', 'weddell_sea', None, None, 'errorvar', None, ValueError, None),
-        ('volume', 'antarctic',   None, None, 'errorvar', None, ValueError, None)
+        ('extent', 'weddell_sea', None, None, 'errorvar', None, KeyError, None),
+        ('volume', 'antarctic',   None, None, 'errorvar', None, KeyError, None)
         ]
     )
     def test_seaice_compute_with_std(self, method, region, value, expected_units, variable,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,10 +90,10 @@ class TestAqua:
 
     def test_empty_dataset_error(self, reader_instance):
         """
-        Test that NoDataError is raised when empty dataset is retrieved
+        Test that None is returned when empty dataset is retrieved
         """
-        with pytest.raises(Exception):
-            reader_instance.retrieve(var="nonexistent_variable")
+        result = reader_instance.retrieve(var="nonexistent_variable")
+        assert result is None
 
     def test_time_selection_with_dates(self, reader_instance):
         """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,10 +90,11 @@ class TestAqua:
 
     def test_empty_dataset_error(self, reader_instance):
         """
-        Test that None is returned when empty dataset is retrieved
+        Test that an empty dataset is returned when nonexistent variable is retrieved
+        Check that we get an empty dataset (not None)
         """
         result = reader_instance.retrieve(var="nonexistent_variable")
-        assert result is None
+        assert len(result.data_vars) == 0
 
     def test_time_selection_with_dates(self, reader_instance):
         """


### PR DESCRIPTION
Fix: change #2141 by partially reverting the changes done. Using a `error` logging insead a `raise`.

## Issues closed by this pull request:

Close #2168 
