### PR TITLE
[Hotfix] CatGen: more flexible handling of forcing string 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ AQUA diagnostics complete list:
 ## [v0.19.11]
 
 AQUA core complete list:
+- CatGen: more flexible handling of forcing string (#2832)
 - Attributes guessing for eccodes works also with local destine table (#2785)
 - Fix area selection, `default_coords` are deduced from the dataset (#2771)
 - Netcdf4 and h5py in env instead of pip (#2739)

--- a/src/aqua/cli/catgen.py
+++ b/src/aqua/cli/catgen.py
@@ -205,6 +205,15 @@ class AquaFDBGenerator:
         if not result:
             raise ValueError(f"Unexpected {value_type}: {value}")
         return result
+    
+    @staticmethod
+    def get_forcing(experiment: str, prefix_map: dict) -> str:
+        """Get the forcing string based on the experiment name."""
+        normalized = re.sub(r"[^a-z0-9]", "", experiment.lower())
+        for key, prefix in prefix_map.items():
+            if experiment.startswith(key):
+                return f"{prefix}-{normalized}"
+        return normalized
 
 
     def load_jinja_template(self, template_file):
@@ -344,17 +353,15 @@ class AquaFDBGenerator:
             
             resolution_id = self.get_value_from_map(self.config['resolution'], resolution_map, 'resolution')
 
-            forcing_map = {
-                'hist': 'baseline-hist',
-                'cont': 'baseline-cont',
-                'SSP3-7.0': 'projections-ssp370',
-                'Tplus2.0K': 'tplus2K'
+            prefix_map = {
+                "hist": "baseline",
+                "cont": "baseline",
+                "SSP": "projections",
             }
 
             forcing = self.config.get('forcing')
             if not forcing:
-                experiment = self.config['experiment']
-                forcing = forcing_map.get(experiment, re.sub(r'[^a-z0-9]', '', experiment.lower()))
+                forcing = self.get_forcing(self.config["experiment"], prefix_map)
             
             main_yaml['sources'][self.config['exp']] = {
                 'description': self.description,

--- a/src/aqua/cli/catgen.py
+++ b/src/aqua/cli/catgen.py
@@ -344,6 +344,7 @@ class AquaFDBGenerator:
             
             forcing = self.config.get("forcing")
             activity = self.config.get("activity")
+            experiment = self.config['experiment']
 
             if not forcing:
                 exp_clean = re.sub(r"[^a-z0-9]+", "-", experiment.lower()).strip("-")

--- a/src/aqua/cli/catgen.py
+++ b/src/aqua/cli/catgen.py
@@ -205,17 +205,6 @@ class AquaFDBGenerator:
         if not result:
             raise ValueError(f"Unexpected {value_type}: {value}")
         return result
-    
-    @staticmethod
-    def get_forcing(experiment: str, prefix_map: dict) -> str:
-        """Get the forcing string based on the experiment name."""
-        normalized = re.sub(r"[^a-z0-9]", "", experiment.lower())
-        for key, prefix in prefix_map.items():
-            if experiment.startswith(key):
-                return f"{prefix}-{normalized}"
-        return normalized
-
-
     def load_jinja_template(self, template_file):
         """
         Load a Jinja2 template.
@@ -352,17 +341,14 @@ class AquaFDBGenerator:
             }
             
             resolution_id = self.get_value_from_map(self.config['resolution'], resolution_map, 'resolution')
-
-            prefix_map = {
-                "hist": "baseline",
-                "cont": "baseline",
-                "SSP": "projections",
-            }
-
-            forcing = self.config.get('forcing')
-            if not forcing:
-                forcing = self.get_forcing(self.config["experiment"], prefix_map)
             
+            forcing = self.config.get("forcing")
+            activity = self.config.get("activity")
+
+            if not forcing:
+                exp_clean = re.sub(r"[^a-z0-9]+", "-", experiment.lower()).strip("-")
+                forcing = f"{activity}-{exp_clean}"
+                        
             main_yaml['sources'][self.config['exp']] = {
                 'description': self.description,
                 'metadata': {


### PR DESCRIPTION
## PR description:

I updated the logic so that the forcing string is now built automatically, including the prefix (e.g., baseline, projections), without hardcoding specific experiment names. This makes it easier to support new storylines or scenarios without needing to update the forcing map each time.

 - [x] Changelog is updated.
 - [x] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
