### PR TITLE
push_analysis SVG support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 ClimateDT workflow modifications:
-- removed dependency on imagemagick
-- removed the --no-convert option from `push_analysis.sh`
+- Removed dependency on imagemagick
+- Removed the `--no-convert` option from `push_analysis.sh`
+- Added the `--format <FORMAT>` option to `push_analysis.sh` to select output formats to be uploaded (`png,pdf,svg` by default)
 
 Main changes:
 
 Complete list:
 - Fallback test download from wilma (#2867)
-- push_analysis png metadata support and remove imagemagick dependency (#2866)
+- push_analysis png, pdf and svg metadata support and remove imagemagick dependency (#2866, #2872)
 - Support for python 3.13 and 3.14, with new default from 3.12 to 3.14 (#2853)
 - Update intake and intake-xarray to >=2.0.0 (#2843)
 - Unlock binding to `eccodes==2.41.0` and allow more recent versions (#2847)

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -175,16 +175,17 @@ def make_content(catalog, model, exp, realization, diagnostics, config_experimen
                 fn_line = f"{catalog}/{model}/{exp}/{realization}/{fn}"
             else:
                 fn_line = f"{catalog}/{model}/{exp}/{fn}"
-            filename_list.append(fn_line)
 
             if fn.endswith(".png"):
                 with Image.open(os.path.join(path, fn)) as img:
                     metadata = img.info
                 properties[fn_line] = metadata
+                filename_list.append(fn_line)
             elif fn.endswith(".pdf"):
                 with PdfReader(os.path.join(path, fn)) as pdf_reader:
                     metadata = pdf_reader.metadata
                 properties[fn_line] = metadata
+                filename_list.append(fn_line)
             elif fn.endswith(".svg"):
                 root = ET.parse(os.path.join(path, fn)).getroot()
                 desc = root.find("{http://www.w3.org/2000/svg}desc")
@@ -195,6 +196,7 @@ def make_content(catalog, model, exp, realization, diagnostics, config_experimen
                             key, value = line.split(": ", 1)
                             metadata[key] = value
                 properties[fn_line] = metadata
+                filename_list.append(fn_line)
 
         grouping = {}
         for key, val in diagnostics.items():

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -195,8 +195,6 @@ def make_content(catalog, model, exp, realization, diagnostics, config_experimen
                             key, value = line.split(": ", 1)
                             metadata[key] = value
                 properties[fn_line] = metadata
-            else:
-                properties[fn_line] = {}
 
         grouping = {}
         for key, val in diagnostics.items():

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -334,7 +334,7 @@ def parse_arguments(arguments):
     """
 
     parser = argparse.ArgumentParser(
-        description="Create content.yaml and content.json files for each experiment in the content/png directory."
+        description="Create content.yaml and content.json files for each experiment in the content/<format> directory."
     )
 
     parser.add_argument(
@@ -368,7 +368,9 @@ def parse_arguments(arguments):
         default="INFO",
         help="Set the logging level (e.g., DEBUG, INFO, WARNING). Default is INFO.",
     )
-    parser.add_argument("--format", type=str, default="png", help="Format of the input data files on which to work (png, pdf)")
+    parser.add_argument(
+        "--format", type=str, default="png", help="Input data formats to work on (png, pdf or svg). Default: png"
+    )
 
     return parser.parse_args(arguments)
 

--- a/cli/aqua-web/make_contents.py
+++ b/cli/aqua-web/make_contents.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+import xml.etree.ElementTree as ET
 from fnmatch import fnmatch
 
 import yaml
@@ -183,6 +184,16 @@ def make_content(catalog, model, exp, realization, diagnostics, config_experimen
             elif fn.endswith(".pdf"):
                 with PdfReader(os.path.join(path, fn)) as pdf_reader:
                     metadata = pdf_reader.metadata
+                properties[fn_line] = metadata
+            elif fn.endswith(".svg"):
+                root = ET.parse(os.path.join(path, fn)).getroot()
+                desc = root.find("{http://www.w3.org/2000/svg}desc")
+                metadata = {}
+                if desc is not None and desc.text:
+                    for line in desc.text.strip().split("\n"):
+                        if ": " in line:
+                            key, value = line.split(": ", 1)
+                            metadata[key] = value
                 properties[fn_line] = metadata
             else:
                 properties[fn_line] = {}

--- a/cli/aqua-web/push_analysis.sh
+++ b/cli/aqua-web/push_analysis.sh
@@ -13,11 +13,16 @@ rsync_with_mkdir() {
     local remote_path="${rsync_target#*:}"
 
     # Run rsync
-    rsync -avz "$local_path/" "$rsync_target/" --relative --chmod=D775,F664
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-        log_message ERROR "Rsync failed with exit code $exit_code"
-        exit $exit_code
+
+    if [ -e "$local_path" ]; then
+        rsync -avz "$local_path/" "$rsync_target/" --relative --chmod=D775,F664
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            log_message ERROR "Rsync failed with exit code $exit_code"
+            exit $exit_code
+        fi
+    else
+        log_message ERROR "Directory $local_path does not exist, skipping rsync"
     fi
 }
 
@@ -43,12 +48,17 @@ get_file() {
 
 push_s3() {
     # push_s3 <bucket> <file>
-    log_message INFO "Pushing file $2 to bucket $1 on LUMI-O"
-    python $SCRIPT_DIR/push_s3.py $1 $2 -d $2
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-        log_message ERROR "Pushing $2 to bucket $1 failed with exit code $exit_code"
-        exit $exit_code
+
+    if [ -e "$2" ]; then
+        log_message INFO "Pushing file $2 to bucket $1 on LUMI-O"
+        python $SCRIPT_DIR/push_s3.py $1 $2 -d $2
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+            log_message ERROR "Pushing $2 to bucket $1 failed with exit code $exit_code"
+            exit $exit_code
+        fi
+    else
+        log_message ERROR "File/directory $2 does not exist, skipping push_s3"
     fi
 }
 
@@ -61,16 +71,18 @@ push_lumio() {
         if [ -f "content/experiments.yaml" ]; then
             rsync -avz content/experiments.yaml $3/content/experiments.yaml
         fi
-        rsync_with_mkdir content/png/$2/ $3
-        rsync_with_mkdir content/pdf/$2/ $3
+        for fmt in $format; do
+            rsync_with_mkdir "content/$fmt/$2/" "$3"
+        done
         return
     else
         log_message INFO "Pushing figures to bucket $1 on LUMI-O, experiment: $2"
         if [ -f "content/experiments.yaml" ]; then
             push_s3 $1 content/experiments.yaml
         fi
-        push_s3 $1 content/png/$2
-        push_s3 $1 content/pdf/$2
+        for fmt in $format; do
+            push_s3 $1 "content/$fmt/$2"
+        done
     fi
 }
 
@@ -80,10 +92,14 @@ make_contents() {
     log_message INFO "Making content files for $1 with config $2 and ensemble $3"
     if [ $ensemble -eq 1 ]; then
         # If ensemble structure, we need to pass the ensemble flag
-        python $SCRIPT_DIR/make_contents.py -f -e $1 -c $2
+        for fmt in $format; do
+            python $SCRIPT_DIR/make_contents.py -f -e $1 -c $2 --format $fmt
+        done
     else
         # Otherwise, we use the old structure
-        python $SCRIPT_DIR/make_contents.py -f -e $1 -c $2 --no-ensemble
+        for fmt in $format; do
+            python $SCRIPT_DIR/make_contents.py -f -e $1 -c $2 --no-ensemble --format $fmt
+        done
     fi
     exit_code=$?
     if [ $exit_code -ne 0 ]; then
@@ -99,11 +115,10 @@ collect_figures() {
 
     indir="$1/$2"
 
-    for format in pdf png
-    do
-        dstdir="./content/$format/$2"
+    for fmt in $format; do
+        dstdir="./content/$fmt/$2"
         mkdir -p $dstdir
-        find $indir -name "*.$format"  -exec cp {} $dstdir/ \;
+        find $indir -name "*.$fmt"  -exec cp {} $dstdir/ \;
         echo $(date) > $dstdir/last_update.txt
     done
 
@@ -111,10 +126,9 @@ collect_figures() {
     log_message INFO "Trying to collect $indir/experiment.yaml"
     if [ -f "$indir/experiment.yaml" ]; then
         log_message INFO "Collecting also experiment.yaml"
-        for format in png pdf
-        do
-            mkdir -p ./content/$format/$2
-            cp "$indir/experiment.yaml" "./content/$format/$2/"
+        for fmt in $format; do
+            mkdir -p "./content/$fmt/$2"
+            cp "$indir/experiment.yaml" "./content/$fmt/$2/"
         done
     fi
 }
@@ -131,6 +145,7 @@ print_help() {
     echo "  -c, --config FILE      alternate config file to determine diagnostic groupings for make_contents (defaults to config.grouping.yaml in \$AQUA/config/analysis)"
     echo "  -d, --no-update        do not update the remote github repository"
     echo "  --no-ensemble          use old ensemble structure with only 3 levels catalog/model/exp"
+    echo "  -f, --format FORMAT    specify image formats to transfer (default is 'pdf,png,svg')"
     echo "  -h, --help             display this help and exit"
     echo "  -l, --loglevel LEVEL   set the log level (1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR, 5=CRITICAL). Default is 2."
     echo "  -r, --repository       remote aqua-web repository (default 'DestinE-Climate-DT/aqua-web'). If it starts with 'local:' a local directory is used."
@@ -154,6 +169,7 @@ update=1
 rsync=""
 config=""
 ensemble=1  # Default to new ensemble structure with 4 levels (catalog/model/experiment/realization)
+format="pdf png svg"
 
 # Parse all options first
 while [[ $# -gt 0 ]]; do
@@ -180,6 +196,10 @@ while [[ $# -gt 0 ]]; do
         ;;
     -b|--bucket)
         bucket="$2"
+        shift 2
+        ;;
+    -f|--format)
+        format=$(echo "$2" | tr ',' ' ')
         shift 2
         ;;
     -s|--rsync)
@@ -275,7 +295,7 @@ echo "Updated figures in bucket $bucket"  > updated.txt
 echo "on $(date) for the following experiments:" >> updated.txt
 
 # erase content and copy all files to content
-log_message INFO "Collect and update figures in content/pdf and content/png"
+log_message INFO "Collect and update figures in content/pdf, content/png and content/svg"
 
 # Check if the second argument is an actual file and use it as a list of experiments
 if [ -f "$exps" ]; then

--- a/docs/sphinx/source/dashboard.rst
+++ b/docs/sphinx/source/dashboard.rst
@@ -104,6 +104,10 @@ Additional options
 
     Compatibility flag to process experiments with old 3-level structure (``catalog/model/experiment``).
 
+.. option:: -f <format>, --format <format>
+
+    Specify image formats to transfer, using a comma-separated list (default is 'pdf,png,svg').
+
 .. option:: -h, --help
 
     Display the help and exit.


### PR DESCRIPTION
## PR description:

Adds support for SVG metadata for push_analysis (make_contents). 
Added a `--format` option to select on which formats to work (can be a list) for push_analysis. By default it tries them all.

## Issues closed by this pull request:
Close #2868

----
 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
 - [x] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
