### PR TITLE
Fix exposed token in tests

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -594,7 +594,7 @@ def run_query_with_input(tmpdir):
         testfile = os.path.join(tmpdir, TESTFILE)
         with open(testfile, 'w', encoding='utf-8') as f:
             f.write(input_text)
-        sys.stdin = open(testfile)
+        sys.stdin = open(testfile, 'r', encoding='utf-8')
         try:
             result = query_yes_no("Question?", default_answer)
         finally:


### PR DESCRIPTION
## PR description:

A recent PR introduced a probably unnecessary feature that exposes the token of aqua actions, which implies that the token gets invalidated.  This is testing the reverting.

## People involved:
@tovaz92 

