### PR TITLE
submit_aqua_web to support kind and separate templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
+- Update submit_aqua_web tool to support kind (#2921))
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)
 - More info on the origin of a push to lumi-o in the logs (#2910)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
-- Update submit_aqua_web tool to support kind (#2921))
+- Update submit_aqua_web tool to support kind and separate templates (#2921))
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)
 - More info on the origin of a push to lumi-o in the logs (#2910)

--- a/cli/aqua-web/aqua-web.experiment.list
+++ b/cli/aqua-web/aqua-web.experiment.list
@@ -6,7 +6,7 @@
 #climatedt-gen2 IFS-FESOM-5km baseline-cont r1 default
 
 #climatedt-gen2 IFS-NEMO-5km baseline-hist r1 default
-#@climatedt-gen2 IFS-NEMO-5km projections-ssp370 r1 scenario
+#climatedt-gen2 IFS-NEMO-5km projections-ssp370 r1 scenario
 #climatedt-gen2 IFS-NEMO-5km baseline-cont r1 default
 
 climatedt-gen2 ICON-5km baseline-hist r1 default

--- a/cli/aqua-web/aqua-web.experiment.list
+++ b/cli/aqua-web/aqua-web.experiment.list
@@ -1,7 +1,18 @@
 # List of experiments to analyze in the format
-# catalog model exp realization [source]
+# catalog model exp realization kind [source]
 
-climatedt-phase1 IFS-NEMO  ssp370 r1
-climatedt-phase1 IFS-NEMO historical-1990 r1
-climatedt-phase1 ICON historical-1990 r1
-climatedt-phase1 ICON ssp370 r1
+#climatedt-gen2 IFS-FESOM-5km baseline-hist r1 default
+#climatedt-gen2 IFS-FESOM-5km projections-ssp370 r1 scenario
+#climatedt-gen2 IFS-FESOM-5km baseline-cont r1 default
+
+#climatedt-gen2 IFS-NEMO-5km baseline-hist r1 default
+#@climatedt-gen2 IFS-NEMO-5km projections-ssp370 r1 scenario
+#climatedt-gen2 IFS-NEMO-5km baseline-cont r1 default
+
+climatedt-gen2 ICON-5km baseline-hist r1 default
+#climatedt-gen2 ICON-5km projections-ssp370 r1 scenario
+#climatedt-gen2 ICON-5km baseline-cont r1 default
+
+#climatedt-gen2 IFS-FESOM-10km story-nudging-Tplus2K r1 storyline
+#climatedt-gen2 IFS-FESOM-10km story-nudging-cont r1 storyline
+#climatedt-gen2 IFS-FESOM-10km story-nudging-hist r1 storyline

--- a/cli/aqua-web/aqua-web.job.j2
+++ b/cli/aqua-web/aqua-web.job.j2
@@ -24,9 +24,9 @@ unset SINGULARITY_BIND  # Lumi specific fix for singularity
 if [[ "{{ nativeaqua }}" == "true" ]]; then
     if [[ "{{ push }}" == "false" ]]; then
         if [[ "{{ ensemble }}" == "true" ]]; then
-            aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source -d $OUTDIR {{ parallel }}
+            aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source {{ kind }} -o $OUTDIR {{ serial }}
         else
-            aqua analysis -l debug -c $catalog -m $model -e $exp -s $source -d $OUTDIR {{ parallel }}
+            aqua analysis -l debug -c $catalog -m $model -e $exp -s $source {{ kind }} -o $OUTDIR {{ serial }}
         fi
     else
         if [[ "{{ ensemble }}" == "true" ]]; then
@@ -40,9 +40,9 @@ else
 #!/bin/bash
 if [[ "{{ push }}" == "false" ]]; then
     if [[ "{{ ensemble }}" == "true" ]]; then
-        aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source -d $OUTDIR {{ parallel }}
+        aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source {{ kind }} -o $OUTDIR {{ serial }}
     else
-        aqua analysis -l debug -c $catalog -m $model -e $exp -s $source -d $OUTDIR {{ parallel }}
+        aqua analysis -l debug -c $catalog -m $model -e $exp -s $source {{ kind }} -o $OUTDIR {{ serial }}
     fi
 else
     if [[ "{{ ensemble }}" == "true" ]]; then

--- a/cli/aqua-web/aqua-web.push.job.j2
+++ b/cli/aqua-web/aqua-web.push.job.j2
@@ -2,8 +2,8 @@
 #SBATCH --job-name={{ job_name }}
 #SBATCH --partition={{ partition }}
 #SBATCH --account={{ account }}
-#SBATCH --nodes={{ nodes }}
-#SBATCH --ntasks-per-node={{ ntasks_per_node }}
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
 #SBATCH --time={{ time }}
 #SBATCH --error={{ logdir_error }}/{{ error }}
 #SBATCH --output={{ logdir_output }}/{{ output }}
@@ -23,17 +23,17 @@ unset SINGULARITY_BIND  # Lumi specific fix for singularity
 
 if [[ "{{ nativeaqua }}" == "true" ]]; then
     if [[ "{{ ensemble }}" == "true" ]]; then
-        aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source {{ kind }} -o $OUTDIR {{ serial }}
+        bash $AQUA/cli/aqua-web/push_analysis.sh $OUTDIR {{ explist }}
     else
-        aqua analysis -l debug -c $catalog -m $model -e $exp -s $source {{ kind }} -o $OUTDIR {{ serial }}
+        bash $AQUA/cli/aqua-web/push_analysis.sh --no-ensemble $OUTDIR {{ explist }}
     fi
 else
     bash $AQUA/cli/aqua-container/load-aqua-container.sh {{ machine }} <<EOF
 #!/bin/bash
     if [[ "{{ ensemble }}" == "true" ]]; then
-        aqua analysis -l debug -c $catalog -m $model -e $exp --realization {{ realization }} -s $source {{ kind }} -o $OUTDIR {{ serial }}
+        bash $AQUA/cli/aqua-web/push_analysis.sh $OUTDIR {{ explist }}
     else
-        aqua analysis -l debug -c $catalog -m $model -e $exp -s $source {{ kind }} -o $OUTDIR {{ serial }}
+        bash $AQUA/cli/aqua-web/push_analysis.sh --no-ensemble $OUTDIR {{ explist }}
     fi
 EOF
 fi

--- a/cli/aqua-web/config.aqua-web.yaml
+++ b/cli/aqua-web/config.aqua-web.yaml
@@ -15,10 +15,11 @@ push:
     ntasks_per_node: 1
     time: 00:30:00
 
-logdir_error: /pfs/lustrep3/projappl/project_465000454/jvonhar/log/
-logdir_output: /pfs/lustrep3/projappl/project_465000454/jvonhar/log/
-aquadir: /pfs/lustrep3/projappl/project_465000454/jvonhar/AQUA
-outdir: /pfs/lustrep3/projappl/project_465000454/jvonhar/aqua-analysis/output
+logdir_error: /pfs/lustrep4/scratch/project_465002727/jvonhar/log/
+logdir_output: /pfs/lustrep4/scratch/project_465002727/jvonhar/log/
+aquadir: /pfs/lustrep4/scratch/project_465002727/jvonhar/AQUA
+outdir: /pfs/lustrep4/scratch/project_465002727/jvonhar/aqua-analysis/output
+
 config: config.aqua-web.yaml
 template: aqua-web.job.j2
 

--- a/cli/aqua-web/config.aqua-web.yaml
+++ b/cli/aqua-web/config.aqua-web.yaml
@@ -4,12 +4,14 @@ username: jvonhar
 
 analysis:
     job_name: aqua-web
+    emplate: aqua-web.job.j2
     partition: small
     nodes: 1
     ntasks_per_node: 128
     time: 04:30:00
 push:
     job_name: aqua-web.push
+    template: aqua-web.push.job.j2
     partition: debug
     nodes: 1
     ntasks_per_node: 1
@@ -19,9 +21,6 @@ logdir_error: /pfs/lustrep4/scratch/project_465002727/jvonhar/log/
 logdir_output: /pfs/lustrep4/scratch/project_465002727/jvonhar/log/
 aquadir: /pfs/lustrep4/scratch/project_465002727/jvonhar/AQUA
 outdir: /pfs/lustrep4/scratch/project_465002727/jvonhar/aqua-analysis/output
-
-config: config.aqua-web.yaml
-template: aqua-web.job.j2
 
 catalog: climatedt-phase1
 model: IFS-NEMO

--- a/cli/aqua-web/config.aqua-web.yaml
+++ b/cli/aqua-web/config.aqua-web.yaml
@@ -2,11 +2,19 @@ machine: lumi
 account: project_462000911
 username: jvonhar
 
-job_name: aqua-web
-partition: small
-nodes: 1
-ntasks_per_node: 128
-time: 03:30:00
+analysis:
+    job_name: aqua-web
+    partition: small
+    nodes: 1
+    ntasks_per_node: 128
+    time: 04:30:00
+push:
+    job_name: aqua-web.push
+    partition: debug
+    nodes: 1
+    ntasks_per_node: 1
+    time: 00:30:00
+
 logdir_error: /pfs/lustrep3/projappl/project_465000454/jvonhar/log/
 logdir_output: /pfs/lustrep3/projappl/project_465000454/jvonhar/log/
 aquadir: /pfs/lustrep3/projappl/project_465000454/jvonhar/AQUA

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -31,7 +31,7 @@ class Submitter:
         config="config.aqua-web.yaml",
         template="aqua-web.job.j2",
         dryrun=False,
-        parallel=True,
+        serial=True,
         ensemble=True,
         native=False,
         fresh=False,
@@ -45,7 +45,7 @@ class Submitter:
             config: yaml configuration file base name
             template: jinja template file base name
             dryrun: perform a dry run (no job submission)
-            parallel: run in parallel mode (multiple cores)
+            serial: run in serial mode (no dask cluster will be created)
             ensemble: process ensemble experiments/new folder structure.
             native: use the native AQUA version (default is the container version)
             fresh: use a fresh (new) output directory, do not recycle original one
@@ -61,7 +61,7 @@ class Submitter:
 
         self.jobname = jobname
         self.dryrun = dryrun
-        self.parallel = parallel
+        self.serial = serial
         self.native = native
         self.ensemble = ensemble
         if fresh:
@@ -78,7 +78,7 @@ class Submitter:
         # Parse the output to check if the job name is in the list
         return job_name in output
 
-    def submit_sbatch(self, catalog, model, exp, realization, source=None, dependency=None):
+    def submit_sbatch(self, catalog, model, exp, realization, kind, source=None, dependency=None):
         """
         Submit a sbatch script with basic options
 
@@ -87,6 +87,7 @@ class Submitter:
             model: model to be processed
             exp: experiment to be processed
             realization: realization to be processed
+            kind: kind of the experiment
             source: source to be processed
             dependency: jobid on which dependency of slurm is built
 
@@ -114,14 +115,18 @@ class Submitter:
             definitions["exp"] = exp
         else:
             exp = definitions["exp"]
+        if kind:
+            definitions["kind"] = f"-k {kind}"
+        else:
+            definitions["kind"] = ""
         if source:
             definitions["source"] = source
         else:
             source = definitions["source"]
-        if self.parallel:
-            definitions["parallel"] = "-p"
+        if self.serial:
+            definitions["serial"] = "--serial"
         else:
-            definitions["parallel"] = ""
+            definitions["serial"] = ""
         if self.native:
             definitions["nativeaqua"] = "true"
         else:
@@ -294,17 +299,18 @@ def parse_arguments(arguments):
 
     parser.add_argument("-c", "--config", type=str, help="yaml configuration file")
     parser.add_argument("-m", "--model", type=str, help="model to be processed")
-    parser.add_argument("-k", "--catalog", type=str, help="catalog for experiment")
+    parser.add_argument("--catalog", type=str, help="catalog for experiment")
     parser.add_argument("-e", "--exp", type=str, help="experiment to be processed")
-    parser.add_argument("--realization", type=str, help="realization to be processed. Specifying it assumes ensemble usage.")
+    parser.add_argument("-k", "--kind", type=str, help="experiment kind to be passed to aqua analysis")
+    parser.add_argument("--realization", type=str, help="realization to be processed. If not specified r1 is assumed")
     parser.add_argument(
         "--no-ensemble",
         action="store_false",
         dest="ensemble",
-        help="Assume old 3-level folder structure. NB: If realization not chosen set it to r1 by default",
+        help="Assume old 3-level folder structure.",
     )
     parser.add_argument("-s", "--source", type=str, help="source to be processed")
-    parser.add_argument("-r", "--serial", action="store_true", help="run in serial mode (only one core)")
+    parser.add_argument("--serial", action="store_true", help="run in serial mode (only one core)")
     parser.add_argument("-x", "--max", type=int, help="max number of jobs to submit without dependency")
     parser.add_argument("-t", "--template", type=str, help="template jinja file for slurm job")
     parser.add_argument("-d", "--dry", action="store_true", help="perform a dry run (no job submission)")
@@ -340,6 +346,7 @@ if __name__ == "__main__":
     push = get_arg(args, "push", False)
     native = get_arg(args, "native", False)
     fresh = get_arg(args, "fresh", False)
+    kind = get_arg(args, "kind", None)
     jobname = get_arg(args, "jobname", None)
 
     ensemble = get_arg(args, "ensemble", True)
@@ -355,7 +362,7 @@ if __name__ == "__main__":
         config=config,
         template=template,
         dryrun=dryrun,
-        parallel=not serial,
+        serial=serial,
         native=native,
         ensemble=ensemble,
         fresh=fresh,
@@ -380,9 +387,9 @@ if __name__ == "__main__":
                     continue
 
                 if ensemble:
-                    catalog, model, exp, realization, *source = re.split(r",|\s+|\t+", line.strip())
+                    catalog, model, exp, realization, kind, *source = re.split(r",|\s+|\t+", line.strip())
                 else:
-                    catalog, model, exp, *source = re.split(r",|\s+|\t+", line.strip())  # split by comma, space, tab
+                    catalog, model, exp, kind, *source = re.split(r",|\s+|\t+", line.strip())  # split by comma, space, tab
 
                 # Convert source list to string or None
                 if len(source) == 0:
@@ -398,13 +405,13 @@ if __name__ == "__main__":
 
                 count = count + 1
 
-                jobid = submitter.submit_sbatch(catalog, model, exp, realization, source=source, dependency=parent_job)
+                jobid = submitter.submit_sbatch(catalog, model, exp, realization, kind, source=source, dependency=parent_job)
                 jobid_list.append(jobid)
 
         if push:
             submitter.submit_push(jobid_list, listfile)
 
     else:
-        jobid = submitter.submit_sbatch(catalog, model, exp, realization, source=source, dependency=parent_job)
+        jobid = submitter.submit_sbatch(catalog, model, exp, realization, kind, source=source, dependency=parent_job)
         if push:
             submitter.submit_push([jobid], f"{model}/{exp}")

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -29,8 +29,8 @@ class Submitter:
         self,
         loglevel="INFO",
         config="config.aqua-web.yaml",
-        template="aqua-web.job.j2",
-        template_push="aqua-web.push.job.j2",
+        template=None,
+        template_push=None,
         dryrun=False,
         serial=True,
         ensemble=True,
@@ -286,6 +286,20 @@ class Submitter:
             if not found_config:
                 raise FileNotFoundError(f"Config file '{config}' not found in search paths: {search_paths}")
 
+        yaml = YAML(typ="rt")
+        with open(config, "r", encoding="utf-8") as file:
+            config_dict = yaml.load(file)
+
+        if template is None:
+            template = config_dict.get("analysis", {}).get("template")
+        if not template:
+            template = "aqua-web.job.j2"
+
+        if template_push is None:
+            template_push = config_dict.get("push", {}).get("template")
+        if not template_push:
+            template_push = "aqua-web.push.job.j2"
+
         if not os.path.isfile(template):
             found_config = False
             for path in search_paths:
@@ -383,8 +397,8 @@ if __name__ == "__main__":
     elif ensemble and not realization:
         realization = "r1"  # Default realization for ensemble mode
 
-    template = get_arg(args, "template", "aqua-web.job.j2")
-    template_push = get_arg(args, "template-push", "aqua-web.push.job.j2")
+    template = get_arg(args, "template", None)
+    template_push = get_arg(args, "template-push", None)
 
     submitter = Submitter(
         config=config,

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -311,6 +311,7 @@ def parse_arguments(arguments):
     )
     parser.add_argument("-s", "--source", type=str, help="source to be processed")
     parser.add_argument("--serial", action="store_true", help="run in serial mode (only one core)")
+    parser.add_argument("--no-kind", action="store_true", help="use legacy list files with no kind")
     parser.add_argument("-x", "--max", type=int, help="max number of jobs to submit without dependency")
     parser.add_argument("-t", "--template", type=str, help="template jinja file for slurm job")
     parser.add_argument("-d", "--dry", action="store_true", help="perform a dry run (no job submission)")
@@ -339,6 +340,7 @@ if __name__ == "__main__":
     source = get_arg(args, "source", None)
     config = get_arg(args, "config", "config.aqua-web.yaml")
     serial = get_arg(args, "serial", False)
+    no_kind = get_arg(args, "no_kind", False)
     listfile = get_arg(args, "list", None)
     dependency = get_arg(args, "max", None)
     dryrun = get_arg(args, "dry", False)
@@ -387,9 +389,17 @@ if __name__ == "__main__":
                     continue
 
                 if ensemble:
-                    catalog, model, exp, realization, kind, *source = re.split(r",|\s+|\t+", line.strip())
+                    if no_kind:
+                        catalog, model, exp, realization, *source = re.split(r",|\s+|\t+", line.strip())
+                        kind = None
+                    else:
+                        catalog, model, exp, realization, kind, *source = re.split(r",|\s+|\t+", line.strip())
                 else:
-                    catalog, model, exp, kind, *source = re.split(r",|\s+|\t+", line.strip())  # split by comma, space, tab
+                    if no_kind:
+                        catalog, model, exp, *source = re.split(r",|\s+|\t+", line.strip())
+                        kind = None
+                    else:
+                        catalog, model, exp, kind, *source = re.split(r",|\s+|\t+", line.strip())  # split by comma, space, tab
 
                 # Convert source list to string or None
                 if len(source) == 0:

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -30,6 +30,7 @@ class Submitter:
         loglevel="INFO",
         config="config.aqua-web.yaml",
         template="aqua-web.job.j2",
+        template_push="aqua-web.push.job.j2",
         dryrun=False,
         serial=True,
         ensemble=True,
@@ -44,6 +45,7 @@ class Submitter:
             loglevel: logging level
             config: yaml configuration file base name
             template: jinja template file base name
+            template_push: jinja template file base name for push job
             dryrun: perform a dry run (no job submission)
             serial: run in serial mode (no dask cluster will be created)
             ensemble: process ensemble experiments/new folder structure.
@@ -57,7 +59,7 @@ class Submitter:
 
         self.logger = log_configure(log_level=loglevel, log_name="aqua-web")
 
-        self.config, self.template = self.find_config_files(config, template)
+        self.config, self.template, self.template_push = self.find_config_files(config, template, template_push)
 
         self.jobname = jobname
         self.dryrun = dryrun
@@ -231,7 +233,7 @@ class Submitter:
 
         definitions["fresh"] = self.fresh
 
-        with open(self.template, "r", encoding="utf-8") as file:
+        with open(self.templat_push, "r", encoding="utf-8") as file:
             rendered_job = Template(file.read()).render(definitions)
 
         with NamedTemporaryFile("w", delete=False) as tempfile:
@@ -261,7 +263,7 @@ class Submitter:
             self.logger.debug("SLURM job name: %s", full_job_name)
             return "0"
 
-    def find_config_files(self, config, template):
+    def find_config_files(self, config, template, template_push):
         """
         Find the configuration and template files
         """
@@ -295,9 +297,21 @@ class Submitter:
             if not found_config:
                 raise FileNotFoundError(f"Template file '{config}' not found in search paths: {search_paths}")
 
+        if not os.path.isfile(template_push):
+            found_config = False
+            for path in search_paths:
+                template_push_path = os.path.join(path, template_push)
+                if os.path.exists(template_push_path):
+                    template_push = template_push_path
+                    found_config = True
+                    break
+            if not found_config:
+                raise FileNotFoundError(f"Template file '{template_push}' not found in search paths: {search_paths}")
+
         self.logger.debug("Using configuration file: %s", config)
-        self.logger.debug("Using job template: %s", template)
-        return config, template
+        self.logger.debug("Using analysis job template: %s", template)
+        self.logger.debug("Using push job template: %s", template_push)
+        return config, template, template_push
 
 
 def parse_arguments(arguments):
@@ -323,7 +337,8 @@ def parse_arguments(arguments):
     parser.add_argument("--serial", action="store_true", help="run in serial mode (only one core)")
     parser.add_argument("--no-kind", action="store_true", help="use legacy list files with no kind")
     parser.add_argument("-x", "--max", type=int, help="max number of jobs to submit without dependency")
-    parser.add_argument("-t", "--template", type=str, help="template jinja file for slurm job")
+    parser.add_argument("-t", "--template", type=str, help="template jinja file for analysis slurm job")
+    parser.add_argument("--template-push", type=str, help="template jinja file for push slurm job")
     parser.add_argument("-d", "--dry", action="store_true", help="perform a dry run (no job submission)")
     parser.add_argument("-l", "--loglevel", type=str, help="logging level")
     parser.add_argument("-p", "--push", action="store_true", help="flag to push to aqua-web")
@@ -369,10 +384,12 @@ if __name__ == "__main__":
         realization = "r1"  # Default realization for ensemble mode
 
     template = get_arg(args, "template", "aqua-web.job.j2")
+    template_push = get_arg(args, "template-push", "aqua-web.push.job.j2")
 
     submitter = Submitter(
         config=config,
         template=template,
+        template_push=template_push,
         dryrun=dryrun,
         serial=serial,
         native=native,

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -233,7 +233,7 @@ class Submitter:
 
         definitions["fresh"] = self.fresh
 
-        with open(self.templat_push, "r", encoding="utf-8") as file:
+        with open(self.template_push, "r", encoding="utf-8") as file:
             rendered_job = Template(file.read()).render(definitions)
 
         with NamedTemporaryFile("w", delete=False) as tempfile:

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -142,10 +142,15 @@ class Submitter:
         if self.jobname:
             jobname = self.jobname
         else:
-            jobname = definitions.get("jobname", "aqua-web")
+            jobname = definitions["analysis"].get("jobname", "aqua-web")
         # create identifier for each model-exp-source-var tuple
         full_job_name = jobname + "_" + "_".join([catalog, model, exp, source])
         definitions["job_name"] = full_job_name
+
+        definitions["partition"] = definitions["analysis"]["partition"]
+        definitions["nodes"] = definitions["analysis"]["nodes"]
+        definitions["ntasks_per_node"] = definitions["analysis"]["ntasks_per_node"]
+        definitions["time"] = definitions["analysis"]["time"]
 
         definitions["output"] = full_job_name + "_%j.out"
         definitions["error"] = full_job_name + "_%j.err"
@@ -202,11 +207,16 @@ class Submitter:
             definitions = yaml.load(file)
 
         username = definitions["username"]
-        full_job_name = definitions.get("jobname", "push-aqua-web")
+        full_job_name = definitions.get("jobname", "aqua-web.push")
 
         definitions["job_name"] = full_job_name
         definitions["output"] = full_job_name + "_%j.out"
         definitions["error"] = full_job_name + "_%j.err"
+
+        definitions["partition"] = definitions["push"]["partition"]
+        definitions["nodes"] = definitions["push"]["nodes"]
+        definitions["ntasks_per_node"] = definitions["push"]["ntasks_per_node"]
+        definitions["time"] = definitions["push"]["time"]
 
         definitions["push"] = "true"
         definitions["explist"] = listfile

--- a/docs/sphinx/source/dashboard.rst
+++ b/docs/sphinx/source/dashboard.rst
@@ -282,6 +282,14 @@ Options
 
     Source to be processed.
 
+.. option: --catalog <catalog>
+
+    The catalog to be processed.
+
+.. option: --kind <kind>
+
+    Experiment kind to be passed to ``aqua analysis`` command.
+
 .. option:: --no-ensemble
 
     Specifies that the old 3-level ensemble structure (catalog/model/experiment) should be used instead
@@ -293,9 +301,9 @@ Options
     If a single experiment is specified, and ``--realization`` is not specified,
     "r1" will be assumed as the realization by default.
 
-.. option:: -r, --serial
+.. option:: --serial
 
-    Run in serial mode (only one core). This is passed to the ``aqua-analysis.py`` script.
+    Run in serial mode (no dask cluster will be started). This is passed to the ``aqua analysis`` command.
 
 .. option:: -x <max>, --max <max>
 

--- a/docs/sphinx/source/dashboard.rst
+++ b/docs/sphinx/source/dashboard.rst
@@ -282,13 +282,17 @@ Options
 
     Source to be processed.
 
-.. option: --catalog <catalog>
+.. option:: --catalog <catalog>
 
     The catalog to be processed.
 
-.. option: --kind <kind>
+.. option:: --kind <kind>
 
     Experiment kind to be passed to ``aqua analysis`` command.
+
+.. option:: --no-kind
+
+    Use legacy list files with no kind.
 
 .. option:: --no-ensemble
 


### PR DESCRIPTION
## PR description:

Support for the new 'kind' option was missing in submit_aqua_web and it needed updating because of an API change in `aqua analysis` (the '-d' --> '-o' options). Additionally this implements two template job files for analysis and push (this allows to push using a cheaper serial job)

close #2102 

 - [x] Documentation is included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
