### PR TITLE
Fix Radiation and Global Biases config file location in .aqua

### DIFF
--- a/src/aqua/cli/diagnostic_config.py
+++ b/src/aqua/cli/diagnostic_config.py
@@ -3,7 +3,7 @@ diagnostic_config = {
         {
             'config_file': 'config_global_biases.yaml',
             'source_path': 'config/diagnostics/global_biases',
-            'target_path': 'diagnostics/global_biases/cli'
+            'target_path': 'diagnostics/global_biases'
         },
     ],
     'lat_lon_profiles': [
@@ -103,17 +103,17 @@ diagnostic_config = {
         {
             'config_file': 'config_radiation-boxplots.yaml',
             'source_path': 'config/diagnostics/radiation',
-            'target_path': 'diagnostics/radiation/cli'
+            'target_path': 'diagnostics/radiation'
         },
         {
             'config_file': 'config_radiation-biases.yaml',
             'source_path': 'config/diagnostics/radiation',
-            'target_path': 'diagnostics/radiation/cli'
+            'target_path': 'diagnostics/radiation'
         },
         {
             'config_file': 'config_radiation-timeseries.yaml',
             'source_path': 'config/diagnostics/radiation',
-            'target_path': 'diagnostics/radiation/cli'
+            'target_path': 'diagnostics/radiation'
         },
     ],
     'seaice': [


### PR DESCRIPTION
## PR description:
Fix Radiation and Global Biases config file location in .aqua: remove cli subdir


## Issues closed by this pull request:

Close #2281

## People involved:

Tag here relevant people to involve in the discussion:

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.
 - [ ] Changelog is updated.
