### PR TITLE
aqua analysis logger bug

### DIFF
--- a/aqua/core/console/analysis.py
+++ b/aqua/core/console/analysis.py
@@ -123,7 +123,7 @@ def analysis_execute(args):
     nmaxprocesses = args.nmaxprocesses if args.nmaxprocesses > 0 else None
 
     logger.debug("outputdir: %s", outputdir)
-    if nmaxprocesses:
+    if nmaxprocesses is not None:
         logger.debug("nmaxprocesses: %d", nmaxprocesses)
 
     # Format the realization string by prepending 'r' if it is a digit or setting a default `r1`.

--- a/aqua/core/console/analysis.py
+++ b/aqua/core/console/analysis.py
@@ -123,7 +123,8 @@ def analysis_execute(args):
     nmaxprocesses = args.nmaxprocesses if args.nmaxprocesses > 0 else None
 
     logger.debug("outputdir: %s", outputdir)
-    logger.debug("nmaxprocesses: %d", nmaxprocesses)
+    if nmaxprocesses:
+        logger.debug("nmaxprocesses: %d", nmaxprocesses)
 
     # Format the realization string by prepending 'r' if it is a digit or setting a default `r1`.
     realization = format_realization(realization)


### PR DESCRIPTION
## PR description:

This fixes a small `aqua analysis` bug: if `nmaxprocesses` is not specified logging fails because its value is None.