### PR TITLE
Update docker base according to requirement for cycle o27.1

### DIFF
--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -42,7 +42,7 @@ on:
         description: 'Container image to use (empty string = ubuntu-latest, default = FDB container)'
         required: false
         type: string
-        default: 'ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.17.3-eccodes2.41.0-aqua:aqua-base-container'
+        default: 'ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container'
       enable-fdb:
         description: 'Enable FDB dependencies and setup'
         required: false

--- a/.github/workflows/aqua-test-reusable.yml
+++ b/.github/workflows/aqua-test-reusable.yml
@@ -42,7 +42,7 @@ on:
         description: 'Container image to use (empty string = ubuntu-latest, default = FDB container)'
         required: false
         type: string
-        default: 'ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container'
+        default: 'ghcr.io/destine-climate-dt/ubuntu26.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container'
       enable-fdb:
         description: 'Enable FDB dependencies and setup'
         required: false

--- a/.github/workflows/create-fdb-container.yaml
+++ b/.github/workflows/create-fdb-container.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME_FDB: ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua
+  IMAGE_NAME_FDB: ubuntu26.04-fdb5.19.0-eccodes2.47.0-aqua
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,5 +28,7 @@ jobs:
           [ "$VERSION" == "main" ] && VERSION=latest
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
+          docker tag $IMAGE_NAME_FDB $IMAGE_ID:aqua-base-container
           docker tag $IMAGE_NAME_FDB $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:aqua-base-container
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/create-fdb-container.yaml
+++ b/.github/workflows/create-fdb-container.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_NAME_FDB: ubuntu24.04-fdb5.17.3-eccodes2.41.0-aqua
+  IMAGE_NAME_FDB: ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
-- Update submit_aqua_web tool to support kind and separate templates (#2921))
+- Updated the AQUA development container to FDB 5.19.0, Metkit 1.15.10, eccodes 2.47.0 and eckit 1.32.5 (#)
+- Update submit_aqua_web tool to support kind and separate templates (#2921)
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)
 - More info on the origin of a push to lumi-o in the logs (#2910)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
-- Updated the AQUA development container to FDB 5.19.0, Metkit 1.15.10, eccodes 2.47.0 and eckit 1.32.5 (#2948)
+- Updated the AQUA development container to Ubuntu 26.04 LTS, FDB 5.19.0, Metkit 1.15.10, eccodes 2.47.0 and eckit 1.32.5 (#2948)
 - Update submit_aqua_web tool to support kind and separate templates (#2921)
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 Unreleased in the current development version (target v1.0.0):
 
 Complete list:
-- Updated the AQUA development container to FDB 5.19.0, Metkit 1.15.10, eccodes 2.47.0 and eckit 1.32.5 (#)
+- Updated the AQUA development container to FDB 5.19.0, Metkit 1.15.10, eccodes 2.47.0 and eckit 1.32.5 (#2948)
 - Update submit_aqua_web tool to support kind and separate templates (#2921)
 - DROP: can now handle level selection with a `--level` cli option or a `level` argument in the DROP class. Levels will be added to the data filenames (#2901)
 - Remove bold from graphics functions (#2916)

--- a/dockerfiles/Dockerfile.aqua
+++ b/dockerfiles/Dockerfile.aqua
@@ -2,7 +2,7 @@
 # Build arguments for different versions
 # this can be configured from github actions, and currently used by create-container-from-tag.yaml
 ARG MICROMAMBA_VERSION=2.3.2
-ARG BASE_IMAGE=ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container
+ARG BASE_IMAGE=ghcr.io/destine-climate-dt/ubuntu26.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container
 ARG MAMBA_USER_ID=57439
 ARG MAMBA_USER_GID=57439
 ARG EXTRA_PACKAGES=""

--- a/dockerfiles/Dockerfile.aqua
+++ b/dockerfiles/Dockerfile.aqua
@@ -2,7 +2,7 @@
 # Build arguments for different versions
 # this can be configured from github actions, and currently used by create-container-from-tag.yaml
 ARG MICROMAMBA_VERSION=2.3.2
-ARG BASE_IMAGE=ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.17.3-eccodes2.41.0-aqua:aqua-base-container
+ARG BASE_IMAGE=ghcr.io/destine-climate-dt/ubuntu24.04-fdb5.19.0-eccodes2.47.0-aqua:aqua-base-container
 ARG MAMBA_USER_ID=57439
 ARG MAMBA_USER_GID=57439
 ARG EXTRA_PACKAGES=""

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -7,7 +7,7 @@
 FROM ubuntu:24.04
 
 LABEL maintainer="jost.hardenberg@polito.it"
-LABEL version="0.7"
+LABEL version="0.8"
 LABEL description="Custom docker image based ion Ubuntu 24.04 with FDB5 and ECCODES for DestinE ClimateDT"
 
 #ARG DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -7,7 +7,7 @@
 FROM ubuntu:24.04
 
 LABEL maintainer="jost.hardenberg@polito.it"
-LABEL version="0.6"
+LABEL version="0.7"
 LABEL description="Custom docker image based ion Ubuntu 24.04 with FDB5 and ECCODES for DestinE ClimateDT"
 
 #ARG DEBIAN_FRONTEND=noninteractive
@@ -16,12 +16,12 @@ RUN apt update
 RUN apt -y install git wget cmake g++
 RUN apt -y install libaec-dev gfortran
 
-# DIR definitions
+# DIR definitions (info on versions: https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-1331)
 ENV INSTALL_DIR=/usr/local
-ENV ECKIT_VER=1.29.3
-ENV ECCODES_VER=2.41.0
-ENV METKIT_VER=1.13.1
-ENV FDB5_VER=5.17.3
+ENV ECKIT_VER=1.32.5
+ENV ECCODES_VER=2.47.0
+ENV METKIT_VER=1.15.10
+ENV FDB5_VER=5.19.0
 # mars client 7.0.2
 
 # ECBUILD

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,14 +1,14 @@
-# Custom Ubuntu 24.04 Docker image with recent FDB5, ECCODES, for the DestinE ClimateDT project
+# Custom Ubuntu 26.04 LTS Docker image with recent FDB5, ECCODES, for the DestinE ClimateDT project
 
 #-----IMPORTANT-----
 # # IMPORTANT: the filename of the docker is defined in the action, and include the name of the branch
 # to keep a level of consistence, please name the branch as "aqua-base-container"
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 LABEL maintainer="jost.hardenberg@polito.it"
-LABEL version="0.8"
-LABEL description="Custom docker image based ion Ubuntu 24.04 with FDB5 and ECCODES for DestinE ClimateDT"
+LABEL version="0.9"
+LABEL description="Custom docker image based on Ubuntu 26.04 LTS with FDB5 and ECCODES for DestinE ClimateDT"
 
 #ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update


### PR DESCRIPTION
## PR description:
This PR follows the changes in PR https://github.com/DestinE-Climate-DT/AQUA/pull/2945, and update ecCodes version to 2.47.0

The motivations for changing these base container packages version can be found at: https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-1331 

## People involved:

@mnurisso 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready to merge" label.
Please apply the "run tests" label if you want to trigger CI tests.

 - [x] Changelog is updated.