### PR TITLE
More info in last_update key for content.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
+- More info on the origin of a push to lumi-o in the logs (#2910)
 - DROP: `drop` option from the `region` block is correctly handled, specifying if the NaN around the region should be kept or not (#2903)
 - DROP: add a `regrid_first` option to perform regridding before time statistics, useful when time-statistics can remove spatial coords (#2899)
 

--- a/cli/aqua-web/push_analysis.sh
+++ b/cli/aqua-web/push_analysis.sh
@@ -119,7 +119,7 @@ collect_figures() {
         dstdir="./content/$fmt/$2"
         mkdir -p $dstdir
         find $indir -name "*.$fmt"  -exec cp {} $dstdir/ \;
-        echo $(date) > $dstdir/last_update.txt
+        echo $(date) $(whoami) @ $(uname -n) $(hostname -I) > $dstdir/last_update.txt
     done
 
     # Copy experiment.yaml if it exists


### PR DESCRIPTION
## PR description:

This small change adds more info on the origin of a push to lumi-o by including in the last_update key of  `content.yaml` the username, the hostname and the ip of the machine on which the file was created.
This will help to track responsibility for the latest pushes to lumi-o, helping in case of debugging.
It allows in theory to drop completely the update of the updated.txt file on the aqua-web repo on github which was kept just for this purpose.

NB: there is already an existing option `(-d, --no-update)` which prevents update on github. If we wish we could either make this behaviour default or simply ask the workflow to always use the `-d` option if we think that this can be dropped.

----

 - [ ] Changelog is updated.