### PR TITLE
Source_oce option also for aqua analysis

### DIFF
--- a/config/analysis/config.aqua-analysis.yaml
+++ b/config/analysis/config.aqua-analysis.yaml
@@ -119,6 +119,7 @@ diagnostics:
     script_path: "ecmean/cli_ecmean.py"
     nworkers: 4
     nocluster: true  # ECmean does not use the global dask cluster
+    source_oce: true  # if a --source_oce argument was passed use it
     config: "${AQUA_CONFIG}/diagnostics/ecmean/config_ecmean_cli.yaml"
   ocean3d_drift:
     script_path: "../../diagnostics/ocean3d/cli/cli_ocean3d.py"

--- a/docs/sphinx/source/aqua-analysis.rst
+++ b/docs/sphinx/source/aqua-analysis.rst
@@ -51,6 +51,10 @@ so that the script can be used in a batch job or in a workflow. These override c
 
     The source to use.
 
+.. option:: --source_oce <source_oce>
+
+    Additional ocean source to use for diagnostics accepting it (currently only ECmean).
+
 .. option:: -f <config>, --config <source>
 
     The config file to use.
@@ -157,5 +161,7 @@ The diagnostics are specified as a dictionary with the following keys:
 - ``nworkers``: the number of workers to use for this diagnostic.
 - ``script_path``: the relative path to the diagnostic script with respect to ``script_path_base``. 
 - ``config``: the configuration file for the diagnostic.
+- ``nocluster``: a boolean flag to disable the use of the global dask cluster for this diagnostic (used by ECmean)
+- ``source_oce``: a boolean flag to pass the additional ocean source to the diagnostic (currently only ECmean). Defaults to False.
 - ``extra``: a string with extra arguments to pass to the diagnostic script.
 - ``outname``: the name of the output folder if different from the diagnostic name.

--- a/src/aqua/analysis/analysis.py
+++ b/src/aqua/analysis/analysis.py
@@ -68,7 +68,7 @@ def run_diagnostic(diagnostic: str, script_path: str, extra_args: str,
 
 def run_diagnostic_func(diagnostic: str, parallel: bool = False, regrid: str = None,
                         config=None, catalog=None, model='default_model', exp='default_exp',
-                        source='default_source', realization=None,
+                        source='default_source', source_oce=None, realization=None,
                         output_dir='./output', loglevel='INFO',
                         logger=None, aqua_path='', cluster=None):
     """
@@ -83,6 +83,7 @@ def run_diagnostic_func(diagnostic: str, parallel: bool = False, regrid: str = N
         model (str): Model name.
         exp (str): Experiment name.
         source (str): Source name.
+        source_oce (str): Extra source name for ocean data when both are needed.
         realization (str): Realization name. Defaults to None.
         output_dir (str): Directory to save output.
         loglevel (str): Log level for the diagnostic.
@@ -126,6 +127,9 @@ def run_diagnostic_func(diagnostic: str, parallel: bool = False, regrid: str = N
 
     if realization:
         extra_args += f" --realization {realization}"
+
+    if diagnostic_config.get('source_oce', False) and source_oce:  # pass source_oce only if allowed by the diagnostic config file
+        extra_args += f" --source_oce {source_oce}"
 
     outname = f"{output_dir}/{diagnostic_config.get('outname', diagnostic)}"
     args = f"--model {model} --exp {exp} --source {source} --outputdir {outname} {extra_args}"

--- a/src/aqua/cli/analysis.py
+++ b/src/aqua/cli/analysis.py
@@ -26,6 +26,7 @@ def analysis_parser(parser=None):
     parser.add_argument("-m", "--model", type=str, help="Model (atmospheric and oceanic)")
     parser.add_argument("-e", "--exp", type=str, help="Experiment")
     parser.add_argument("-s", "--source", type=str, help="Source")
+    parser.add_argument("--source_oce", type=str, help="Extra source for oceanic data when --source is used for atmospheric data and both are needed")
     parser.add_argument("--realization", type=str, default=None, help="Realization (default: None)")
     parser.add_argument("-d", "--outputdir", type=str, help="Output directory")
     parser.add_argument("-f", "--config", type=str, required=False, default=None,
@@ -59,6 +60,7 @@ def analysis_execute(args):
     model = args.model or config.get('job', {}).get('model')
     exp = args.exp or config.get('job', {}).get('exp')
     source = args.source or config.get('job', {}).get('source', 'lra-r100-monthly')
+    source_oce = args.source_oce or config.get('job', {}).get('source_oce', None)
     realization = args.realization if args.realization else config.get('job', {}).get('realization', None)
     # We get regrid option and then we set it to None if it is False
     # This avoids to add the --regrid argument to the command line
@@ -71,7 +73,7 @@ def analysis_execute(args):
         logger.error("Model, experiment, and source must be specified either in config or as command-line arguments.")
         sys.exit(1)
     else:
-        logger.info(f"Requested experiment: Model = {model}, Experiment = {exp}, Source = {source}.")
+        logger.info(f"Requested experiment: Model = {model}, Experiment = {exp}, Source = {source}. Source_oce = {source_oce}")
 
     catalog = args.catalog or config.get('job', {}).get('catalog')
     if catalog:
@@ -159,6 +161,7 @@ def analysis_execute(args):
                 model=model,
                 exp=exp,
                 source=source,
+                source_oce=source_oce,
                 realization=realization,
                 regrid=regrid,
                 output_dir=output_dir,


### PR DESCRIPTION
## PR description:

The ECmean diagnostic has a `--source_oce` option to specify a second extra source  just for ocean data since this may be different from the source for atmospheric data. The problem is that, so far, `aqua analysis` did not support this option, so it was impossible to specify it in a script. This PR introduces two changes:
1) a `--source_oce SOURCENAME` option for `aqua analysis`.
2) This option is passed to a diagnostic only if it has a `source_oce = true` flag in the aqua analysis config file
3) the ECmean entry in `config.aqua-analysis.yaml` now has this option set to true, so that the option is passed to ECmean (if and only if specified on the command line of aqua anlysis)

----

 - [ ] Documentation is included if a new feature is included.
 - [ ] Changelog is updated.
 
