### PR TITLE
Fix image name as a function of the branch name

### DIFF
--- a/.github/workflows/create-container-from-tag.yaml
+++ b/.github/workflows/create-container-from-tag.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           TARGET_BRANCH="${{ github.event.release.target_commitish }}"
           echo "Release target branch: $TARGET_BRANCH"
-          if [[ "$TARGET_BRANCH" == v0.13.*" || "$TARGET_BRANCH" == v0.19.* ]]; then
+          if [[ "$TARGET_BRANCH" == v0.13-*" || "$TARGET_BRANCH" == v0.19-* ]]; then
             echo "IMAGE_NAME=aqua" >> $GITHUB_ENV
           else
             echo "IMAGE_NAME=aqua-core" >> $GITHUB_ENV


### PR DESCRIPTION
## PR description:

Apparently the workflow on release use only what is found on the main, so a new operational release will get the name aqua-core instead of aqua. I am trying to fix this with this change
