### PR TITLE
Update Gregory and oceanic timeseries to use BERKELEY-EARTH and ESA-CCI 

### DIFF
--- a/config/diagnostics/timeseries/config_timeseries_atm.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_atm.yaml
@@ -75,5 +75,5 @@ diagnostics:
     std_startdate: '19900101'
     std_enddate: '20201231'
     # Gregory needs 2 datasets and do not care about the references block above
-    t2m_ref: {'catalog': 'obs', 'model': 'ERA5', 'exp': 'era5', 'source': 'monthly'}
+    t2m_ref: {'catalog': 'obs', 'model': 'BERKELEY-EARTH', 'exp': 'aqua-filled', 'source': 'r100-monthly'}
     net_toa_ref: {'catalog': 'obs', 'model': 'CERES', 'exp': 'ebaf-toa42', 'source': 'monthly'}

--- a/config/diagnostics/timeseries/config_timeseries_oce.yaml
+++ b/config/diagnostics/timeseries/config_timeseries_oce.yaml
@@ -17,9 +17,9 @@ datasets:
 
 references:
   - catalog: 'obs'
-    model: 'ERA5'
-    exp: 'era5'
-    source: 'monthly'
+    model: 'ESA-CCI-L4'
+    exp: 'v3.0.1'
+    source: 'r100-monthly'
     regrid: null
 
 output:


### PR DESCRIPTION
## PR description:

As per title, this updates the configuration files to make use of two new datasets. 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated. 
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
 - [ ] Diagnostic config files path are updated in the console if needed
