### PR TITLE
v0.19.9 preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -50,6 +50,8 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.19.9+op
+      - v0.19.9
       - v0.19.8+op
       - v0.19.8
       - v0.19.7+op

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 AQUA core complete list:
-- Handle support for Destine local parameters if paramId is not WMO table (for eccodes v2.41.0) (#2620)
 
 AQUA diagnostics complete list:
+
+## [v0.19.9]
+
+AQUA core complete list:
+- Handle support for Destine local parameters if paramId is not WMO table (for eccodes v2.41.0) (#2620)
 
 ## [v0.19.8]
 
@@ -1252,7 +1256,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/HEAD...v0.19.8
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/HEAD...v0.19.9
+[v0.19.9]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.8...v0.19.9
 [v0.19.8]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.7...v0.19.8
 [v0.19.7]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.6...v0.19.7
 [v0.19.6]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.5...v0.19.6

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.19.8'
+__version__ = '0.19.9'


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `aqua/core/src/version.py`
- [x] if it's an operational release, be sure the bug report menu is updated in the main as well
