### PR TITLE
[OP] v0.19.12 preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -50,6 +50,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v0.19.12
       - v0.19.11
       - v0.19.10+op
       - v0.19.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 AQUA core complete list:
+
+AQUA diagnostics complete list:
+
+## [v0.19.12]
+
+AQUA core complete list:
 - Catalog generator: support for model names with resolution suffixes (e.g. IFS-NEMO-5km) (#2907)
 - More info on the origin of a push to lumi-o in the logs (#2913)
 
@@ -1278,7 +1284,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers. 
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/HEAD...v0.19.11
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/HEAD...v0.19.12
+[v0.19.12]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.11...v0.19.12
 [v0.19.11]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.10...v0.19.11
 [v0.19.10]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.9...v0.19.10
 [v0.19.9]: https://github.com/DestinE-Climate-DT/AQUA/compare/v0.19.8...v0.19.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ AQUA diagnostics complete list:
 AQUA core complete list:
 - Catalog generator: support for model names with resolution suffixes (e.g. IFS-NEMO-5km) (#2907)
 - More info on the origin of a push to lumi-o in the logs (#2913)
+- CatGen: more flexible handling of forcing string (#2832)
 
 AQUA diagnostics complete list:
 - Storyline reference dates updated to 2025 (#2855)
@@ -21,7 +22,6 @@ AQUA diagnostics complete list:
 ## [v0.19.11]
 
 AQUA core complete list:
-- CatGen: more flexible handling of forcing string (#2832)
 - Attributes guessing for eccodes works also with local destine table (#2785)
 - Fix area selection, `default_coords` are deduced from the dataset (#2771)
 - Netcdf4 and h5py in env instead of pip (#2739)

--- a/src/aqua/version.py
+++ b/src/aqua/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = '0.19.11'
+__version__ = '0.19.12'


### PR DESCRIPTION
## Version release PR:
This PR prepares for the release of the v0.19.12

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `aqua/core/version.py`
- [x] Check key pyproject pins (gsv, xarray, pandas, etc.)
- [ ] if a major operational release, update Dockerfiles and relative action
- [x] if it's an operational release, be sure the bug report menu is updated in the main as well
