### PR TITLE
DROP missing native resolution in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ClimateDT workflow modifications:
 Main changes:
 
 Complete list:
+- DROP: resolution is now always present in paths and filenames as a string, with "native" as default value if not specified (#2898)
 - Add references to climatedt-community-resources in getting_started.rst and polytope.rst (#2854)
 - Introduce a `aqua grids deploy` command to deploy target grids from a bucket to the local file system (#2865)
 - AQUA analysis accept a `--kind` option to apply jinja templating for diagnostic configuration files (#2834)

--- a/aqua/core/drop/output_path_builder.py
+++ b/aqua/core/drop/output_path_builder.py
@@ -44,10 +44,13 @@ class OutputPathBuilder:
         self.catalog = catalog
         self.model = model
         self.exp = exp
-        self.resolution = resolution
+
+        # Treat missing resolution or frequency as 'native' so paths explicitly reflect
+        # that no spatial or temporal manipulation was performed.
+        self.resolution = resolution if resolution is not None else "native"
+        self.frequency = frequency if frequency is not None else "native"
 
         self.realization = format_realization(realization)  # ensure realization is formatted correctly
-        self.frequency = frequency if frequency is not None else "native"
         self.stat = stat if stat is not None else "nostat"
         self.region = region if region is not None else "global"
 

--- a/tests/test_drop.py
+++ b/tests/test_drop.py
@@ -36,7 +36,7 @@ class TestOutputPathBuilder:
 
     expected = [
         None,
-        "ci/IFS/test-tco79/r1/native/nostat/europe/2t_ci_IFS_test-tco79_r1_native_nostat_europe_202001.nc",
+        "ci/IFS/test-tco79/r1/native/native/nostat/europe/2t_ci_IFS_test-tco79_r1_native_native_nostat_europe_202001.nc",
         None,
     ]
 


### PR DESCRIPTION
## PR description:

When `resolution` was set to `None` in drop the `native` info was missing in paths and filenames.
The PR add native on those when there is no resolution manipulation. 
However this will duplicate the native info and change the path for some DROP so I'm open to feedbacks.

## People involved:
@oloapinivad 

 - [x] Tests are included if a new feature is included.
 - [x] Changelog is updated.
 - [x] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
