### PR TITLE
Revert "config to 2025 (#2855)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ AQUA core complete list:
 - More info on the origin of a push to lumi-o in the logs (#2913)
 
 AQUA diagnostics complete list:
-- Storyline reference dates updated to 2025 (#2855)
 
 ## [v0.19.11]
 

--- a/config/diagnostics/storylines/atmosphere2d/config-atmosphere2d-berkeley.yaml
+++ b/config/diagnostics/storylines/atmosphere2d/config-atmosphere2d-berkeley.yaml
@@ -50,7 +50,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
     plot_params:
       default: 
         projection: 'robinson'
@@ -72,8 +72,8 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
       2t:
         regions: ['nh', 'sh', 'europe']
 
@@ -84,8 +84,8 @@ diagnostics:
     center_time: true
     params:
       default:
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
       2t:
         regions: ['nh', 'sh', 'europe']
 
@@ -101,9 +101,9 @@ diagnostics:
     params:
       default:
         startdate: '2017-01-01'
-        enddate: '2025-12-31'
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        enddate: '2024-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
     variables:
       - name: '2t'
         regions: [null, 'tropics']  # global and tropics

--- a/config/diagnostics/storylines/atmosphere2d/config-atmosphere2d-era5.yaml
+++ b/config/diagnostics/storylines/atmosphere2d/config-atmosphere2d-era5.yaml
@@ -45,7 +45,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
       (10u^2+10v^2)^0.5:
         short_name: "10si"
         long_name: "Wind speed at 10m"
@@ -69,8 +69,8 @@ diagnostics:
     center_time: true
     params:
       default:
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
   
   timeseries:
     run: true
@@ -84,5 +84,5 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'

--- a/config/diagnostics/storylines/atmosphere3d/config-atmosphere3d-era5.yaml
+++ b/config/diagnostics/storylines/atmosphere3d/config-atmosphere3d-era5.yaml
@@ -44,7 +44,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
     plot_params:
       default: 
         projection: 'robinson'

--- a/config/diagnostics/storylines/ocean2d/config-ocean2d-esacci.yaml
+++ b/config/diagnostics/storylines/ocean2d/config-ocean2d-esacci.yaml
@@ -50,7 +50,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
     plot_params:
       default: 
         projection: 'robinson'
@@ -72,8 +72,8 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '20000101'
+        std_enddate: '20241231'
       tos:
         regions: ['nh', 'sh']
 
@@ -84,8 +84,8 @@ diagnostics:
     center_time: true
     params:
       default:
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '20000101'
+        std_enddate: '20241231'
       tos:
         regions: ['nh', 'sh']
 
@@ -101,9 +101,9 @@ diagnostics:
     params:
       default:
         startdate: '2017-01-01'
-        enddate: '2025-12-31'
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        enddate: '2024-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
     variables:
       - name: 'tos'
         regions: [null]  # global

--- a/config/diagnostics/storylines/ocean3d/config-ocean3d-en4-stratification.yaml
+++ b/config/diagnostics/storylines/ocean3d/config-ocean3d-en4-stratification.yaml
@@ -20,7 +20,7 @@ references:
     regrid: r100  # EN4 is on 1x1 grid different from r100
     reader_kwargs: {chunks: {"time": 1, "depth": 42}}  # it can be a dictionary with reader kwargs
     startdate: 2017-01-01
-    enddate: 2025-12-31
+    enddate: 2024-12-31
 
 output:
   outputdir: "./"

--- a/config/diagnostics/storylines/radiation_surface/config-radiation_surface-boxplots.yaml
+++ b/config/diagnostics/storylines/radiation_surface/config-radiation_surface-boxplots.yaml
@@ -24,7 +24,7 @@ references:
     exp: 'era5'
     source: 'monthly'
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
   - catalog: 'obs'
     model: 'CERES'
     exp: 'ebaf-sfc421'
@@ -32,7 +32,7 @@ references:
     regrid: 'r100'
     reader_kwargs: null
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
 
 output:
   outputdir: "./"

--- a/config/diagnostics/storylines/radiation_surface/config-radiation_surface-ceres.yaml
+++ b/config/diagnostics/storylines/radiation_surface/config-radiation_surface-ceres.yaml
@@ -26,7 +26,7 @@ references:
     regrid: 'r100'
     reader_kwargs: null
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
 
 output:
   outputdir: "./"
@@ -49,8 +49,8 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '20010101'
+        std_enddate: '20241231'
 
   globalbiases:
     run: true
@@ -65,7 +65,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
     plot_params: 
       default: 
         projection: 'robinson'

--- a/config/diagnostics/storylines/radiation_surface/config-radiation_surface-era5.yaml
+++ b/config/diagnostics/storylines/radiation_surface/config-radiation_surface-era5.yaml
@@ -24,7 +24,7 @@ references:
     exp: 'era5'
     source: 'monthly'
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
 
 output:
   outputdir: "./"
@@ -63,7 +63,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
     plot_params: 
       default: 
         projection: 'robinson'

--- a/config/diagnostics/storylines/radiation_toa/config-radiation_toa-boxplots.yaml
+++ b/config/diagnostics/storylines/radiation_toa/config-radiation_toa-boxplots.yaml
@@ -25,7 +25,7 @@ references:
     regrid: 'r100'
     source: 'monthly'
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
   - catalog: 'obs'
     model: 'CERES'
     exp: 'ebaf-toa421'
@@ -33,7 +33,7 @@ references:
     regrid: 'r100'
     reader_kwargs: null
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
 
 output:
   outputdir: "./"

--- a/config/diagnostics/storylines/radiation_toa/config-radiation_toa-ceres.yaml
+++ b/config/diagnostics/storylines/radiation_toa/config-radiation_toa-ceres.yaml
@@ -26,7 +26,7 @@ references:
     regrid: 'r100'
     reader_kwargs: null
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
 
 output:
   outputdir: "./"
@@ -50,8 +50,8 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01' 
-        std_enddate: '2025-12-31'
+        std_startdate: '20010101' 
+        std_enddate: '20241231'
       tnlwrf+tnswrf:
         standard_name: "top_net_radiation"
         long_name: "Top net radiation"
@@ -70,7 +70,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
       tnlwrf+tnswrf:
         short_name: "tnr"
         long_name: "Top net radiation"

--- a/config/diagnostics/storylines/seaice/config-seaice.yaml
+++ b/config/diagnostics/storylines/seaice/config-seaice.yaml
@@ -80,7 +80,7 @@ diagnostics:
     # List of regions to plot. The default regions are defined in config/diagnostics/seaice
     regions: ['arctic','antarctic']
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
     calc_ref_std: true
     ref_std_freq: 'monthly' # set to 'monthly' 'annual'
     varname:
@@ -121,7 +121,7 @@ diagnostics:
     methods: ["extent", "volume"]
     regions: ['arctic','antarctic']
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
     calc_ref_std: true
     ref_std_freq: 'monthly' # set to 'monthly' 'annual'
     varname:
@@ -163,7 +163,7 @@ diagnostics:
     methods: ["fraction", "thickness"]
     regions: ['arctic','antarctic']
     startdate: '2017-01-01'
-    enddate: '2025-12-31'
+    enddate: '2024-12-31'
     # List of months to plot (e.g., [3, 9] for March and September)
     months: [3, 9]
     # List of projections to use

--- a/config/diagnostics/storylines/water_cycle/config-water_cycle-mswep.yaml
+++ b/config/diagnostics/storylines/water_cycle/config-water_cycle-mswep.yaml
@@ -50,7 +50,7 @@ diagnostics:
         startdate_data: null
         enddate_data: null
         startdate_ref: "2017-01-01"
-        enddate_ref: "2025-12-31"
+        enddate_ref: "2024-12-31"
       tprate:
         units: 'mm/day'
     plot_params:
@@ -74,8 +74,8 @@ diagnostics:
         daily: False
         monthly: True
         annual: True
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
       tprate:
         regions: ['nh', 'sh', 'europe']
 
@@ -86,8 +86,8 @@ diagnostics:
     center_time: true
     params:
       default:
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
       tprate:
         regions: ['nh', 'sh', 'europe']
 
@@ -103,9 +103,9 @@ diagnostics:
     params:
       default:
         startdate: '2017-01-01'
-        enddate: '2025-12-31'
-        std_startdate: '2001-01-01'
-        std_enddate: '2025-12-31'
+        enddate: '2024-12-31'
+        std_startdate: '2000-01-01'
+        std_enddate: '2024-12-31'
     variables:
       - name: 'tprate'
         regions: [null, 'tropics']  # global and tropics


### PR DESCRIPTION
This reverts commit aada3c0a6e18e0b571095980fb28cc1228022f39.

We realized that data on DVC have not been updated yet (and descriptions on the DESP are inaccurate if there are less data then those indicated on the config files).
