### PR TITLE
Speedup tropical rainfall by a factor of 30

### DIFF
--- a/diagnostics/tropical_rainfall/cli/src/tropical_rainfall_cli_class.py
+++ b/diagnostics/tropical_rainfall/cli/src/tropical_rainfall_cli_class.py
@@ -298,15 +298,26 @@ class Tropical_Rainfall_CLI:
         hist_path = f"{self.path_to_netcdf}histograms/"
         hist_buffer_path = f"{self.path_to_buffer}{self.regrid}/{self.freq}/histograms/"
         bins_info = self.diag.get_bins_info()
-        model_merged = self.diag.merge_list_of_histograms(
-            path_to_histograms=hist_buffer_path,
+
+        filename = self.diag.dataset_to_netcdf_filename(
             start_year=self.s_year, end_year=self.f_year,
-            start_month=self.s_month, end_month=self.f_month, flag=bins_info
-        )
-        self.diag.dataset_to_netcdf(
-            model_merged, path_to_netcdf=hist_path,
+            start_month=self.s_month, end_month=self.f_month,
+            path_to_netcdf=hist_path,
             name_of_file=f'histogram_{self.model}_{self.exp}_{self.regrid}_{self.freq}'
         )
+        if os.path.exists(filename) and not self.rebuild_output:
+            self.logger.debug("File %s already exists, loading ...", filename)
+            model_merged = xr.open_dataset(filename)
+        else:
+            model_merged = self.diag.merge_list_of_histograms(
+                path_to_histograms=hist_buffer_path,
+                start_year=self.s_year, end_year=self.f_year,
+                start_month=self.s_month, end_month=self.f_month, flag=bins_info
+            )
+            self.diag.dataset_to_netcdf(
+                model_merged, path_to_netcdf=hist_path,
+                name_of_file=f'histogram_{self.model}_{self.exp}_{self.regrid}_{self.freq}'
+            )
 
         # Define sources with a loop for flexibility
         sources = {
@@ -319,13 +330,23 @@ class Tropical_Rainfall_CLI:
         for name, source in sources.items():
             # Add 'name' key to the source dictionary
             source['name'] = name
-            merged_data = self.get_merged_histogram_for_source(source)
-            if merged_data is not None:
-                merged_data_sources[name] = merged_data
-                self.diag.dataset_to_netcdf(
-                    merged_data, path_to_netcdf=hist_path,
+
+            filename = self.diag.dataset_to_netcdf_filename(
+                    path_to_netcdf=hist_path,
                     name_of_file=f"histogram_{name}_{self.regrid}_{self.freq}"
-                )
+            )
+            if os.path.exists(filename) and not self.rebuild_output:
+                self.logger.debug("File %s already exists, loading ...", filename)
+                merged_data= xr.open_dataset(filename)
+                merged_data_sources[name] = merged_data
+            else:
+                merged_data = self.get_merged_histogram_for_source(source)
+                if merged_data is not None:
+                    merged_data_sources[name] = merged_data
+                    self.diag.dataset_to_netcdf(
+                        merged_data, path_to_netcdf=hist_path,
+                        name_of_file=f"histogram_{name}_{self.regrid}_{self.freq}"
+                    )
 
         # Process histograms for each combination of pdf and pdfP flags
         for pdf, pdfP in [(True, False), (False, True)]:

--- a/diagnostics/tropical_rainfall/tropical_rainfall/src/tropical_rainfall_main.py
+++ b/diagnostics/tropical_rainfall/tropical_rainfall/src/tropical_rainfall_main.py
@@ -571,6 +571,31 @@ class MainClass:
 
         return tprate_dataset
 
+
+    def dataset_to_netcdf_filename(self, start_year=None, end_year=None, start_month=None, end_month=None, path_to_netcdf: Optional[str] = None,
+                          name_of_file: Optional[str] = None) -> str:
+        """
+        Function to compute the name of a destination file for the histogram.
+
+        Args:
+            dataset (xarray, optional):         The Dataset with the histogram.     Defaults to None.
+            path_to_netcdf (str, optional):  The path to save the histogram.     Defaults to None.
+
+        Returns:
+            str: The filename
+        """
+        if path_to_netcdf is None:
+            path_to_netcdf = self.path_to_netcdf
+
+        path_to_netcdf = self.tools.select_files_by_year_and_month_range(path_to_histograms=path_to_netcdf,
+                                                                        start_year=start_year, end_year=end_year,
+                                                                        start_month=start_month, end_month=end_month, flag=name_of_file)
+
+        self.logger.debug("Generated filename %s", path_to_netcdf)
+
+        return(path_to_netcdf[0])
+
+
     def dataset_to_netcdf(self, dataset: Optional[xr.Dataset] = None, path_to_netcdf: Optional[str] = None, rebuild: bool = False,
                           name_of_file: Optional[str] = None) -> str:
         """


### PR DESCRIPTION
## PR description:

While the tropical rainfall diagnostic will be completely refactored in the future, in the meantime it is one of the slowest among all of our diagnostics, significantly affecting the run tme of the full aqua analysis stack.
Currently a run of the tropical rainfall diagnostic takes about 30 minutes (running almost alone), despite the fact that it actually buffers already computed histograms in a cache. The histograms are stored both as single pieces (month by month) and as one complete file.

Investigating this a bit,  it turns out that every time it runs it merges again and again the single pieces into the full histogram file, even if this is already available. This operation takes up most of its run time.

The change implemented here makes sure that already computed histogram files are recycled, without merging them again.

As a result, instead of 30min it now takes only 1 minute if the histograms had already been computed in the past (on climatedt-phase1/IFS-NEMO/ssp370)

----

 - [ ] Changelog is updated.