### PR TITLE
Areas should be a dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Workflow modifications:
 - `aqua-analysis.py` is now an entry point `aqua analysis` in the AQUA console, with the same syntax as before.
 
 AQUA core complete list:
+- Fix loaded areas as dataset (#2174)
 - Fix fldstat coordinate treatment (#2147)
 - Fixer applied when units name changes is required and no factor is found (#2128)
 - Update aqua-analysis config for refactored diagnostics (#2144)

--- a/src/aqua/regridder/regridder.py
+++ b/src/aqua/regridder/regridder.py
@@ -275,7 +275,7 @@ class Regridder():
                              cellareas_var, cellareas)
             if not os.path.exists(cellareas):
                 raise FileNotFoundError(f"Grid based cell area  file {cellareas} not found.")
-            return xr.open_mfdataset(cellareas)[cellareas_var].rename("cell_area").squeeze()
+            return xr.open_mfdataset(cellareas)[cellareas_var].rename("cell_area").squeeze().to_dataset()
 
         # clean if necessary
         if os.path.exists(area_filename):


### PR DESCRIPTION
## PR description:

This solves a  problem which may arise  when a cellarea file is provided. Method `_generate_area()` in the Regridder class will then return a Dataarray, but actually our default is to have areas as Datasets (smmregrid returns datasets): at line 196 of `reader.py` we have `cell_area = self.src_grid_area.cell_area if areas else None` ... so that would fail if `self.src_grid_area` is a Dataarray.

----

 - [x] Changelog is updated.