### PR TITLE
add source and target grid as AQUA attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ClimateDT workflow modifications:
 Main changes:
 
 Complete list:
+- Add AQUA attributes for source and target grid (#2869)
 - Fallback test download from wilma (#2867)
 - push_analysis png metadata support and remove imagemagick dependency (#2866)
 - Support for python 3.13 and 3.14, with new default from 3.12 to 3.14 (#2853)

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -618,7 +618,9 @@ class Reader:
         out = self.regridder.regrid(data)
 
         # set regridded attribute to 1 for all vars
-        out = set_attrs(out, {"AQUA_regridded": 1})
+        out = set_attrs(
+            out, {"AQUA_regridded": 1, "AQUA_source_grid": self.src_grid_name, "AQUA_target_grid": self.tgt_grid_name}
+        )
         return out
 
     # def trend(self, data, dim='time', degree=1, skipna=False):

--- a/tests/test_regrid.py
+++ b/tests/test_regrid.py
@@ -131,6 +131,8 @@ class TestRegridder:
         reader = Reader(model=model, exp=exp, source=source, regrid="r200", fix=True, loglevel=LOGLEVEL)
         data = reader.retrieve()
         rgd = reader.regrid(data[variable])
+        assert getattr(rgd, "AQUA_regridded") == 1
+        assert getattr(rgd, "AQUA_target_grid") == "r200"
         assert len(rgd.lon) == 180
         assert len(rgd.lat) == 90
         assert ratio == pytest.approx((rgd.isnull().sum() / rgd.size).values, rel=APPROX_REL)  # land fraction


### PR DESCRIPTION
## PR description:

As discussed, I extended the marking of attributes from the regridding operation. I added source and target grid, but this is not very clean for a series of reasons

- In principle, it should be the `Regridder` class to take care of this, not the `Reader`. However, the regridder is built so that `remap_method` and `tgt_grd_name` are argument of the weights generation, and then ignored by the regrid operation. We should access the smmregrid object to get this info
- The `remap_method`,  another useful info, is set to None because is controlled by the `Regridder`class
- The `set_attrs` function is only a function of the reader, and in general it calls for a restructuring of the util set.

Long story short, this is fine, but a more elegant solution will require a bit of reworking and thinking

## Issues closed by this pull request:

Close #2722


## People involved:

@mcadau @jhardenberg 

 - [x] Tests are included if a new feature is included.
 - [x] Changelog is updated.

