### PR TITLE
Minor fix in Histogram core function

### DIFF
--- a/aqua/core/histogram/histogram.py
+++ b/aqua/core/histogram/histogram.py
@@ -80,13 +80,9 @@ def histogram(data: xr.DataArray, bins = 10, range = None, units = None,
     counts_per_bin.attrs['size_of_the_data'] = size_of_the_data
 
     if density:
-        if "long_name" in counts_per_bin.attrs:
-            counts_per_bin.attrs['long_name'] = 'Pdf of {}'.format(counts_per_bin.attrs['long_name'])
         counts_per_bin.name = 'pdf'
         counts_per_bin.attrs['units'] = 'probability density'
     else:
-        if "long_name" in counts_per_bin.attrs:
-            counts_per_bin.attrs['long_name'] = 'Histogram of {}'.format(counts_per_bin.attrs['long_name'])
         counts_per_bin.name = 'histogram'
         counts_per_bin.attrs['units'] = 'counts'
 


### PR DESCRIPTION
## PR description:

@jhardenberg in the Histogram plot issues that you mentioned [here](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/pull/85#issuecomment-3686344927), you say:

> Title and legend: "Histogram of PDF of ... " does not make much sense. If the plot is a PDF then the title should be "PDF of ..."

I think `long_name `should describe only the physical variable, while the responsibility to add "PDF of" should fall on the plotting class (in PlotHistogram, in fact). In any case, to workaround the unusual variable wrong_name which results in the duplication that you noticed, the correction for `PlotHistogram` would be much heavier compared to deleting this further information here. 

What do you think? If you agree, we could merge this quickly