### PR TITLE
Papering over https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-1043 wit…

### DIFF
--- a/cli/aqua-web/push_analysis.sh
+++ b/cli/aqua-web/push_analysis.sh
@@ -348,6 +348,12 @@ else  # Otherwise, use the second argument as the experiment folder
 fi
 
 if [ $update -eq 1 ]; then
+    # Ulf Tigerstedt 11.12.2025
+    # Shrink the window of a race condition between this running process 
+    # and another started just before. If the github repo gets updated between
+    # clone and push the push will fail and the temporary working 
+    # directory will be left behind. 
+    git pull
     git add updated.txt
 
     # commit and push


### PR DESCRIPTION
    Papering over https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-1043 with the
    explanation from there:

You are having massive amounts of conflicts since your work flow is:

1 clone repo
2 make graphs
3 update updated.txt
4 commit that
5 push to main
6 if there is a problem at step 5, don't clean up after yourself The delay between 1 and 5 means that if any other experiment did the same operation with an overlap, there will now be a conflict (since what's in github and what's in the repo at 1 will be different)

This landlord special fix papers over the issue by shrinking the race condition window from multiple minutes to less than a second by pulling from github just before updated.txt is updated+added+committed+pushed.




Please go the the `Preview` tab and select the appropriate sub-template:

* [Standard PR](?expand=1&template=standard_pull_request.md)
* [Version Release PR](?expand=1&template=version_release.md)