### PR TITLE
Solve `areas=True` and `src_grd_name=False` conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ClimateDT workflow modifications:
 Main changes:
 
 Complete list:
+- Solve `areas=True` and `src_grd_name=False` conflict (#2871)
 - Fallback test download from wilma (#2867)
 - push_analysis png metadata support and remove imagemagick dependency (#2866)
 - Support for python 3.13 and 3.14, with new default from 3.12 to 3.14 (#2853)

--- a/aqua/core/config/fixes/OBS-climatedt.yaml
+++ b/aqua/core/config/fixes/OBS-climatedt.yaml
@@ -194,6 +194,14 @@ fixer_name:
             mx2t24: # there might be 24h mismatch in grib definition
                 source: tx
 
+    era5-earth-data-hub:
+        convention: eccodes
+        coords:
+            time:
+                source: valid_time
+            plev:
+                source: isobaricInhPa
+
     era5-arco:
         convention: eccodes
         data_model: false

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -261,6 +261,7 @@ class Reader:
         self.tgt_grid_name = regrid
 
         # init the regridder and the areas
+        self.regridder = None
         areas, regrid = self._configure_regridder(
             machine_paths, regrid=regrid, areas=areas, rebuild=rebuild, reader_kwargs=reader_kwargs
         )
@@ -612,7 +613,7 @@ class Reader:
     def regrid(self, data):
         """Call the regridder function returning container or iterator"""
 
-        if self.tgt_grid_name is None:
+        if not callable(getattr(self, "regridder", None)):
             raise NoRegridError("regrid has not been initialized in the Reader, cannot perform any regrid.")
 
         data = counter_reverse_coordinate(data)
@@ -1301,7 +1302,7 @@ class Reader:
             **kwargs: additional arguments passed to fldstat
         """
         # Handle regridding logic - use appropriate fldstat module
-        if self._check_if_regridded(data) and self.tgt_fldstat:
+        if self._check_if_regridded(data) and callable(getattr(self, "tgt_fldstat", None)):
             data = self.tgt_fldstat.fldstat(
                 data,
                 stat=stat,

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -302,7 +302,7 @@ class Reader:
         # load and check the regrid
         if regrid or areas:
             if self.src_grid_name is False:
-                self.logger.info("Grid metadata is False, regrid and areas disabled")
+                self.logger.warning("Grid metadata is False, regrid and areas disabled")
                 return False, False
 
             # create the configuration dictionary

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -301,6 +301,10 @@ class Reader:
 
         # load and check the regrid
         if regrid or areas:
+            if self.src_grid_name is False:
+                self.logger.info("Grid metadata is False, regrid and areas disabled")
+                return False, False
+
             # create the configuration dictionary
             cfg_regrid = load_multi_yaml(
                 folder_path=self.grids_folder, definitions=machine_paths["paths"], loglevel=self.loglevel
@@ -311,9 +315,6 @@ class Reader:
                 self.logger.info("Grid metadata is not defined. Trying to access the real data")
                 data = self._retrieve_plain()
                 self.regridder = Regridder(cfg_regrid, data=data, loglevel=self.loglevel)
-            elif self.src_grid_name is False:
-                self.logger.info("Grid metadata is False, regrid and areas disabled")
-                return False, False
             else:
                 self.logger.info("Grid metadata is %s", self.src_grid_name)
                 self.regridder = Regridder(cfg_regrid, src_grid_name=self.src_grid_name, loglevel=self.loglevel)

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -261,7 +261,9 @@ class Reader:
         self.tgt_grid_name = regrid
 
         # init the regridder and the areas
-        self._configure_regridder(machine_paths, regrid=regrid, areas=areas, rebuild=rebuild, reader_kwargs=reader_kwargs)
+        areas, regrid = self._configure_regridder(
+            machine_paths, regrid=regrid, areas=areas, rebuild=rebuild, reader_kwargs=reader_kwargs
+        )
 
         # init the fldstat modules. if areas are not available, will issue a warning
         cell_area = self.src_grid_area.cell_area if areas else None
@@ -311,15 +313,13 @@ class Reader:
                 self.regridder = Regridder(cfg_regrid, data=data, loglevel=self.loglevel)
             elif self.src_grid_name is False:
                 self.logger.info("Grid metadata is False, regrid and areas disabled")
-                regrid = False
-                areas = False
-                return
+                return False, False
             else:
                 self.logger.info("Grid metadata is %s", self.src_grid_name)
                 self.regridder = Regridder(cfg_regrid, src_grid_name=self.src_grid_name, loglevel=self.loglevel)
 
                 if self.regridder.error:
-                    self.logger.warning("Issues in the Regridder() init: trying with data")
+                    self.logger.info("Regridder() cannot init with the provided grid metadata: trying with data")
                     data = self._retrieve_plain()
                     self.regridder = Regridder(cfg_regrid, src_grid_name=self.src_grid_name, data=data, loglevel=self.loglevel)
 
@@ -329,8 +329,7 @@ class Reader:
 
             # TODO: it is likely there are other cases where we need to disable regrid.
             if not self.regridder.cdo:
-                areas = False
-                regrid = False
+                return False, False
 
         if areas:
             # generate source areas and expose them in the reader
@@ -371,6 +370,8 @@ class Reader:
 
         # activate time statistics
         self.timemodule = TimStat(loglevel=self.loglevel)
+
+        return areas, regrid
 
     def _fix_datamodel_weights(self, weights, mode="datamodel"):
         """

--- a/aqua/core/reader/reader.py
+++ b/aqua/core/reader/reader.py
@@ -613,7 +613,7 @@ class Reader:
     def regrid(self, data):
         """Call the regridder function returning container or iterator"""
 
-        if not callable(getattr(self, "regridder", None)):
+        if self.regridder is None:
             raise NoRegridError("regrid has not been initialized in the Reader, cannot perform any regrid.")
 
         data = counter_reverse_coordinate(data)
@@ -1302,7 +1302,7 @@ class Reader:
             **kwargs: additional arguments passed to fldstat
         """
         # Handle regridding logic - use appropriate fldstat module
-        if self._check_if_regridded(data) and callable(getattr(self, "tgt_fldstat", None)):
+        if self._check_if_regridded(data) and self.tgt_fldstat is not None:
             data = self.tgt_fldstat.fldstat(
                 data,
                 stat=stat,

--- a/docs/sphinx/source/adding_data.rst
+++ b/docs/sphinx/source/adding_data.rst
@@ -105,7 +105,9 @@ Once this is defined, we can access our dataset from AQUA with the following com
 
 Finally, the ``metadata`` entry contains optional additional information useful to define how to postprocess the data:
 
-    - ``source_grid_name``: the grid name defined in ``aqua-grids.yaml`` to be used for areas and regridding
+    - ``source_grid_name``: the grid name defined in ``aqua-grids.yaml`` to be used for areas and regridding.
+                            if set to ``null`` or not specified, the regridder will try to guess the grid based on the data coordinates, but this can be costly and not always successful.
+                            if set to ``False``, the regridder will be disabled and no attempt to guess the grid will be done.
     - ``fixer_name``: the name of the fixer defined in the fixes folder
     - ``deltat`` (optional): the cumulation window of fluxes in the dataset. This is a fixer option. If not present, the default is 1 second.
     - ``time_coder`` (optional): xarray builds on pandas, and pandas support a limited time range becuase time precision is based on nanoseconds.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -189,10 +189,11 @@ class TestAqua:
 
     def test_reader_no_area(self):
         """
-        Test that the Reader class works when areas are disabled
+        Test that the Reader class works when `source_grid_name` is set to False.
         """
         reader = Reader(catalog="ci", model="ERA5", exp="era5-hpz3", source="monthly-no-grid", regrid="r100")
-        data = reader.retrieve()
+        data = reader.retrieve(var="2t")
         assert reader.tgt_fldstat is None
+        assert reader.regridder is None
         with pytest.raises(NoRegridError):
             reader.regrid(data)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@ import pytest
 from conftest import APPROX_REL, LOGLEVEL
 
 from aqua import Reader
+from aqua.core.exceptions import NoRegridError
 
 approx_rel = APPROX_REL
 loglevel = LOGLEVEL
@@ -185,3 +186,13 @@ class TestAqua:
             model="ICON", exp="test-healpix", source="fake-ensemble-str", loglevel=loglevel, areas=False, realization="r2i1p1"
         )
         assert reader.kwargs["realization"] == "r2i1p1"
+
+    def test_reader_no_area(self):
+        """
+        Test that the Reader class works when areas are disabled
+        """
+        reader = Reader(catalog="ci", model="ERA5", exp="era5-hpz3", source="monthly-no-grid", regrid="r100")
+        data = reader.retrieve()
+        assert reader.tgt_fldstat is None
+        with pytest.raises(NoRegridError):
+            reader.regrid(data)


### PR DESCRIPTION
## PR description:

In #2653 @maqsoodrajput noticed that there is a problem when `areas=True` and `src_grd_name=False`. Despite the possibility being evaluated, the areas are not disabled entirely. This addresses the problem. 

## Issues closed by this pull request:

Close #2653


 - [x] Tests are included if a new feature is included.
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.

