### PR TITLE
[Fix] Correct initialization of area selection in fldstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ ClimateDT workflow modifications:
 
 Complete list:
 
+- Area selection can be correctly performed with `areas=False` in the Reader (#2960)
+
 ## [v1.0.0a6]
 
 ClimateDT workflow modifications:

--- a/aqua/core/fldstat/fldstat.py
+++ b/aqua/core/fldstat/fldstat.py
@@ -40,6 +40,9 @@ class FldStat:
             self.logger.warning("No horizontal dimensions provided, will try to guess from data when provided!")
         self.horizontal_dims = horizontal_dims
 
+        # Initialize area selection
+        self.area_selection = AreaSelection(loglevel=loglevel)
+
         if self.area is None:
             self.logger.warning("No area provided, no weighted area can be provided.")
             return
@@ -49,9 +52,6 @@ class FldStat:
             raise ValueError("Area must be an xarray DataArray or Dataset.")
 
         self.grid_name = grid_name
-
-        # Initialize area selection
-        self.area_selection = AreaSelection(loglevel=loglevel)
 
     @property
     def available_fldstats(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,11 @@ def ifs_tco79_long_fixfalse_reader():
 
 
 @pytest.fixture(scope="session")
+def ifs_tco79_long_areasfalse_fixfalse_reader():
+    return Reader(model="IFS", exp="test-tco79", source="long", areas=False, fix=False, loglevel=LOGLEVEL)
+
+
+@pytest.fixture(scope="session")
 def ifs_tco79_long400_fixfalse_reader():
     return Reader(model="IFS", exp="test-tco79", source="long400", fix=False, loglevel=LOGLEVEL)
 

--- a/tests/test_fldstat.py
+++ b/tests/test_fldstat.py
@@ -63,6 +63,11 @@ def reader_ifs(ifs_tco79_short_reader):
 
 
 @pytest.fixture(scope="module")
+def reader_ifs_noarea(ifs_tco79_long_areasfalse_fixfalse_reader):
+    return ifs_tco79_long_areasfalse_fixfalse_reader
+
+
+@pytest.fixture(scope="module")
 def data_ifs(ifs_tco79_short_data_2t):
     return ifs_tco79_short_data_2t
 
@@ -189,6 +194,12 @@ class TestFldmean:
         avg_reg = reader.fldmean(regrid["2t"])
         assert regrid.lat[0] > regrid.lat[1]  # verify lat decreasing
         assert avg_reg.values == pytest.approx(285.426661)  # verify fldmean value
+
+    def test_areasel_areasfalse(self, reader_ifs_noarea):
+        """Area selection test for IFS long source with areas=False"""
+        data_ifs = reader_ifs_noarea.retrieve(var="2t")
+        area_sel = reader_ifs_noarea.select_area(data_ifs, lon=[0, 360], lat=[-80, 80], drop=True)
+        assert area_sel.lat.min().values == pytest.approx(-67.5)
 
 
 @pytest.mark.aqua


### PR DESCRIPTION
## PR description:

I noticed that with areas=False the area selection does not work. This because its constructor happens after the check on the presence of an area in Fldstat, but this is not necessary for the area selection. Therefore I'm moving above the constructor so that it's built also in this specific setup (which unluckily is mine for TRMM)

 - [x] Changelog is updated.