### PR TITLE
Prettify contour line levels in plot_single_map_diff

### DIFF
--- a/aqua/core/graphics/single_map.py
+++ b/aqua/core/graphics/single_map.py
@@ -30,6 +30,7 @@ from aqua.core.util import (
     set_ticks,
 )
 from aqua.core.util.graphics import isnpixok
+from aqua.core.util.graphics import prettify_levels, get_decimals
 
 from .gridlines import draw_manual_gridlines
 from .styles import ConfigStyle
@@ -392,22 +393,27 @@ def plot_single_map_diff(
     logger.debug("Setting contour vmin to %s, vmax to %s", vmin_contour, vmax_contour)
 
     if add_contour:
+        pretty_levels = prettify_levels(vmin_contour, vmax_contour, line_levels)
+        logger.debug("Pretty contour levels: %s", pretty_levels)
+
         ds = data.plot.contour(
             ax=ax,
             transform=ccrs.PlateCarree(),
-            vmin=vmin_contour,
-            vmax=vmax_contour,
-            levels=line_levels,
+            levels=pretty_levels,       
             colors="k",
             linewidths=0.5,
         )
 
-        fmt = {
-            level: "0.0"
-            if np.isclose(level, 0.0)
-            else (f"{level:.1e}" if (abs(level) < 0.1 or abs(level) > 1000) else f"{level:.1f}")
-            for level in ds.levels
-        }
+        # Label format: integer if step >= 1, otherwise minimum required decimal places
+        step = pretty_levels[1] - pretty_levels[0] if len(pretty_levels) > 1 else 1
+        decimals = get_decimals(step)
+        fmt = {}
+        for level in ds.levels:
+            if abs(level) >= 1000 or (abs(level) < 0.01 and level != 0):
+                fmt[level] = f"{level:.2e}"
+            else:
+                fmt[level] = f"{level:.{decimals}f}"
+
         ax.clabel(ds, fmt=fmt, fontsize=6, inline=True)
 
     if title:

--- a/aqua/core/graphics/single_map.py
+++ b/aqua/core/graphics/single_map.py
@@ -399,7 +399,7 @@ def plot_single_map_diff(
         ds = data.plot.contour(
             ax=ax,
             transform=ccrs.PlateCarree(),
-            levels=pretty_levels,       
+            levels=pretty_levels,
             colors="k",
             linewidths=0.5,
         )

--- a/aqua/core/graphics/single_map.py
+++ b/aqua/core/graphics/single_map.py
@@ -29,8 +29,7 @@ from aqua.core.util import (
     set_map_title,
     set_ticks,
 )
-from aqua.core.util.graphics import isnpixok
-from aqua.core.util.graphics import prettify_levels, get_decimals
+from aqua.core.util.graphics import get_decimals, isnpixok, prettify_levels
 
 from .gridlines import draw_manual_gridlines
 from .styles import ConfigStyle

--- a/aqua/core/util/__init__.py
+++ b/aqua/core/util/__init__.py
@@ -8,6 +8,7 @@ from .graphics import evaluate_colorbar_limits, cbar_get_label, set_map_title
 from .graphics import coord_names, ticks_round, set_ticks, generate_colorbar_ticks
 from .graphics import apply_circular_window
 from .graphics import get_nside, get_npix, healpix_resample
+from .graphics import prettify_levels, get_decimals
 from .io_util import files_exist, create_folder, file_is_complete
 from .io_util import update_metadata
 from .projections import get_projection
@@ -32,6 +33,7 @@ __all__ = ['replace_intake_vars', 'replace_urlpath_jinja', 'replace_urlpath_wild
            'coord_names', 'ticks_round', 'set_ticks', 'generate_colorbar_ticks',
            'apply_circular_window',
            'get_nside', 'get_npix', 'healpix_resample',
+           'prettify_levels', 'get_decimals',
            'files_exist', 'create_folder', 'file_is_complete',
            'update_metadata',
            'get_projection',

--- a/aqua/core/util/graphics.py
+++ b/aqua/core/util/graphics.py
@@ -15,7 +15,6 @@ from scipy.interpolate import griddata
 
 from aqua.core.logger import log_configure
 
-
 from .sci_util import check_coordinates
 from .string import unit_to_latex
 

--- a/aqua/core/util/graphics.py
+++ b/aqua/core/util/graphics.py
@@ -479,7 +479,7 @@ def prettify_levels(vmin: float, vmax: float, nlevels: int) -> np.ndarray:
         best_step = 10 * magnitude
 
     # Build levels aligned to zero if possible (cleaner grid)
-    start = np.ceil(vmin / best_step) * best_step
+    start = np.floor(vmin / best_step) * best_step
     levels = np.arange(start, vmax + best_step * 0.5, best_step)
 
     return np.round(levels, decimals=get_decimals(best_step))

--- a/aqua/core/util/graphics.py
+++ b/aqua/core/util/graphics.py
@@ -15,6 +15,7 @@ from scipy.interpolate import griddata
 
 from aqua.core.logger import log_configure
 
+
 from .sci_util import check_coordinates
 from .string import unit_to_latex
 
@@ -445,6 +446,53 @@ def apply_circular_window(ax, extent=None, apply_black_circle=False):
     return ax
 
 
+def prettify_levels(vmin: float, vmax: float, nlevels: int) -> np.ndarray:
+    """
+    Generate visually clean contour levels using rounded 'nice' numbers.
+    Prefer multiples of 1, 2, 2.5, 5, 10, 25, 50, ... depending on the range.
+
+    Args:
+        vmin (float):    Minimum value.
+        vmax (float):    Maximum value.
+        nlevels (int):   Approximate number of levels desired.
+
+    Returns:
+        np.ndarray: Array of pretty level values.
+    """
+    data_range = vmax - vmin
+    if data_range == 0:
+        return np.array([vmin])
+
+    raw_step = data_range / nlevels
+
+    # Candidate "nice" multipliers
+    nice_multipliers = [1, 2, 2.5, 5, 10]
+    magnitude = 10 ** np.floor(np.log10(abs(raw_step)))
+
+    best_step = None
+    for m in nice_multipliers:
+        candidate = m * magnitude
+        if candidate >= raw_step:
+            best_step = candidate
+            break
+
+    if best_step is None:
+        best_step = 10 * magnitude
+
+    # Build levels aligned to zero if possible (cleaner grid)
+    start = np.ceil(vmin / best_step) * best_step
+    levels = np.arange(start, vmax + best_step * 0.5, best_step)
+
+    return np.round(levels, decimals=get_decimals(best_step))
+
+
+def get_decimals(step: float) -> int:
+    """Return the number of decimal places needed for a given step size."""
+    if step >= 1:
+        return 0
+    return max(0, int(np.ceil(-np.log10(step))))
+
+
 """
 Following functions are taken and adjusted from the easygems package,
 on this repository:
@@ -619,50 +667,3 @@ def healpix_resample(
     result = xr.DataArray(res, coords=[("lat", yvals), ("lon", xvals)])
     result.attrs = getattr(var, "attrs", {}).copy()
     return result
-
-
-def prettify_levels(vmin: float, vmax: float, nlevels: int) -> np.ndarray:
-    """
-    Generate visually clean contour levels using rounded 'nice' numbers.
-    Prefer multiples of 1, 2, 2.5, 5, 10, 25, 50, ... depending on the range.
-    
-    Args:
-        vmin (float):    Minimum value.
-        vmax (float):    Maximum value.
-        nlevels (int):   Approximate number of levels desired.
-
-    Returns:
-        np.ndarray: Array of pretty level values.
-    """
-    data_range = vmax - vmin
-    if data_range == 0:
-        return np.array([vmin])
-
-    raw_step = data_range / nlevels
-
-    # Candidate "nice" multipliers
-    nice_multipliers = [1, 2, 2.5, 5, 10]
-    magnitude = 10 ** np.floor(np.log10(abs(raw_step)))
-
-    best_step = None
-    for m in nice_multipliers:
-        candidate = m * magnitude
-        if candidate >= raw_step:
-            best_step = candidate
-            break
-
-    if best_step is None:
-        best_step = 10 * magnitude
-
-    # Build levels aligned to zero if possible (cleaner grid)
-    start = np.ceil(vmin / best_step) * best_step
-    levels = np.arange(start, vmax + best_step * 0.5, best_step)
-
-    return np.round(levels, decimals=get_decimals(best_step))
-
-
-def get_decimals(step: float) -> int:
-    """Return the number of decimal places needed for a given step size."""
-    if step >= 1:
-        return 0
-    return max(0, int(np.ceil(-np.log10(step))))

--- a/aqua/core/util/graphics.py
+++ b/aqua/core/util/graphics.py
@@ -619,3 +619,50 @@ def healpix_resample(
     result = xr.DataArray(res, coords=[("lat", yvals), ("lon", xvals)])
     result.attrs = getattr(var, "attrs", {}).copy()
     return result
+
+
+def prettify_levels(vmin: float, vmax: float, nlevels: int) -> np.ndarray:
+    """
+    Generate visually clean contour levels using rounded 'nice' numbers.
+    Prefer multiples of 1, 2, 2.5, 5, 10, 25, 50, ... depending on the range.
+    
+    Args:
+        vmin (float):    Minimum value.
+        vmax (float):    Maximum value.
+        nlevels (int):   Approximate number of levels desired.
+
+    Returns:
+        np.ndarray: Array of pretty level values.
+    """
+    data_range = vmax - vmin
+    if data_range == 0:
+        return np.array([vmin])
+
+    raw_step = data_range / nlevels
+
+    # Candidate "nice" multipliers
+    nice_multipliers = [1, 2, 2.5, 5, 10]
+    magnitude = 10 ** np.floor(np.log10(abs(raw_step)))
+
+    best_step = None
+    for m in nice_multipliers:
+        candidate = m * magnitude
+        if candidate >= raw_step:
+            best_step = candidate
+            break
+
+    if best_step is None:
+        best_step = 10 * magnitude
+
+    # Build levels aligned to zero if possible (cleaner grid)
+    start = np.ceil(vmin / best_step) * best_step
+    levels = np.arange(start, vmax + best_step * 0.5, best_step)
+
+    return np.round(levels, decimals=get_decimals(best_step))
+
+
+def get_decimals(step: float) -> int:
+    """Return the number of decimal places needed for a given step size."""
+    if step >= 1:
+        return 0
+    return max(0, int(np.ceil(-np.log10(step))))

--- a/tests/test_graphics-tools.py
+++ b/tests/test_graphics-tools.py
@@ -14,7 +14,7 @@ from aqua.core.util import (
     healpix_resample,
     set_map_title,
 )
-from aqua.core.util.graphics import add_cyclic_lon, minmax_maps, plot_box
+from aqua.core.util.graphics import add_cyclic_lon, get_decimals, minmax_maps, plot_box, prettify_levels
 
 loglevel = LOGLEVEL
 
@@ -239,3 +239,20 @@ class TestHealpixResample:
         result = healpix_resample(var, nx=20, ny=20, method="nearest")
         assert isinstance(result, xr.DataArray)
         assert result.ndim == 2
+        
+@pytest.mark.graphics
+class TestPrettifyLevels:
+ 
+    @pytest.mark.parametrize("vmin,vmax,n", [(0, 100, 10), (0, 0.05, 5), (0, 1e5, 4), (-50, 50, 10), (0, 9.999, 0.99)])
+    def test_prettify_levels(self, vmin, vmax, n):
+        levels = prettify_levels(vmin, vmax, n)
+        assert len(levels) >= 1
+        assert (np.diff(levels) > 0).all()
+ 
+    def test_prettify_levels_zero_range(self):
+        assert prettify_levels(5.0, 5.0, 10).tolist() == [5.0]
+ 
+    @pytest.mark.parametrize("step,expected", [(1, 0), (0.5, 1), (0.05, 2), (0.001, 3), (0.99, 1)])
+    def test_get_decimals(self, step, expected):
+        assert get_decimals(step) == expected
+ 

--- a/tests/test_graphics-tools.py
+++ b/tests/test_graphics-tools.py
@@ -239,20 +239,19 @@ class TestHealpixResample:
         result = healpix_resample(var, nx=20, ny=20, method="nearest")
         assert isinstance(result, xr.DataArray)
         assert result.ndim == 2
-        
+
+
 @pytest.mark.graphics
 class TestPrettifyLevels:
- 
     @pytest.mark.parametrize("vmin,vmax,n", [(0, 100, 10), (0, 0.05, 5), (0, 1e5, 4), (-50, 50, 10), (0, 9.999, 0.99)])
     def test_prettify_levels(self, vmin, vmax, n):
         levels = prettify_levels(vmin, vmax, n)
         assert len(levels) >= 1
         assert (np.diff(levels) > 0).all()
- 
+
     def test_prettify_levels_zero_range(self):
         assert prettify_levels(5.0, 5.0, 10).tolist() == [5.0]
- 
+
     @pytest.mark.parametrize("step,expected", [(1, 0), (0.5, 1), (0.05, 2), (0.001, 3), (0.99, 1)])
     def test_get_decimals(self, step, expected):
         assert get_decimals(step) == expected
- 


### PR DESCRIPTION
## PR description:

Contour levels are now generated using a "nice number" algorithm (multiples of 1, 2, 2.5, 5, 10 scaled to the appropriate magnitude) instead of raw linspace values. Labels are formatted consistently with the step size, using integers when possible and scientific notation only for extreme values.

From: 
<img width="931" height="579" alt="Screenshot 2026-06-09 at 18 18 11" src="https://github.com/user-attachments/assets/bdc63510-4e23-481d-aa69-a4be3a782eeb" />

To:
<img width="906" height="605" alt="Screenshot 2026-06-09 at 19 00 38" src="https://github.com/user-attachments/assets/5b007340-c925-49cd-b0d5-04cdbe888426" />

## Issues closed by this pull request:

Close #2676 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.
 - [ ] Changelog is updated.
 - [ ] Run Cross check tests for AQUA-diagnostics [AQUA-diagnostics cross-check workflow](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/actions/workflows/aqua-diagnostics-cross-check.yml)
 - [ ] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
