### PR TITLE
pin xarray version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "smmregrid==0.1.3",
     #"smmregrid @ git+https://github.com/jhardenberg/smmregrid.git",
     "sparse",
-    "xarray>=2025.01.2", # Version 2025.01.2 is the first version introducing the CFDatetimeCoder
+    "xarray>=2025.01.2,<2025.09.1", # Version 2025.01.2 is the first version introducing the CFDatetimeCoder
     "kerchunk",
     "h5py>=3.12.1", #specific github pin to avoid installation of binaries
     "fastparquet",


### PR DESCRIPTION
## PR description:

Some of the issue described in #2302 seems related to a change in the `map` behaviour which breaks `smmregrid`. Temporarily pinning xarray to go over this. Not sure this will address also the bigger issue with CDO. 

## Issues closed by this pull request:

Close #issue_number

## People involved:

Tag here relevant people to involve in the discussion:

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated. 
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. 
 - [ ] Diagnostic config files path are updated in the console if needed
