### PR TITLE
[Catalog generator] support for model names with resolution suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
+- Catalog generator: support for model names with resolution suffixes (e.g. IFS-NEMO-5km) (#2925)
 - Update submit_aqua_web tool to support kind and separate templates (#2921))
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)

--- a/aqua/core/catgen/catgen.py
+++ b/aqua/core/catgen/catgen.py
@@ -229,7 +229,7 @@ class AquaFDBGenerator:
         if levtype in grid_mappings:
             grid_str = (
                 grid_mappings[levtype]
-                .get(self.model, grid_mappings[levtype].get("default"))
+                .get(model_key, grid_mappings[levtype].get("default"))
                 .format(ocean_grid=self.ocean_grid, aqua_grid=aqua_grid)
             )
         else:

--- a/aqua/core/catgen/catgen.py
+++ b/aqua/core/catgen/catgen.py
@@ -75,7 +75,7 @@ class AquaFDBGenerator:
         self.machine = self.config["machine"]
         self.dp_dir_path = self.config["repos"]["data-portfolio_path"]
         self.catalog_dir_path = self.config["repos"]["Climate-DT-catalog_path"]
-        self.model = self.config["model"].lower()
+        self.model = self.config["model"]
         # self.portfolio = self.config["portfolio"]
         self.resolution = self.config["resolution"]
         self.ocean_grid = self.config.get("ocean_grid")
@@ -103,13 +103,12 @@ class AquaFDBGenerator:
         Returns:
             dict: Local grids for the given portfolio.
         """
-        local_grids = grids["common"]
+        local_grids = dict(grids["common"])  # copy to avoid mutating the shared dict
         if resolution in grids:
             self.logger.debug("Update grids for specific %s portfolio", resolution)
             local_grids.update(grids[resolution])
         else:
             self.logger.error("Cannot find grids for %s portfolio", resolution)
-        print(local_grids)
         return local_grids
 
     def get_available_resolutions(self, local_grids, model):
@@ -123,7 +122,7 @@ class AquaFDBGenerator:
         Returns:
             list: List of available grid resolutions.
         """
-        re_pattern = f"horizontal-{model.upper()}-(.+)"
+        re_pattern = f"horizontal-{model}-(.+)"
         grid_resolutions = [match.group(1) for key in local_grids if (match := re.match(re_pattern, key))]
         self.logger.debug("Resolutions found are %s", grid_resolutions)
         return grid_resolutions
@@ -195,8 +194,11 @@ class AquaFDBGenerator:
             dict: Generated profile content.
         """
 
-        grid = self.local_grids[f"horizontal-{self.model.upper()}-{grid_resolution}"]
+        # Normalize model name: remove resolution suffix for data lookups
+        model_base = re.sub(r"-\d+km$", "", self.model)  # IFS-NEMO-5km -> IFS-NEMO
+        model_key = model_base.lower()  # IFS-NEMO -> ifs-nemo
 
+        grid = self.local_grids[f"horizontal-{model_base}-{grid_resolution}"]
         aqua_grid = self.matching_grids[grid]
         levelist, levels_values = self.get_levelist(profile, self.local_grids, self.levels)
         levtype_str = (
@@ -212,14 +214,14 @@ class AquaFDBGenerator:
         )
 
         if not self.ocean_grid:
-            self.ocean_grid = self.matching_grids["ocean_grid"][self.model][self.resolution]
+            self.ocean_grid = self.matching_grids["ocean_grid"][model_key][self.resolution]
             if self.ocean_grid is None:
-                raise ValueError(f"No ocean grid available for: {self.model} {self.resolution}")
+                raise ValueError(f"No ocean grid available for: {model_key} {self.resolution}")
 
         if not self.atm_grid:
-            self.atm_grid = self.matching_grids["atm_grid"][self.model][self.resolution]
+            self.atm_grid = self.matching_grids["atm_grid"][model_key][self.resolution]
             if self.atm_grid is None:
-                raise ValueError(f"No atmospheric grid available for: {self.model} {self.resolution}")
+                raise ValueError(f"No atmospheric grid available for: {model_key} {self.resolution}")
 
         grid_mappings = self.matching_grids["grid_mappings"]
         levtype = profile["levtype"]
@@ -277,7 +279,7 @@ class AquaFDBGenerator:
         Args:
             all_content (dict): Dictionary of all generated content strings.
         """
-        output_dir = os.path.join(self.catalog_dir_path, "catalogs", self.config["catalog_dir"], "catalog", self.model.upper())
+        output_dir = os.path.join(self.catalog_dir_path, "catalogs", self.config["catalog_dir"], "catalog", self.model)
         os.makedirs(output_dir, exist_ok=True)
         output_filename = f"{self.config['exp']}.yaml"
         output_path = os.path.join(output_dir, output_filename)
@@ -343,11 +345,12 @@ class AquaFDBGenerator:
 
             if self.model not in catalog_yaml.get("sources", {}):
                 catalog_yaml.setdefault("sources", {})
-                catalog_yaml["sources"][self.model.upper()] = {
-                    "description": f"{self.model.upper()} model",
+                catalog_yaml["sources"][self.model] = {
+                    "description": f"{self.model} model",
                     "driver": "yaml_file_cat",
-                    "args": {"path": f"{{{{CATALOG_DIR}}}}/catalog/{self.model.upper()}/main.yaml"},
+                    "args": {"path": f"{{{{CATALOG_DIR}}}}/catalog/{self.model}/main.yaml"},
                 }
+
                 dump_yaml(catalog_yaml_path, catalog_yaml)
                 self.logger.info("%s entry in 'catalog.yaml' has been created at %s", self.model, catalog_yaml_path)
 
@@ -357,15 +360,20 @@ class AquaFDBGenerator:
         """
         all_content = {"sources": {}}
 
+        # Normalize model name: remove resolution suffix
+        model_base = re.sub(r"-\d+km$", "", self.model)  # IFS-NEMO-5km -> IFS-NEMO
+
         # Retrieve available resolutions for the current model
-        self.grid_resolutions = self.get_available_resolutions(self.local_grids, self.model)
+        self.grid_resolutions = self.get_available_resolutions(self.local_grids, model_base)
 
         if not self.grid_resolutions:
             self.logger.error("No resolutions found, generating an empty file!")
             return
 
-        for profile in self.dp[self.model]:
-            # Filter out omitted resolutions, if any
+        # Normalize model name to lowercase for portfolio.yaml access
+        model_key = re.sub(r"-\d+km$", "", self.model).lower()
+
+        for profile in self.dp[model_key]:  # Filter out omitted resolutions, if any
             current_resolutions = [
                 res
                 for res in self.grid_resolutions
@@ -375,6 +383,8 @@ class AquaFDBGenerator:
             for grid_resolution in current_resolutions:
                 content = self.get_profile_content(profile, grid_resolution)
                 combined = {**self.config, **content}
+                # Add model_base (without resolution suffix) for template
+                combined["model_base"] = model_base
                 source_name = combined.get("source")
 
                 if source_name in all_content["sources"]:

--- a/aqua/core/config/catgen/catalog_entry.j2
+++ b/aqua/core/config/catgen/catalog_entry.j2
@@ -6,7 +6,7 @@
         activity: {{ activity }}  # To be overwritten by workflow/config file
         experiment: {{ experiment }}  # To be overwritten by workflow/config file
         generation: {{ generation | default(1) }}  # To be overwritten by workflow/config file
-        model: {{ model }}
+        model: {{ model_base }}
         realization: {% if num_of_realizations > 1 %}{% raw %}'{{ realization }}'{% endraw %}{% else %}1{% endif %}
         resolution: {{ resolution }}
         expver: {{ expver }}  # To be overwritten by workflow/config file

--- a/tests/test_catgen.py
+++ b/tests/test_catgen.py
@@ -153,9 +153,9 @@ def _load_generated_sources(config):
     [
         ("IFS-NEMO", "minimal", "lowres", 4, NEMO_OCEAN_LEVELS, 5),
         ("IFS-NEMO", "reduced", "intermediate", 9, NEMO_OCEAN_LEVELS, 5),
-        ("IFS-NEMO", "full", "production", 28, NEMO_OCEAN_LEVELS, 1),
+        ("IFS-NEMO-5km", "full", "production", 28, NEMO_OCEAN_LEVELS, 1),
         ("IFS-FESOM", "full", "production", 31, FESOM_OCEAN_LEVELS, 1),
-        ("ICON", "full", "production", 27, ICON_OCEAN_LEVELS, 1),
+        ("ICON-10km", "full", "production", 27, ICON_OCEAN_LEVELS, 1),
     ],
 )
 @pytest.mark.catgen

--- a/tests/test_catgen.py
+++ b/tests/test_catgen.py
@@ -137,7 +137,7 @@ def _load_generated_sources(config):
     model = config["model"]
     exp = config["exp"]
 
-    catalog_entry_dir = catalog_path / "catalogs" / catalog_dir / "catalog" / model.upper()
+    catalog_entry_dir = catalog_path / "catalogs" / catalog_dir / "catalog" / model
     entry_file = catalog_entry_dir / f"{exp}.yaml"
     main_yaml_file = catalog_entry_dir / "main.yaml"
 


### PR DESCRIPTION
## PR description:

In the new cycle we have resolution explicitly in the model name. This PR adapts catalog generator for that.


Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [x] Tests are included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.
 - [x] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
