### PR TITLE
[DROP] netcdf driver daily saving frequency

### DIFF
--- a/aqua/core/console/drop.py
+++ b/aqua/core/console/drop.py
@@ -82,6 +82,10 @@ def drop_parser(parser=None):
                         help='Output directory. Required when running without a config file.')
     parser.add_argument('--tmpdir', type=str,
                         help='Temporary directory. Required when running without a config file.')
+    parser.add_argument('--save-frequency', type=str, choices=['monthly', 'daily'],
+                        help='Checkpoint granularity for writing intermediate files: '
+                             "'monthly' (default) writes one file per month; "
+                             "'daily' writes one file per day (netcdf only).")
     # fmt: on
     return parser
 
@@ -164,6 +168,7 @@ def drop_execute(args):
     loglevel = get_arg(args, "loglevel", _cfg(config, "options", "loglevel", "WARNING"))
     compact = _cfg(config, "options", "compact", "cdo")
     driver = get_arg(args, "driver", _cfg(config, "options", "driver", "netcdf"))
+    save_frequency = get_arg(args, "save_frequency", _cfg(config, "options", "save_frequency", "monthly"))
 
     # Other options, only from command line
     definitive = get_arg(args, "definitive", False)
@@ -218,6 +223,7 @@ def drop_execute(args):
         catalog_entry=catalog_entry,
         driver=driver,
         exclude_incomplete=exclude_incomplete,
+        save_frequency=save_frequency,
     )
 
 
@@ -247,6 +253,7 @@ def drop_cli(
     compact="cdo",
     catalog_entry="yes",
     exclude_incomplete=True,
+    save_frequency="monthly",
 ):
     """
     Running the default DROP from CLI, looping on all the configuration model/exp/source/var combination
@@ -276,6 +283,7 @@ def drop_cli(
         compact: compaction method
         catalog_entry: catalog entry behaviour ('yes', 'no', 'only')
         exclude_incomplete: bool flag to exclude incomplete temporal chunks when averaging
+        save_frequency: checkpoint granularity ('monthly' or 'daily')
     """
 
     models = to_list(get_arg(args, "model", config["data"]))
@@ -341,6 +349,7 @@ def drop_cli(
                             exclude_incomplete=exclude_incomplete,
                             output_format=driver,
                             engine=engine,
+                            save_frequency=save_frequency,
                             **extra_args,
                         )
 

--- a/aqua/core/drop/drop.py
+++ b/aqua/core/drop/drop.py
@@ -81,6 +81,7 @@ class Drop:
         engine="fdb",
         output_format="netcdf",
         zarr_chunks=None,
+        save_frequency="monthly",
         **kwargs,
     ):
         """
@@ -134,6 +135,9 @@ class Drop:
             output_format (string, opt): Output format: 'netcdf', 'zarr' or 'icechunk'.
                                          Default is 'netcdf'. When set to 'icechunk',
                                          catalog entry generation is skipped.
+            save_frequency (string, opt): Checkpoint granularity for writing intermediate files.
+                                          'monthly' (default) writes one file per month;
+                                          'daily' writes one file per day (netcdf only).
             **kwargs:                kwargs to be sent to the Reader, as 'zoom' or 'realization'
         """
 
@@ -185,6 +189,7 @@ class Drop:
         self.output_format = output_format
         self.compact = compact
         self.zarr_chunks = zarr_chunks
+        self.save_frequency = save_frequency
 
         # validate parameters and raise errors if needed
         self._issue_info_raise()
@@ -279,6 +284,8 @@ class Drop:
         else:
             self.logger.info("Frequency: %s", self.frequency)
 
+        self.logger.info("Save frequency (checkpoint granularity): %s", self.save_frequency)
+
         if self.overwrite:
             self.logger.warning("File will be overwritten if already existing.")
 
@@ -313,6 +320,12 @@ class Drop:
         # Validate output format
         if self.output_format not in ["netcdf", "zarr", "icechunk"]:
             raise ValueError("output_format must be 'netcdf', 'zarr' or 'icechunk'")
+
+        # Validate save_frequency
+        if self.save_frequency not in ["monthly", "daily"]:
+            raise ValueError("save_frequency must be 'monthly' or 'daily'")
+        if self.save_frequency == "daily" and self.output_format != "netcdf":
+            raise ValueError("save_frequency='daily' is currently supported only for output_format='netcdf'")
 
         # Zarr/icechunk do not support post-write compact (they write in-place)
         if self.output_format in ("zarr", "icechunk"):
@@ -478,6 +491,7 @@ class Drop:
                 tmpdir=self.tmpdir,
                 outdir=self.outdir,
                 compact=self.compact,
+                save_frequency=self.save_frequency,
                 filename_builder=self.outbuilder,
                 loglevel=self.loglevel,
             )
@@ -529,9 +543,9 @@ class Drop:
         self.logger.info("Removing temporary directory %s", self.tmpdir)
         shutil.rmtree(self.tmpdir)
 
-    def get_filename(self, var, year=None, month=None, tmp=False):
+    def get_filename(self, var, year=None, month=None, day=None, tmp=False):
         """Create output filenames (delegates to writer)"""
-        return self.writer.get_filename(var, year=year, month=month, tmp=tmp)
+        return self.writer.get_filename(var, year=year, month=month, day=day, tmp=tmp)
 
     def check_integrity(self, varname):
         """To check if the DROP entry is fine before running (delegates to writer)"""

--- a/aqua/core/drop/drop_writer_base.py
+++ b/aqua/core/drop/drop_writer_base.py
@@ -277,6 +277,33 @@ class BaseWriter(ABC):
         for day in days:
             yield day, month_data.sel(time=month_data.time.dt.day == day)
 
+    def _month_day_coverage(self, month_data, year, month):
+        """Return day coverage information for a given year-month slice.
+
+        This is used by daily save mode to avoid compacting partial months into
+        a monthly file.
+
+        Args:
+            month_data: xarray Dataset/DataArray for a single month.
+            year: Year.
+            month: Month.
+
+        Returns:
+            tuple: (present_days, expected_days, is_complete_month)
+        """
+        expected_days = pd.Period(f"{int(year):04d}-{int(month):02d}").days_in_month
+
+        if "time" not in month_data.coords or month_data.time.size == 0:
+            return 0, expected_days, False
+
+        times = pd.DatetimeIndex(pd.to_datetime(month_data.time.values))
+        present_days = times.normalize().nunique()
+        min_day = int(times.day.min())
+        max_day = int(times.day.max())
+
+        is_complete_month = present_days == expected_days and min_day == 1 and max_day == expected_days
+        return present_days, expected_days, is_complete_month
+
     def _write_chunk(self, data, var, year, month, day=None, dask=False, performance_reporting=False):
         """
         Write a single chunk (monthly or daily).
@@ -544,10 +571,11 @@ class BaseWriter(ABC):
         Write complete variable with all year/month(/day) logic.
 
         Template method that orchestrates the complete write process.
-        When ``save_frequency="daily"``, each day is written as a separate chunk
-        and daily files are concatenated into monthly files before the optional
-        yearly concat.  When ``save_frequency="monthly"`` (default), the
-        existing monthly behaviour is preserved.
+        When ``save_frequency="daily"``, each day is written as a separate chunk.
+        Daily files are concatenated into monthly files only for full calendar
+        months before the optional yearly concat. When
+        ``save_frequency="monthly"`` (default), the existing monthly behaviour
+        is preserved.
 
         1. Split data into years
         2. For each year:
@@ -699,8 +727,20 @@ class BaseWriter(ABC):
                 self.logger.info("Moving temporary file %s to %s", tmpfile, dayfile)
                 move_tmp_files(self.tmpdir, self.outdir)
 
-        # After all days in the month, concatenate daily → monthly if supported
+        # After all days in the month, concatenate daily → monthly only when the
+        # month coverage is complete. This avoids compacting truncated ranges.
         if definitive and self._should_concat():
+            present_days, expected_days, is_complete_month = self._month_day_coverage(month_data, year, month)
+            if not is_complete_month:
+                self.logger.info(
+                    "Skipping daily-to-monthly compaction for %s %04d-%02d: partial month (%d/%d days present)",
+                    var,
+                    int(year),
+                    int(month),
+                    present_days,
+                    expected_days,
+                )
+                return
             self.concat_month_files(var, year, month)
 
     def _record_chunk_stats(self, var, year, month, t_elapsed, size_bytes, stats_file, day=None):

--- a/aqua/core/drop/drop_writer_base.py
+++ b/aqua/core/drop/drop_writer_base.py
@@ -51,6 +51,7 @@ class BaseWriter(ABC):
         tmpdir: str,
         outdir: str,
         filename_builder: OutputPathBuilder = None,
+        save_frequency: str = "monthly",
         loglevel: str = "WARNING",
     ):
         """
@@ -60,12 +61,14 @@ class BaseWriter(ABC):
             tmpdir: Temporary directory for intermediate files
             outdir: Output directory for final files
             filename_builder: OutputPathBuilder instance for filename generation
+            save_frequency: Checkpoint granularity ('monthly' or 'daily'). Default 'monthly'.
             loglevel: Logging level
         """
         self.tmpdir = tmpdir
         self.outdir = outdir
         self.filename_builder = filename_builder
         self.logger = log_configure(loglevel, self.__class__.__name__)
+        self.save_frequency = save_frequency
         self._chunk_stats = []
         self._last_mem_stats = None
         self._last_chunk_size_bytes = None
@@ -258,9 +261,25 @@ class BaseWriter(ABC):
         for month in months:
             yield month, year_data.sel(time=year_data.time.dt.month == month)
 
-    def _write_chunk(self, data, var, year, month, dask=False, performance_reporting=False):
+    def _iter_days_in_month(self, month_data, performance_reporting):
+        """Yield (day, day_data) pairs for each day present in month_data.
+
+        Args:
+            month_data: xarray Dataset for a single month.
+            performance_reporting: If True, yield only the first day.
+
+        Yields:
+            tuple: (day, day_data) where day is an int and day_data has original attrs.
         """
-        Write a single monthly chunk.
+        days = sorted(set(month_data.time.dt.day.values))
+        if performance_reporting:
+            days = [days[0]]
+        for day in days:
+            yield day, month_data.sel(time=month_data.time.dt.day == day)
+
+    def _write_chunk(self, data, var, year, month, day=None, dask=False, performance_reporting=False):
+        """
+        Write a single chunk (monthly or daily).
 
         Template method that orchestrates the write process:
         1. Compute data with monitoring
@@ -268,17 +287,18 @@ class BaseWriter(ABC):
         3. Write to disk using format-specific method
 
         Args:
-            data: xarray Dataset/DataArray for one month
+            data: xarray Dataset/DataArray for one chunk
             var: Variable name
             year: Year
             month: Month
+            day: Day (only for daily save_frequency)
             dask: If True, use Dask for distributed computing
             performance_reporting: Enable performance reporting
 
         Returns:
             bool: True if write successful
         """
-        tmpfile = self.get_filename(var, year=year, month=month, tmp=True)
+        tmpfile = self.get_filename(var, year=year, month=month, day=day, tmp=True)
 
         # Remove existing tmpfile
         if os.path.exists(tmpfile):
@@ -308,14 +328,31 @@ class BaseWriter(ABC):
 
         return success
 
-    def get_filename(self, var, year=None, month=None, tmp=False):
+    def concat_month_files(self, var, year, month):
+        """Concatenate daily files into a single monthly file.
+
+        Base implementation is a no-op; override in format-specific writers
+        that support daily saving (currently only NetCDFWriter).
+
+        Args:
+            var: Variable name.
+            year: Year.
+            month: Month.
+
+        Returns:
+            bool: False (not supported at base level).
         """
-        Generate filename/storename (monthly or yearly).
+        return False
+
+    def get_filename(self, var, year=None, month=None, day=None, tmp=False):
+        """
+        Generate filename/storename (daily, monthly, or yearly).
 
         Args:
             var: Variable name
             year: Year (for yearly or monthly files)
-            month: Month (for monthly files, optional)
+            month: Month (for monthly or daily files, optional)
+            day: Day (for daily files, optional)
             tmp: If True, return path in tmpdir
 
         Returns:
@@ -323,7 +360,7 @@ class BaseWriter(ABC):
         """
         ext = self.get_extension()
 
-        filename = self.filename_builder.build_filename(var=var, year=year, month=month)
+        filename = self.filename_builder.build_filename(var=var, year=year, month=month, day=day)
         # Replace extension if needed
         if not filename.endswith(ext):
             filename = os.path.splitext(filename)[0] + ext
@@ -504,18 +541,22 @@ class BaseWriter(ABC):
         stats_file=None,
     ):
         """
-        Write complete variable with all year/month logic.
+        Write complete variable with all year/month(/day) logic.
 
-        Template method that orchestrates the complete write process:
+        Template method that orchestrates the complete write process.
+        When ``save_frequency="daily"``, each day is written as a separate chunk
+        and daily files are concatenated into monthly files before the optional
+        yearly concat.  When ``save_frequency="monthly"`` (default), the
+        existing monthly behaviour is preserved.
+
         1. Split data into years
         2. For each year:
            - Check if yearly file exists
            - Split into months
            - For each month:
-             * Check if monthly file exists
-             * Write monthly chunk
-             * Validate tmpfile
-             * Move tmpfile to outdir (IMMEDIATELY)
+             * (monthly) Check if monthly file exists, write monthly chunk
+             * (daily)   For each day: check/write daily chunk; after all days
+                         call concat_month_files to merge daily → monthly
            - Concatenate monthly files into yearly file
         3. Return success status
 
@@ -525,7 +566,7 @@ class BaseWriter(ABC):
             overwrite: Overwrite existing files
             definitive: Actually write files (vs dry-run)
             dask: If True, use Dask for distributed computing
-            performance_reporting: Limit to first month only
+            performance_reporting: Limit to first month/day only
             stats_file: Path to stats text file for immediate per-chunk writes. None disables writing.
         """
         for year, year_data in self._iter_years(data, performance_reporting):
@@ -541,38 +582,52 @@ class BaseWriter(ABC):
 
             for month, month_data in self._iter_months_in_year(year_data, performance_reporting):
                 self.logger.info("Processing month %s...", str(month))
-                monthfile = self.get_filename(var, year=year, month=month)
 
-                # Check if monthly file exists
-                if os.path.exists(monthfile):
-                    if not overwrite:
-                        self.logger.info("Monthly file %s already exists, skipping...", monthfile)
-                        continue
-                    self.logger.warning("Monthly file %s already exists, overwriting...", monthfile)
-
-                # Write file
-                if definitive:
-                    tmpfile = self.get_filename(var, year=year, month=month, tmp=True)
-                    t_start = time()
-                    success = self._write_chunk(
-                        month_data, var, year, month, dask=dask, performance_reporting=performance_reporting
+                if self.save_frequency == "daily":
+                    self._write_month_as_daily_chunks(
+                        month_data,
+                        var,
+                        year,
+                        month,
+                        overwrite=overwrite,
+                        definitive=definitive,
+                        dask=dask,
+                        performance_reporting=performance_reporting,
+                        stats_file=stats_file,
                     )
-                    t_elapsed = time() - t_start
-                    self.logger.info("Chunk execution time: %.2f", t_elapsed)
-                    self._record_chunk_stats(var, year, month, t_elapsed, self._last_chunk_size_bytes, stats_file)
+                else:
+                    # Default monthly behaviour
+                    monthfile = self.get_filename(var, year=year, month=month)
 
-                    if not success:
-                        self.logger.error("Failed to write chunk for %s-%s", year, month)
-                        continue
+                    # Check if monthly file exists
+                    if os.path.exists(monthfile):
+                        if not overwrite:
+                            self.logger.info("Monthly file %s already exists, skipping...", monthfile)
+                            continue
+                        self.logger.warning("Monthly file %s already exists, overwriting...", monthfile)
 
-                    # Validate temp file
-                    if not self.validate(tmpfile):
-                        self.logger.error("Something has gone wrong in %s!", tmpfile)
-                        continue
+                    if definitive:
+                        tmpfile = self.get_filename(var, year=year, month=month, tmp=True)
+                        t_start = time()
+                        success = self._write_chunk(
+                            month_data, var, year, month, dask=dask, performance_reporting=performance_reporting
+                        )
+                        t_elapsed = time() - t_start
+                        self.logger.info("Chunk execution time: %.2f", t_elapsed)
+                        self._record_chunk_stats(var, year, month, t_elapsed, self._last_chunk_size_bytes, stats_file)
 
-                    # Move IMMEDIATELY (NetCDF timing, not Zarr's deferred move)
-                    self.logger.info("Moving temporary file %s to %s", tmpfile, monthfile)
-                    move_tmp_files(self.tmpdir, self.outdir)
+                        if not success:
+                            self.logger.error("Failed to write chunk for %s-%s", year, month)
+                            continue
+
+                        # Validate temp file
+                        if not self.validate(tmpfile):
+                            self.logger.error("Something has gone wrong in %s!", tmpfile)
+                            continue
+
+                        # Move IMMEDIATELY
+                        self.logger.info("Moving temporary file %s to %s", tmpfile, monthfile)
+                        move_tmp_files(self.tmpdir, self.outdir)
 
             # Concatenate into yearly file if concat enabled
             if definitive and self._should_concat():
@@ -580,7 +635,75 @@ class BaseWriter(ABC):
 
         return True
 
-    def _record_chunk_stats(self, var, year, month, t_elapsed, size_bytes, stats_file):
+    def _write_month_as_daily_chunks(
+        self,
+        month_data,
+        var,
+        year,
+        month,
+        overwrite=False,
+        definitive=True,
+        dask=False,
+        performance_reporting=False,
+        stats_file=None,
+    ):
+        """Write all daily chunks for a single month, then concat into a monthly file.
+
+        Called by ``write_variable`` when ``save_frequency="daily"``.
+
+        Args:
+            month_data: xarray Dataset for a single month.
+            var: Variable name.
+            year: Year.
+            month: Month.
+            overwrite: Overwrite existing files.
+            definitive: Actually write files (vs dry-run).
+            dask: If True, use Dask for distributed computing.
+            performance_reporting: If True, process only the first day.
+            stats_file: Path to stats text file, or None.
+        """
+        for day, day_data in self._iter_days_in_month(month_data, performance_reporting):
+            self.logger.info("Processing day %s...", str(day))
+            dayfile = self.get_filename(var, year=year, month=month, day=day)
+
+            if os.path.exists(dayfile):
+                if not overwrite:
+                    self.logger.info("Daily file %s already exists, skipping...", dayfile)
+                    continue
+                self.logger.warning("Daily file %s already exists, overwriting...", dayfile)
+
+            if definitive:
+                tmpfile = self.get_filename(var, year=year, month=month, day=day, tmp=True)
+                t_start = time()
+                success = self._write_chunk(
+                    day_data,
+                    var,
+                    year,
+                    month,
+                    day=day,
+                    dask=dask,
+                    performance_reporting=performance_reporting,
+                )
+                t_elapsed = time() - t_start
+                self.logger.info("Chunk execution time: %.2f", t_elapsed)
+                self._record_chunk_stats(var, year, month, t_elapsed, self._last_chunk_size_bytes, stats_file, day=day)
+
+                if not success:
+                    self.logger.error("Failed to write daily chunk for %s-%s-%s", year, month, day)
+                    continue
+
+                if not self.validate(tmpfile):
+                    self.logger.error("Something has gone wrong in %s!", tmpfile)
+                    continue
+
+                self.logger.info("Moving temporary file %s to %s", tmpfile, dayfile)
+                move_tmp_files(self.tmpdir, self.outdir)
+
+        # After all days in the month, concatenate daily → monthly if supported
+        if definitive and self._should_concat():
+            self.concat_month_files(var, year, month)
+
+    def _record_chunk_stats(self, var, year, month, t_elapsed, size_bytes, stats_file, day=None):
         """Record per-chunk performance stats and optionally append to the stats file.
 
         Resets ``_last_mem_stats`` and ``_last_chunk_size_bytes`` after recording
@@ -593,11 +716,13 @@ class BaseWriter(ABC):
             t_elapsed: Wall-clock elapsed time in seconds.
             size_bytes: Uncompressed data size in bytes, or None.
             stats_file: Path to the stats text file, or None to skip file write.
+            day: Day of the chunk (only for daily save_frequency). Defaults to None.
         """
         entry = {
             "var": var,
             "year": year,
             "month": month,
+            "day": day,
             "elapsed": t_elapsed,
             "mem": self._last_mem_stats,
             "size_bytes": size_bytes,
@@ -618,9 +743,11 @@ class BaseWriter(ABC):
         mem_str = f"  avg_mem={mem['avg_mem']:.2f} GiB  peak_mem={mem['max_mem']:.2f} GiB" if mem is not None else ""
         size_str = f"  size={size_bytes / (1024**2):.1f} MiB" if size_bytes is not None else ""
         tp_str = f"  throughput={tp:.2f} MiB/s" if tp is not None else ""
+        day = entry.get("day")
+        day_str = f"  day={day:02d}" if day is not None else ""
         line = (
             f"[{ts}] CHUNK  var={entry['var']}  year={entry['year']}  "
-            f"month={entry['month']:02d}  elapsed={entry['elapsed']:.2f}s{size_str}{tp_str}{mem_str}\n"
+            f"month={entry['month']:02d}{day_str}  elapsed={entry['elapsed']:.2f}s{size_str}{tp_str}{mem_str}\n"
         )
         with open(stats_file, "a", encoding="utf-8") as fh:
             fh.write(line)

--- a/aqua/core/drop/drop_writer_netcdf.py
+++ b/aqua/core/drop/drop_writer_netcdf.py
@@ -5,6 +5,8 @@ Handles writing climate data chunks to NetCDF files with optional concatenation
 into yearly files. Supports both xarray and CDO for file concatenation.
 """
 
+import glob
+import os
 import shutil
 import subprocess
 
@@ -26,7 +28,7 @@ class NetCDFWriter(BaseWriter):
     """
     Writer for NetCDF format in DROP processing.
 
-    Handles monthly file creation and optional yearly concatenation.
+    Handles daily or monthly file creation and optional yearly concatenation.
     """
 
     def __init__(
@@ -34,6 +36,7 @@ class NetCDFWriter(BaseWriter):
         tmpdir,
         outdir,
         compact="xarray",
+        save_frequency="monthly",
         **kwargs,
     ):
         """
@@ -43,9 +46,10 @@ class NetCDFWriter(BaseWriter):
             tmpdir: Temporary directory for intermediate files
             outdir: Output directory for final files
             compact: Concatenation method ('xarray', 'cdo', or None)
+            save_frequency: Checkpoint granularity ('monthly' or 'daily'). Default 'monthly'.
             **kwargs: Additional arguments passed to BaseWriter
         """
-        super().__init__(tmpdir, outdir, **kwargs)
+        super().__init__(tmpdir, outdir, save_frequency=save_frequency, **kwargs)
         self.time_encoding = TIME_ENCODING
         self.var_encoding = VAR_ENCODING
         self.compact = compact
@@ -151,4 +155,70 @@ class NetCDFWriter(BaseWriter):
 
         except Exception as e:
             self.logger.error("Failed to concatenate monthly files: %s", e)
+            return False
+
+    def concat_month_files(self, var, year, month):
+        """
+        Concatenate daily files into a single monthly file.
+
+        Used when ``save_frequency='daily'``.  Expects one file per calendar day
+        present in the data for the given year-month; accepts any number >= 1.
+
+        Args:
+            var: Variable name
+            year: Year
+            month: Month
+
+        Returns:
+            bool: True if successful
+        """
+        # Gather daily files for this month using a glob on the day component
+        daily_pattern = self.get_filename(var, year=year, month=month, day="??")
+        daily_files = sorted(glob.glob(daily_pattern))
+
+        if not daily_files:
+            self.logger.warning("No daily files found for %s year %s month %s", var, year, month)
+            return False
+
+        self.logger.info(
+            "Concatenating %d daily files into monthly file for %s %s-%02d...",
+            len(daily_files),
+            var,
+            year,
+            month,
+        )
+
+        month_file = self.get_filename(var, year=year, month=month)
+        tmp_month_file = os.path.join(self.tmpdir, os.path.basename(month_file))
+
+        # Move daily files to tmpdir for safety
+        for daily_file in daily_files:
+            shutil.move(daily_file, self.tmpdir)
+        tmp_daily_files = [os.path.join(self.tmpdir, os.path.basename(f)) for f in daily_files]
+
+        # Remove any pre-existing monthly file
+        for f in [tmp_month_file, month_file]:
+            if os.path.exists(f):
+                os.remove(f)
+
+        try:
+            if self.compact == "cdo":
+                command = ["cdo", *self.cdo_options, "cat", *tmp_daily_files, tmp_month_file]
+                self.logger.debug("Using CDO: %s", " ".join(command[:4]) + " ...")
+                subprocess.check_output(command, stderr=subprocess.STDOUT)
+            else:
+                self.logger.debug("Using xarray for daily-to-monthly concatenation")
+                ds = self._open_files(tmp_daily_files)
+                var_name = list(ds.data_vars)[0]
+                ds.to_netcdf(
+                    tmp_month_file,
+                    encoding={"time": self.time_encoding, var_name: self.var_encoding},
+                )
+
+            shutil.move(tmp_month_file, month_file)
+            self._cleanup_monthly_files(tmp_daily_files)
+            return True
+
+        except Exception as e:
+            self.logger.error("Failed to concatenate daily files into monthly file: %s", e)
             return False

--- a/tests/test_drop.py
+++ b/tests/test_drop.py
@@ -12,6 +12,7 @@ from aqua import Drop
 from aqua.core.drop.catalog_entry_builder import CatalogEntryBuilder
 from aqua.core.drop.drop import available_stats
 from aqua.core.drop.drop_writer_icechunk import IcechunkWriter
+from aqua.core.drop.drop_writer_netcdf import NetCDFWriter
 from aqua.core.drop.drop_writer_zarr import ZarrWriter
 from aqua.core.drop.output_path_builder import OutputPathBuilder
 from aqua.core.lock import SafeFileLock
@@ -404,6 +405,51 @@ class TestDROP:
                 assert os.path.exists(monthly_file), f"Monthly file/store {monthly_file} should exist"
 
         shutil.rmtree(os.path.join(drop_arguments["outdir"]))
+
+    def test_daily_save_frequency_skips_partial_month_compaction(self, drop_arguments, tmp_path):
+        """Daily save mode must not compact when the requested month is partial."""
+        outdir = tmp_path / "out"
+        tmpdir = tmp_path / "tmp"
+        os.makedirs(outdir, exist_ok=True)
+        os.makedirs(tmpdir, exist_ok=True)
+
+        builder = OutputPathBuilder(
+            catalog="ci",
+            model=drop_arguments["model"],
+            exp=drop_arguments["exp"],
+            realization="r1",
+            resolution="r100",
+            frequency="daily",
+            stat="mean",
+            region="global",
+        )
+
+        writer = NetCDFWriter(
+            tmpdir=str(tmpdir),
+            outdir=str(outdir),
+            compact="xarray",
+            save_frequency="daily",
+            filename_builder=builder,
+            loglevel=LOGLEVEL,
+        )
+
+        var = drop_arguments["var"]
+        data = xr.DataArray(
+            range(10),
+            dims=["time"],
+            coords={"time": pd.date_range("2020-01-01", periods=10, freq="D")},
+            name=var,
+        )
+
+        writer.write_variable(data=data, var=var, overwrite=True, definitive=True, dask=False)
+
+        monthly_file = writer.get_filename(var, year=2020, month="01")
+        day1_file = writer.get_filename(var, year=2020, month="01", day="01")
+        day10_file = writer.get_filename(var, year=2020, month="01", day="10")
+
+        assert not os.path.exists(monthly_file), "Partial month should not be compacted into a monthly file"
+        assert os.path.exists(day1_file), "Daily file for first requested day should exist"
+        assert os.path.exists(day10_file), "Daily file for last requested day should exist"
 
     def test_unknown_statistic(self, drop_arguments, tmp_path):
         """Test DROP with an unknown statistic."""


### PR DESCRIPTION
## PR description:

Quick draft of a daily saving freq for the netcdf driver. I'm going to test it with histograms to check if my previous machinery can be simply part of an extra feature for DROP and not an aqua-friends

## Issues closed by this pull request:

Close #2886 

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated.
 - [ ] Run Cross check tests for AQUA-diagnostics [AQUA-diagnostics cross-check workflow](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/actions/workflows/aqua-diagnostics-cross-check.yml)
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. Installation instructions are updated if new conda dependencies are added.
 - [ ] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
