### PR TITLE
Healpy as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - fastparquet<=2025.12.0
   - filelock<=3.25.0
   - gcsfs<=2026.2.0
+  - healpy<=1.18.1
   - intake==0.7.0
   - intake-xarray<=2.0.0
   - jinja2<=3.1.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "fastparquet", #enable support for parquet files
     "filelock",
     "gcsfs", # Google Cloud Storage File System: required by ARCO
+    "healpy",
     "intake==0.7.0", # Version 2 is a major refactor still in development
     "intake-xarray",
     "jinja2",
@@ -77,8 +78,7 @@ docs = [
     "sphinx-rtd-theme"
 ]
 notebooks = [
-    "ipykernel",
-    "healpy"
+    "ipykernel"
 ]
 tests = [
     "pytest",


### PR DESCRIPTION
## PR description:

As per title, healpy was not a dependency and was listed only as option in notebooks, but is used by graphics

## Issues closed by this pull request:

Close #2830
