### PR TITLE
[TimeSeries] Add missing center time option to seasonalcycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ AQUA core complete list:
 - `apply_circular_window()` utility function to apply a circular window to cartopy maps (#2100)
 
 AQUA diagnostics complete list:
+- Add missing center time option to seasonalcycles (#2247)
 - Teleconnections: adapted MJO to the new Hovmoller graphical function (#1969)
 - Ocean Drift: Hovmoller multiplot class and complete diagnostic cli (#1969)
 - Diagnostic core: Locking of catalog yaml when modified (#2238)

--- a/config/diagnostics/radiation/config_radiation-timeseries.yaml
+++ b/config/diagnostics/radiation/config_radiation-timeseries.yaml
@@ -35,6 +35,7 @@ diagnostics:
     diagnostic_name: 'radiation'
     variables: ['tnlwrf', 'tnswrf']
     formulae: ['tnlwrf+tnswrf']
+    center_time: true
     params:
       default:
         hourly: False

--- a/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
+++ b/config/diagnostics/timeseries/config_seasonalcycles_atm.yaml
@@ -45,6 +45,7 @@ diagnostics:
                  'tnlwrf', #Mean top net long-wave radiation flux
                  'tnswrf' #Mean top net short-wave radiation flux
                  ]
+    center_time: true
     params:
       default:
         std_startdate: '19900101'

--- a/src/aqua_diagnostics/timeseries/cli_timeseries.py
+++ b/src/aqua_diagnostics/timeseries/cli_timeseries.py
@@ -228,6 +228,7 @@ if __name__ == '__main__':
             logger.info("SeasonalCycles diagnostic is enabled.")
 
             diagnostic_name = config_dict['diagnostics']['seasonalcycles'].get('diagnostic_name', 'seasonalcycles')
+            center_time = config_dict['diagnostics']['seasonalcycles'].get('center_time', True)
 
             for var in config_dict['diagnostics']['seasonalcycles'].get('variables', []):
                 try:
@@ -240,7 +241,8 @@ if __name__ == '__main__':
                         init_args = {'region': region, 'loglevel': loglevel, 'diagnostic_name': diagnostic_name}
                         run_args = {'var': var, 'formula': False, 'long_name': var_config.get('long_name'),
                                     'units': var_config.get('units'), 'short_name': var_config.get('short_name'),
-                                    'outputdir': outputdir, 'rebuild': rebuild, 'reader_kwargs': reader_kwargs}
+                                    'outputdir': outputdir, 'rebuild': rebuild, 'center_time': center_time,
+                                    'reader_kwargs': reader_kwargs}
 
                         # Initialize a list of len from the number of datasets
                         sc = [None] * len(config_dict['datasets'])


### PR DESCRIPTION
## PR description:

The seasonalcycles diagnostic was not reading and passing the `center_time` option from the cli and this fixes that. 
Added explicit `center_time` keys also to the seasonal cycles and radiation config files which were missing it (completing #2028)

Linked to #2011

----

 - [x] Changelog is updated.
 