### PR TITLE
Fesom fix NEMO coordinates

### DIFF
--- a/aqua/core/config/fixes/FESOM-climatedt-phase1.yaml
+++ b/aqua/core/config/fixes/FESOM-climatedt-phase1.yaml
@@ -8,3 +8,8 @@ fixer_name:
                 src_units: degC
             thetao:
                 src_units: degC
+
+        coords:
+            level:
+                source: level
+                tgt_units: 'm'


### PR DESCRIPTION
## PR description:

Small addition to the phase1 NEMO fixer to make sure that the vertical coordinate of NEMO is recognized by the data model (making the units 'm')

## Issues closed by this pull request:

Addresses partially #2601
Complements: https://github.com/DestinE-Climate-DT/Climate-DT-catalog/pull/223

----

 - [ ] Changelog is updated.