### PR TITLE
[OP] prepare release v0.13.11

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -49,6 +49,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.13.11
       - v0.13.10
       - v0.13.9
       - v0.13.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 Unreleased in the current development version:
 
+## [v0.13.11]
+
+Hotfixes:
+- Hard-pin netcdf4, hdf5 and h5py (#2745)
+
 ## [v0.13.10]
 
 Hotfixes:
@@ -876,7 +881,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.10...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.11...HEAD
+[v0.13.11]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.10...v0.13.11
 [v0.13.10]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.9...v0.13.10
 [v0.13.9]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.8...v0.13.9
 [v0.13.8]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.13.7...v0.13.8

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.13.10'
+__version__ = '0.13.11'


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `aqua/core/version.py`
- [x] Check key pyproject pins (gsv, xarray, pandas, etc.)
- [ ] if a major operational release, update Dockerfiles and relative action
- [ ] if it's an operational release, be sure the bug report menu is updated in the main as well
