### PR TITLE
Experimental removal of fdb from main dependencies

### DIFF
--- a/.github/workflows/aqua-complete.yml
+++ b/.github/workflows/aqua-complete.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/aqua-test-reusable.yml
     with:
       python-versions: '["3.10", "3.11", "3.12"]'
-      pytest-markers: 'aqua or slow or gsv or graphics or catgen'
+      pytest-markers: 'aqua or slow or polytope or gsv or graphics or catgen'
       enable-parallel: false
       enable-coverage: false
       fail-fast: false

--- a/.github/workflows/aqua-no-fdb.yml
+++ b/.github/workflows/aqua-no-fdb.yml
@@ -1,0 +1,66 @@
+name: AQUA tests (without FDB)
+# Quick test pipeline without FDB dependencies
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1" # run every Monday night at 3AM UTC
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  # Run tests only when specific conditions are met
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Check if tests should run
+        id: check
+        run: |
+          # Run tests if:
+          # 1) PR has label "run tests" or "ready to merge"
+          # 2) Triggered by Dependabot
+          # 3) Triggered manually (workflow_dispatch)
+          # 4) Triggered by schedule
+          # 5) Pushed to main branch
+          SHOULD_RUN="false"
+
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run tests') }}" == "true" ]] || \
+             [[ "${{ contains(github.event.pull_request.labels.*.name, 'ready to merge') }}" == "true" ]] || \
+             [[ "${{ github.actor }}" == "dependabot[bot]" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
+             [[ "${{ github.event_name }}" == "schedule" ]] || \
+             [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            SHOULD_RUN="true"
+          fi
+
+          echo "result=$SHOULD_RUN" >> $GITHUB_OUTPUT
+
+  # Call the reusable workflow without FDB
+  aqua-no-fdb-tests:
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should-run == 'true'
+    uses: ./.github/workflows/aqua-test-reusable.yml
+    with:
+      python-versions: '["3.12"]'
+      pytest-markers: 'aqua or slow or graphics or catgen'
+      enable-parallel: true
+      enable-coverage: true
+      fail-fast: false
+      enable-fdb: false
+    secrets:
+      AQUA_GITHUB_PAT: ${{ secrets.AQUA_GITHUB_PAT }}
+      AQUA_DVC_PAT: ${{ secrets.AQUA_DVC_PAT }}
+      BSC_GITLAB: ${{ secrets.BSC_GITLAB }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      POLYTOPE_KEY: ${{ secrets.POLYTOPE_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/aqua-no-fdb.yml
+++ b/.github/workflows/aqua-no-fdb.yml
@@ -53,7 +53,7 @@ jobs:
       python-versions: '["3.12"]'
       pytest-markers: 'aqua or slow or graphics or catgen'
       enable-parallel: true
-      enable-coverage: true
+      enable-coverage: false
       fail-fast: false
       enable-fdb: false
       container-image: ''

--- a/.github/workflows/aqua-no-fdb.yml
+++ b/.github/workflows/aqua-no-fdb.yml
@@ -56,6 +56,7 @@ jobs:
       enable-coverage: true
       fail-fast: false
       enable-fdb: false
+      container-image: ''
     secrets:
       AQUA_GITHUB_PAT: ${{ secrets.AQUA_GITHUB_PAT }}
       AQUA_DVC_PAT: ${{ secrets.AQUA_DVC_PAT }}

--- a/.github/workflows/aqua-pypi.yml
+++ b/.github/workflows/aqua-pypi.yml
@@ -21,6 +21,7 @@ jobs:
       enable-coverage: false
       fail-fast: false
       install-mode: 'pypi'
+      container-image: ''
     secrets:
       AQUA_GITHUB_PAT: ${{ secrets.AQUA_GITHUB_PAT }}
       AQUA_DVC_PAT: ${{ secrets.AQUA_DVC_PAT }}

--- a/.github/workflows/aqua-pypi.yml
+++ b/.github/workflows/aqua-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/aqua-test-reusable.yml
     with:
       python-versions: '["3.12"]'
-      pytest-markers: 'aqua or slow or gsv or graphics or catgen'
+      pytest-markers: 'aqua or slow or graphics or catgen'
       enable-parallel: true
       enable-coverage: false
       fail-fast: false

--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -92,7 +92,8 @@ jobs:
 
     container:
       # To run FDB tests we need to use a Docker image with FDB installed.
-      image: ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.17.3-eccodes2.41.0-aqua:aqua-base-container
+      # Pass container-image: '' from the caller to use plain ubuntu-latest (no container).
+      image: ${{ inputs.container-image }}
       options: --user root
 
     permissions:
@@ -153,20 +154,25 @@ jobs:
           git checkout tags/v2.1.0
 
       # ========================================
-      # 3. SETUP PYTHON ENVIRONMENT
+      # 3. SETUP ENVIRONMENT
       # ========================================
+      - name: Strip pip install from environment file (local mode)
+        if: ${{ inputs.install-mode == 'local' }}
+        run: |
+          sed -e '/^  - pip:$/d' \
+              -e '/^    # pip install/d' \
+              -e '/^    - -e \.\[all\]$/d' \
+              AQUA/environment.yml > AQUA/environment-stripped.yml
+
       - name: Set up Micromamba (local mode)
         if: ${{ inputs.install-mode == 'local' }}
         uses: mamba-org/setup-micromamba@v3
         with:
           micromamba-version: 'latest'
-          environment-file: AQUA/environment.yml
+          environment-file: AQUA/environment-stripped.yml
           environment-name: aqua
           cache-downloads: true
           cache-environment: false
-          condarc: |
-            channels:
-              - conda-forge
           create-args: >-
             python=${{ matrix.python-version }}
 
@@ -183,25 +189,19 @@ jobs:
             python=${{ matrix.python-version }}
 
       # ========================================
-      # 3.5 REINSTALL AQUA (local mode without FDB)
+      # 4. INSTALL AQUA (local mode)
       # ========================================
-      - name: Reinstall AQUA without FDB dependencies (local mode)
+      - name: Install AQUA with FDB dependencies (local mode)
+        if: ${{ inputs.install-mode == 'local' && inputs.enable-fdb != false }}
+        run: |
+          cd AQUA
+          python -m pip install -e ".[tests,fdb]" --no-deps
+
+      - name: Install AQUA without FDB dependencies (local mode)
         if: ${{ inputs.install-mode == 'local' && inputs.enable-fdb == false }}
         run: |
           cd AQUA
-          python -m pip install -e ".[tests]" --force-reinstall --no-deps
-
-      # ========================================
-      # 4. LINTING
-      # ========================================
-      - name: Install pre-commit
-        run: python -m pip install pre-commit
-
-      - name: Check code formatting with pre-commit
-        if: ${{ inputs.install-mode == 'local' }}
-        run: |
-          cd AQUA
-          pre-commit run --all-files
+          python -m pip install -e ".[tests]" --no-deps
 
       # ========================================
       # 5. INSTALL AQUA (PyPI mode)

--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -197,13 +197,13 @@ jobs:
         if: ${{ inputs.install-mode == 'local' && inputs.enable-fdb != false }}
         run: |
           cd AQUA
-          python -m pip install -e ".[tests,fdb]" --no-deps
+          python -m pip install -e ".[tests,fdb]"
 
       - name: Install AQUA without FDB dependencies (local mode)
         if: ${{ inputs.install-mode == 'local' && inputs.enable-fdb == false }}
         run: |
           cd AQUA
-          python -m pip install -e ".[tests]" --no-deps
+          python -m pip install -e ".[tests]"
 
       # ========================================
       # 5. INSTALL AQUA (PyPI mode)

--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -38,6 +38,16 @@ on:
         required: false
         type: string
         default: ''
+      container-image:
+        description: 'Container image to use (empty string = ubuntu-latest, default = FDB container)'
+        required: false
+        type: string
+        default: 'ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.17.3-eccodes2.41.0-aqua:aqua-base-container'
+      enable-fdb:
+        description: 'Enable FDB dependencies and setup'
+        required: false
+        type: boolean
+        default: true
     secrets:
       AQUA_GITHUB_PAT:
         required: true
@@ -173,6 +183,15 @@ jobs:
             python=${{ matrix.python-version }}
 
       # ========================================
+      # 3.5 REINSTALL AQUA (local mode without FDB)
+      # ========================================
+      - name: Reinstall AQUA without FDB dependencies (local mode)
+        if: ${{ inputs.install-mode == 'local' && inputs.enable-fdb == false }}
+        run: |
+          cd AQUA
+          python -m pip install -e ".[tests]" --force-reinstall --no-deps
+
+      # ========================================
       # 4. LINTING
       # ========================================
       - name: Install pre-commit
@@ -232,6 +251,7 @@ jobs:
       # 7. SETUP FDB
       # ========================================
       - name: Set up FDB
+        if: ${{ inputs.enable-fdb == true }}
         run: |
           # FDB for GSV
           rm -rf /app/

--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -140,9 +140,11 @@ jobs:
       # ========================================
       - name: Install GH Actions dependencies
         run: |
+          # Use sudo when not running as root (plain ubuntu-latest runner)
+          SUDO=$([ "$(id -u)" = "0" ] && echo "" || echo "sudo")
           # Ubuntu dependencies (Git, curl, gpg...)
-          apt-get update && \
-            apt-get install -y \
+          $SUDO apt-get update && \
+            $SUDO apt-get install -y \
               curl \
               git \
               gpg

--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/aqua-test-reusable.yml
     with:
       python-versions: '["3.12"]'
-      pytest-markers: 'aqua or slow or gsv or graphics or catgen'
+      pytest-markers: 'aqua or slow or polytope or gsv or graphics or catgen'
       enable-parallel: true
       enable-coverage: true
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v1.0.0):
 Main changes:
 
 Complete list:
+- Base AQUA is now shipped without FDB/GSV/polytope dependencies, available with [fdb] optional installation argument (#2818)
 - Small fix to wrong number of arguments of exception call (#2829)
 - Adding LLM directives in `AGENTS.md` (#2820)
 - Add `Ruff` linter and formatter to CI and add `pre-commit` implementation (#2748, #2786, #2791, #2815)

--- a/aqua/core/console/drop.py
+++ b/aqua/core/console/drop.py
@@ -79,15 +79,6 @@ def drop_execute(args):
     """
     Executing the DROP by parsing the arguments and configuring the machinery
     """
-    # to check if GSV is available and return the version
-    try:
-        import gsv
-
-        print("GSV version is: " + gsv.__version__)
-    except RuntimeError:
-        print("GSV not available. FDB5 binary library not present on system.")
-    except KeyError:
-        print("GSV not available. Environment variables not correctly set.")
 
     print("AQUA version is: " + version)
 

--- a/aqua/core/gsv/intake_gsv.py
+++ b/aqua/core/gsv/intake_gsv.py
@@ -40,6 +40,12 @@ except RuntimeError:
 except KeyError:
     gsv_available = False
     gsv_error_cause = "Environment variables for gsv, such as GRID_DEFINITION_PATH, not set."
+except ImportError:
+    gsv_available = False
+    gsv_error_cause = (
+        "GSVRetriever cannot be imported. "
+        "Check if the gsv package is installed and if the FDB5 binary library is available and properly set up."
+    )
 
 BRIDGE_API_URL = "https://qubed.lumi.apps.dte.destination-earth.eu/api/v2/stac"  # LUMI QUBED STAC API
 

--- a/docs/sphinx/source/installation.rst
+++ b/docs/sphinx/source/installation.rst
@@ -34,6 +34,9 @@ This can be achieved with:
 The same environment is available in the AQUA-core GitHub repository in the ``environment-pypi.yml`` file.
 
 .. note ::
+    If you want to access ClimateDT data, you will need to run `pip install aqua-core[fdb]`
+
+.. note ::
     If you need to access data written in a local FDB database (not polytope), you need to install the FDB5 library.
     The FDB5 library is not available in the conda-forge repository, so you need to install it manually.
     If you are working on a supported HPC, you can check the corresponding section for more information in the :ref:`HPC installation <installation-hpc>` section.
@@ -56,6 +59,8 @@ You can install them with the following command:
     pip install aqua-core[docs]
     pip install aqua-core[notebooks]
     pip install aqua-core[tests]
+    pip install aqua-core[style]
+    pip install aqua-core[fdb]
 
 Or to install all the extra dependencies:
 
@@ -115,8 +120,6 @@ At this point, you should have successfully installed the AQUA package and its d
 .. note ::
 
     By default, the environment file installs the cloned version of AQUA in editable mode with ``pip install -e .[all]``.
-    For development workflows, switch that line in ``environment.yml`` to ``pip install -e .[precommit,all]`` and then
-    run ``pre-commit install`` once in the repository.
 
 Update of the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - gcsfs<=2026.2.0
   - healpy<=1.18.1
   - intake==0.7.0
-  - intake-xarray<=2.0.0
+  - intake-xarray<=0.7.0
   - jinja2<=3.1.6
   - kerchunk<=0.2.9
   - matplotlib<=3.10.8

--- a/environment.yml
+++ b/environment.yml
@@ -48,4 +48,4 @@ dependencies:
   - pip
   - pip:
     # pip install -e of AQUA itself
-    - -e .[tests]
+    - -e .[all]

--- a/environment.yml
+++ b/environment.yml
@@ -47,4 +47,4 @@ dependencies:
   - pip
   - pip:
     # pip install -e of AQUA itself
-    - -e .[all]
+    - -e .[tests]

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - fastparquet<=2025.12.0
   - filelock<=3.25.0
   - gcsfs<=2026.2.0
+  - healpy<=1.18.1
   - intake==0.7.0
   - intake-xarray<=2.0.0
   - jinja2<=3.1.6

--- a/environment.yml
+++ b/environment.yml
@@ -47,5 +47,3 @@ dependencies:
   - pip:
     # pip install -e of AQUA itself
     - -e .[all]
-    # For devs who want pre-commit, comment line above and uncomment the line below
-    # - -e .[precommit,all]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "filelock",
     "gcsfs", # Google Cloud Storage File System: required by ARCO
     "intake==0.7.0", # Version 2 is a major refactor still in development
-    "intake-xarray",
+    "intake-xarray<=0.7.0", # Version 2 is a major refactor still in development
     "healpy",
     "jinja2",
     "kerchunk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ markers = [
     "gsv: mark test that requires ECMWF FDB libraries",
     "catgen: mark test for catalog generator",
     "console: mark test for console",
+    "polytope: mark test that uses polytope"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "gcsfs", # Google Cloud Storage File System: required by ARCO
     "intake==0.7.0", # Version 2 is a major refactor still in development
     "intake-xarray",
+    "healpy",
     "jinja2",
     "kerchunk",
     "matplotlib",
@@ -79,7 +80,6 @@ docs = [
 ]
 notebooks = [
     "ipykernel",
-    "healpy"
 ]
 tests = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ fdb = [
     "pyfdb",
     "gsv-interface==2.13.1"
 ]
-
 docs = [
     "sphinx",
     "sphinx-rtd-theme"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,12 +66,14 @@ dependencies = [
     "typeguard",
     "xarray>=2025.12.0",
     "zarr<=3.1.5",
-    # not available on conda
-    "pyfdb", #to be pinned when doing operational release
-    "gsv-interface==2.13.1"
 ]
 
 [project.optional-dependencies]
+fdb = [
+    "pyfdb",
+    "gsv-interface==2.13.1"
+]
+
 docs = [
     "sphinx",
     "sphinx-rtd-theme"
@@ -96,7 +98,8 @@ all = [
     "aqua-core[docs]",
     "aqua-core[notebooks]",
     "aqua-core[tests]",
-    "aqua-core[style]"
+    "aqua-core[style]",
+    "aqua-core[fdb]"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
 [project.optional-dependencies]
 fdb = [
     "pyfdb",
+    "polytope-client",
     "gsv-interface==2.13.1"
 ]
 docs = [

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -22,7 +22,7 @@ def reader(request):
     model, exp, source = request.param
     if source == "intake-esm-test":  # temporary skip of intake esm sources
         pytest.skip("Skipping intake-esm-test for now, not supported for now")
-    if not gsv_available and source in ["fdb", "fdb-levels", "fdb-nolevels"]:
+    if not gsv_available and "fdb" in source:
         pytest.skip(f"Skipping {model} {exp} {source} because GSV is not available")
     myread = Reader(catalog="ci", model=model, exp=exp, source=source, areas=False, fix=False, loglevel=LOGLEVEL)
     data = myread.retrieve()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -5,6 +5,7 @@ import xarray
 from conftest import LOGLEVEL
 
 from aqua import Reader
+from aqua.core.gsv.intake_gsv import gsv_available
 from aqua.core.reader import show_catalog_content as catalog
 
 
@@ -21,6 +22,8 @@ def reader(request):
     model, exp, source = request.param
     if source == "intake-esm-test":  # temporary skip of intake esm sources
         pytest.skip("Skipping intake-esm-test for now, not supported for now")
+    if not gsv_available and source in ["fdb", "fdb-levels", "fdb-nolevels"]:
+        pytest.skip(f"Skipping {model} {exp} {source} because GSV is not available")
     myread = Reader(catalog="ci", model=model, exp=exp, source=source, areas=False, fix=False, loglevel=LOGLEVEL)
     data = myread.retrieve()
     return myread, data

--- a/tests/test_gridbuilder.py
+++ b/tests/test_gridbuilder.py
@@ -9,11 +9,13 @@ from aqua.core.configurer import ConfigPath
 from aqua.core.gridbuilder.gridentrymanager import GridEntryManager
 from aqua.core.util import load_yaml
 
-pytestmark = [pytest.mark.aqua, pytest.mark.xdist_group(name="grid_builder")]
+pytestmark = [pytest.mark.xdist_group(name="grid_builder")]
 
 
-class TestGridBuilder:
+class TestPolytopeGridBuilder:
     """Test the GridBuilder class."""
+
+    pytestmark = [pytest.mark.polytope]
 
     grid_dir = f"{ConfigPath().configdir}/grids"
 
@@ -44,6 +46,14 @@ class TestGridBuilder:
         data = reader.retrieve(var="tos")
         grid_builder = GridBuilder(outdir=tmp_path, model_name="FESOM", original_resolution="ng5")
         grid_builder.build(data, verify=True, create_yaml=False)
+
+
+class TestBasicGridBuilder:
+    """Test the GridBuilder class."""
+
+    pytestmark = [pytest.mark.aqua]
+
+    grid_dir = f"{ConfigPath().configdir}/grids"
 
     @pytest.mark.parametrize("rebuild", [False, True])
     def test_grid_regular(self, tmp_path, rebuild):
@@ -83,6 +93,8 @@ class TestGridBuilder:
 
 class TestGridEntryManager:
     """Test the GridEntryManager class."""
+
+    pytestmark = [pytest.mark.aqua]
 
     @pytest.mark.parametrize(
         "model,aquagrid,cdogrid,original,kind",


### PR DESCRIPTION
## PR description:

We are exploring if AQUA core can be shipped without FDB dependencies as default, which might potentially allow the publication of aqua on conda-forge. A new test is introduced to verify if without it everything is working. Question is if we want those tests to run frequently or not.


 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated.
 - [ ] Run Cross check tests for AQUA-diagnostics [AQUA-diagnostics cross-check workflow](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/actions/workflows/aqua-diagnostics-cross-check.yml)
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. Installation instructions are updated if new conda dependencies are added.
 - [ ] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
