### PR TITLE
Bump eccodes to 2.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v1.0.0):
 Main changes:
 
 Complete list:
+- Unlock binding to `eccodes==2.41.0` and allow more recent versions (#2847)
 - Improve Grahics coverage (#2841)
 - Switch to astropy-healpix due to licensing issues with healpy (#2844)
 - Catalog generator: adapt to new sources names and more flexible handling of forcing string  (#2777)

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -50,7 +50,7 @@ def convert_to_new_structure(data):
                 for model, experiments in models.items():
                     if isinstance(experiments, list):
                         # Old structure found: {model: [exp1, exp2]}
-                        new_experiments_dict = {exp: ['r1'] for exp in experiments}
+                        new_experiments_dict = {exp: ["r1"] for exp in experiments}
                         # Replace the list with the new dictionary
                         models[model] = new_experiments_dict
     return data

--- a/cli/lumi-install/environment_lumi.yml
+++ b/cli/lumi-install/environment_lumi.yml
@@ -11,7 +11,7 @@ channels:
 dependencies:
   - python>=3.10,<3.13
   - cdo>=2.5.0
-  - eccodes==2.41.0
+  - eccodes>=2.41.0,<=2.47.0
   - cartopy_offlinedata # this is needed for MN5 HPC
   - pip
   - netcdf4

--- a/docs/sphinx/source/references_acknowledgments.rst
+++ b/docs/sphinx/source/references_acknowledgments.rst
@@ -30,7 +30,7 @@ and please include also the following acknowledgements:
   publisher = {Copernicus GmbH},
   author = {Nurisso,  Matteo and von Hardenberg,  Jost and Cadau,  Marco and Caprioli,  Silvia and Ghinassi,  Paolo and Ghosh,  Supriyo and Koldunov,  Nikolay and Nazarova,  Natalia and Rajput,  Maqsood Mubarak and Tovazzi,  Emanuele and Davini,  Paolo},
   year = {2026},
-  month = May 
+  month = May
   }
 
 Acknowledgments

--- a/environment-pypi.yml
+++ b/environment-pypi.yml
@@ -10,5 +10,5 @@ channels:
 dependencies:
   - python>=3.10,<3.13
   - cdo>=2.5.0
-  - eccodes==2.41.0
+  - eccodes>=2.41.0,<=2.47.0
   - netcdf4

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   # binaries
   - python>=3.10,<3.13
   - cdo>=2.5.0 #for smmregrid compatibility
-  - eccodes==2.41.0
+  - eccodes==2.47.0
   - cartopy>=0.24.1,<=0.25.0
   - cartopy_offlinedata # this is needed for MN5 HPC
   - netcdf4<=1.7.2

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   # binaries
   - python>=3.10,<3.13
   - cdo>=2.5.0 #for smmregrid compatibility
-  - eccodes==2.47.0
+  - eccodes>=2.41.0,<=2.47.0
   - cartopy>=0.24.1,<=0.25.0
   - cartopy_offlinedata # this is needed for MN5 HPC
   - netcdf4<=1.7.4

--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,9 @@ dependencies:
   - eccodes==2.47.0
   - cartopy>=0.24.1,<=0.25.0
   - cartopy_offlinedata # this is needed for MN5 HPC
-  - netcdf4<=1.7.2
-  - hdf5<=1.14.6
-  - h5py>=3.12.1,<=3.16.0
+  - netcdf4<=1.7.4 * nompi* #y
+  - hdf5<=2.10.0 * nompi*
+  - h5py>=3.12.1,<=3.16.0 * nompi*
   - imagemagick
   # python
   - boto3<=1.42.63

--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,9 @@ dependencies:
   - eccodes==2.47.0
   - cartopy>=0.24.1,<=0.25.0
   - cartopy_offlinedata # this is needed for MN5 HPC
-  - netcdf4<=1.7.4 * nompi* #y
-  - hdf5<=2.10.0 * nompi*
-  - h5py>=3.12.1,<=3.16.0 * nompi*
+  - netcdf4<=1.7.4
+  - hdf5<=2.10.0
+  - h5py>=3.12.1,<=3.16.0
   - imagemagick
   # python
   - boto3<=1.42.63

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     # binaries
-    "eccodes==2.41.0",
+    "eccodes>=2.41.0,<=2.47.0",
     "netcdf4",
     "h5py>=3.12.1",
     # shared with conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     # binaries
-    "eccodes>=2.41.0,<=2.47.0",
+    "eccodes>=2.41.0",
     "netcdf4",
     "h5py>=3.12.1",
     # shared with conda


### PR DESCRIPTION
## PR description:
Bump eccodes from 2.41.0 to 2.47.0


Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.
 
 - [x] Changelog is updated.
 