### PR TITLE
Remove ocean3d dependency from pip installation list for lumi

### DIFF
--- a/cli/lumi-install/pip_lumi.txt
+++ b/cli/lumi-install/pip_lumi.txt
@@ -1,5 +1,4 @@
 # pip dependencies
-pip install -e $AQUA/diagnostics/ocean3d/[all]
 pip install -e $AQUA/diagnostics/tropical_cyclones/[all]
 pip install -e $AQUA/diagnostics/tropical_rainfall/[all]
 pip install -e $AQUA/[all]


### PR DESCRIPTION
## PR description:

Little lumi installation fix for v0.20

## People involved:

@jhardenberg 

 - [x] Changelog is updated.
 - [x] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool.
 - [x] bug menu in main
 - [x] version bump
