### PR TITLE
Update smmregrid pin to v0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
     "ruamel.yaml<=0.19.1",
     "scipy<=1.17.0",
     "seaborn<=0.13.2",
-    #"smmregrid==0.1.3",
-    "smmregrid @ git+https://github.com/jhardenberg/smmregrid.git",
+    "smmregrid==0.1.4",
+    #"smmregrid @ git+https://github.com/jhardenberg/smmregrid.git",  # for development
     "typeguard<=4.5.0",
     "xarray>=2025.12.0,<=2026.1.0",
     "kerchunk<=0.2.9",


### PR DESCRIPTION
## PR description:

As per title, reinstates regular pinning to v0.1.4 for smmregrid
Let's check test running.

Possibly does not even desrve a changelog
 - [ ] Changelog is updated.
