### PR TITLE
Fix missing checks on non-default kwargs in Reader 

### DIFF
--- a/aqua/core/analysis/cli_checker.py
+++ b/aqua/core/analysis/cli_checker.py
@@ -41,35 +41,33 @@ def parse_arguments(args):
         required=False,
         help="by default rebuild of areas is forced, this prevents it",
     )
-    parser.add_argument(
-        "--engine",
-        type=str,
-        default=None,
-        help="GSV engine to use for data retrieval: 'polytope' or 'fdb'. Defaults to 'fdb'.",
-    )
 
     return parser.parse_args(args)
 
 
 def build_reader_kwargs(args):
-    """Build Reader engine and kwargs from CLI args and optional analysis config.
+    """Build the Reader keyword arguments from CLI args and optional analysis config.
+
+    Keyword arguments declared under ``job.reader_kwargs`` in the analysis config
+    (e.g. ``engine: polytope``, ``databridge``) are forwarded to the Reader as-is,
+    so that the checker instantiates the Reader exactly like the analysis does.
+    Values given on the command line take precedence over the config.
 
     Args:
         args: Parsed command-line arguments.
 
     Returns:
-        tuple[str, dict]: Engine name and remaining Reader keyword arguments.
+        dict: Reader keyword arguments.
     """
     reader_kwargs = {}
     config_file = get_arg(args, "config", None)
     if config_file:
-        config = expand_env_vars(load_yaml(config_file))
+        config = expand_env_vars(load_yaml(config_file)) or {}
         reader_kwargs.update(config.get("job", {}).get("reader_kwargs") or {})
     realization = get_arg(args, "realization", None)
     if realization:
         reader_kwargs["realization"] = realization
-    engine = get_arg(args, "engine", None) or reader_kwargs.pop("engine", "fdb")
-    return engine, reader_kwargs
+    return reader_kwargs
 
 
 if __name__ == "__main__":
@@ -103,7 +101,7 @@ if __name__ == "__main__":
     # which is 1 degree for the regrid. The user can override it
     # with the --regrid argument.
     regrid = get_arg(args, "regrid", "r100")
-    engine, reader_kwargs = build_reader_kwargs(args)
+    reader_kwargs = build_reader_kwargs(args)
     yamldir = get_arg(args, "yaml", None)
     fread = getattr(args, "read", True)  # --no-read means fread=False, default is to read data
     frebuild = getattr(args, "rebuild", True)  # --no-rebuild means frebuild=False, default is to rebuild areas
@@ -122,7 +120,6 @@ if __name__ == "__main__":
             loglevel=loglevel,
             rebuild=frebuild,
             regrid=regrid,
-            engine=engine,
             **reader_kwargs,
         )
 

--- a/aqua/core/analysis/cli_checker.py
+++ b/aqua/core/analysis/cli_checker.py
@@ -10,7 +10,7 @@ import argparse
 import os
 import sys
 
-from aqua.core.util import expand_env_vars, get_arg, load_yaml, template_parse_arguments
+from aqua.core.util import get_arg, template_parse_arguments
 
 
 def parse_arguments(args):
@@ -45,31 +45,6 @@ def parse_arguments(args):
     return parser.parse_args(args)
 
 
-def build_reader_kwargs(args):
-    """Build the Reader keyword arguments from CLI args and optional analysis config.
-
-    Keyword arguments declared under ``job.reader_kwargs`` in the analysis config
-    (e.g. ``engine: polytope``, ``databridge``) are forwarded to the Reader as-is,
-    so that the checker instantiates the Reader exactly like the analysis does.
-    Values given on the command line take precedence over the config.
-
-    Args:
-        args: Parsed command-line arguments.
-
-    Returns:
-        dict: Reader keyword arguments.
-    """
-    reader_kwargs = {}
-    config_file = get_arg(args, "config", None)
-    if config_file:
-        config = expand_env_vars(load_yaml(config_file)) or {}
-        reader_kwargs.update(config.get("job", {}).get("reader_kwargs") or {})
-    realization = get_arg(args, "realization", None)
-    if realization:
-        reader_kwargs["realization"] = realization
-    return reader_kwargs
-
-
 if __name__ == "__main__":
     args = parse_arguments(sys.argv[1:])
 
@@ -101,7 +76,8 @@ if __name__ == "__main__":
     # which is 1 degree for the regrid. The user can override it
     # with the --regrid argument.
     regrid = get_arg(args, "regrid", "r100")
-    reader_kwargs = build_reader_kwargs(args)
+    realization = get_arg(args, "realization", None)
+    reader_kwargs = {"realization": realization} if realization else {}
     yamldir = get_arg(args, "yaml", None)
     fread = getattr(args, "read", True)  # --no-read means fread=False, default is to read data
     frebuild = getattr(args, "rebuild", True)  # --no-rebuild means frebuild=False, default is to rebuild areas

--- a/aqua/core/analysis/cli_checker.py
+++ b/aqua/core/analysis/cli_checker.py
@@ -10,7 +10,7 @@ import argparse
 import os
 import sys
 
-from aqua.core.util import template_parse_arguments
+from aqua.core.util import expand_env_vars, get_arg, load_yaml, template_parse_arguments
 
 
 def parse_arguments(args):
@@ -41,8 +41,35 @@ def parse_arguments(args):
         required=False,
         help="by default rebuild of areas is forced, this prevents it",
     )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default=None,
+        help="GSV engine to use for data retrieval: 'polytope' or 'fdb'. Defaults to 'fdb'.",
+    )
 
     return parser.parse_args(args)
+
+
+def build_reader_kwargs(args):
+    """Build Reader engine and kwargs from CLI args and optional analysis config.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Returns:
+        tuple[str, dict]: Engine name and remaining Reader keyword arguments.
+    """
+    reader_kwargs = {}
+    config_file = get_arg(args, "config", None)
+    if config_file:
+        config = expand_env_vars(load_yaml(config_file))
+        reader_kwargs.update(config.get("job", {}).get("reader_kwargs") or {})
+    realization = get_arg(args, "realization", None)
+    if realization:
+        reader_kwargs["realization"] = realization
+    engine = get_arg(args, "engine", None) or reader_kwargs.pop("engine", "fdb")
+    return engine, reader_kwargs
 
 
 if __name__ == "__main__":
@@ -76,8 +103,7 @@ if __name__ == "__main__":
     # which is 1 degree for the regrid. The user can override it
     # with the --regrid argument.
     regrid = get_arg(args, "regrid", "r100")
-    realization = get_arg(args, "realization", None)
-    reader_kwargs = {"realization": realization} if realization else {}
+    engine, reader_kwargs = build_reader_kwargs(args)
     yamldir = get_arg(args, "yaml", None)
     fread = getattr(args, "read", True)  # --no-read means fread=False, default is to read data
     frebuild = getattr(args, "rebuild", True)  # --no-rebuild means frebuild=False, default is to rebuild areas
@@ -96,6 +122,7 @@ if __name__ == "__main__":
             loglevel=loglevel,
             rebuild=frebuild,
             regrid=regrid,
+            engine=engine,
             **reader_kwargs,
         )
 

--- a/aqua/core/console/analysis.py
+++ b/aqua/core/console/analysis.py
@@ -172,6 +172,7 @@ def analysis_execute(args):
             command += f" --catalog {catalog}"
         if realization:
             command += f" --realization {realization}"
+        command += f" --config {aqua_config_path}"
         logger.debug("Command: %s", command)
         result = run_command(command, log_file=output_log_path, logger=logger)
 

--- a/aqua/core/console/analysis.py
+++ b/aqua/core/console/analysis.py
@@ -172,7 +172,6 @@ def analysis_execute(args):
             command += f" --catalog {catalog}"
         if realization:
             command += f" --realization {realization}"
-        command += f" --config {aqua_config_path}"
         logger.debug("Command: %s", command)
         result = run_command(command, log_file=output_log_path, logger=logger)
 

--- a/tests/test_cli_checker.py
+++ b/tests/test_cli_checker.py
@@ -26,7 +26,6 @@ def test_cli_checker_parse_arguments():
             "--no-rebuild",
             "--realization", "r1",
             "--regrid", "r200",
-            "--engine", "polytope",
             "--config", "/tmp/config.yaml",
         ]
     )
@@ -39,7 +38,6 @@ def test_cli_checker_parse_arguments():
     assert args.rebuild is False  # --no-rebuild sets rebuild=False
     assert args.realization == "r1"
     assert args.regrid == "r200"
-    assert args.engine == "polytope"
     assert args.config == "/tmp/config.yaml"
 
     # Test defaults when flags are not provided

--- a/tests/test_cli_checker.py
+++ b/tests/test_cli_checker.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 
 from aqua import __path__ as aqua_pkg_path
-from aqua.core.analysis.cli_checker import parse_arguments
+from aqua.core.analysis.cli_checker import build_reader_kwargs, parse_arguments
 
 pytestmark = pytest.mark.aqua
 
@@ -26,6 +26,8 @@ def test_cli_checker_parse_arguments():
             "--no-rebuild",
             "--realization", "r1",
             "--regrid", "r200",
+            "--engine", "polytope",
+            "--config", "/tmp/config.yaml",
         ]
     )
     # fmt: on
@@ -37,6 +39,8 @@ def test_cli_checker_parse_arguments():
     assert args.rebuild is False  # --no-rebuild sets rebuild=False
     assert args.realization == "r1"
     assert args.regrid == "r200"
+    assert args.engine == "polytope"
+    assert args.config == "/tmp/config.yaml"
 
     # Test defaults when flags are not provided
     args_defaults = parse_arguments(["--model", "IFS", "--exp", "test-tco79", "--source", "short"])
@@ -45,6 +49,74 @@ def test_cli_checker_parse_arguments():
     assert args_defaults.read is True  # Default is True (read data)
     assert args_defaults.rebuild is True  # Default is True (rebuild areas)
     assert args_defaults.realization is None
+    assert args_defaults.engine is None
+
+
+def test_build_reader_kwargs_from_cli(tmp_path):
+    """Test build_reader_kwargs uses CLI engine and realization."""
+    args = parse_arguments(
+        [
+            "--model",
+            "IFS",
+            "--exp",
+            "test-tco79",
+            "--source",
+            "short",
+            "--engine",
+            "polytope",
+            "--realization",
+            "r2",
+        ]
+    )
+    engine, reader_kwargs = build_reader_kwargs(args)
+    assert engine == "polytope"
+    assert reader_kwargs == {"realization": "r2"}
+
+
+def test_build_reader_kwargs_from_config(tmp_path):
+    """Test build_reader_kwargs merges job.reader_kwargs from config and CLI overrides."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("job:\n  reader_kwargs:\n    engine: polytope\n    zoom: 10\n")
+    args = parse_arguments(
+        [
+            "--model",
+            "IFS",
+            "--exp",
+            "test-tco79",
+            "--source",
+            "short",
+            "--config",
+            str(config_path),
+            "--realization",
+            "r1",
+        ]
+    )
+    engine, reader_kwargs = build_reader_kwargs(args)
+    assert engine == "polytope"
+    assert reader_kwargs == {"zoom": 10, "realization": "r1"}
+
+
+def test_build_reader_kwargs_cli_engine_overrides_config(tmp_path):
+    """Test CLI --engine overrides engine from config reader_kwargs."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("job:\n  reader_kwargs:\n    engine: polytope\n")
+    args = parse_arguments(
+        [
+            "--model",
+            "IFS",
+            "--exp",
+            "test-tco79",
+            "--source",
+            "short",
+            "--config",
+            str(config_path),
+            "--engine",
+            "fdb",
+        ]
+    )
+    engine, reader_kwargs = build_reader_kwargs(args)
+    assert engine == "fdb"
+    assert reader_kwargs == {}
 
 
 @pytest.mark.slow

--- a/tests/test_cli_checker.py
+++ b/tests/test_cli_checker.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 
 from aqua import __path__ as aqua_pkg_path
-from aqua.core.analysis.cli_checker import build_reader_kwargs, parse_arguments
+from aqua.core.analysis.cli_checker import parse_arguments
 
 pytestmark = pytest.mark.aqua
 
@@ -26,7 +26,6 @@ def test_cli_checker_parse_arguments():
             "--no-rebuild",
             "--realization", "r1",
             "--regrid", "r200",
-            "--config", "/tmp/config.yaml",
         ]
     )
     # fmt: on
@@ -38,7 +37,6 @@ def test_cli_checker_parse_arguments():
     assert args.rebuild is False  # --no-rebuild sets rebuild=False
     assert args.realization == "r1"
     assert args.regrid == "r200"
-    assert args.config == "/tmp/config.yaml"
 
     # Test defaults when flags are not provided
     args_defaults = parse_arguments(["--model", "IFS", "--exp", "test-tco79", "--source", "short"])
@@ -48,73 +46,6 @@ def test_cli_checker_parse_arguments():
     assert args_defaults.rebuild is True  # Default is True (rebuild areas)
     assert args_defaults.realization is None
     assert args_defaults.engine is None
-
-
-def test_build_reader_kwargs_from_cli(tmp_path):
-    """Test build_reader_kwargs uses CLI engine and realization."""
-    args = parse_arguments(
-        [
-            "--model",
-            "IFS",
-            "--exp",
-            "test-tco79",
-            "--source",
-            "short",
-            "--engine",
-            "polytope",
-            "--realization",
-            "r2",
-        ]
-    )
-    engine, reader_kwargs = build_reader_kwargs(args)
-    assert engine == "polytope"
-    assert reader_kwargs == {"realization": "r2"}
-
-
-def test_build_reader_kwargs_from_config(tmp_path):
-    """Test build_reader_kwargs merges job.reader_kwargs from config and CLI overrides."""
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("job:\n  reader_kwargs:\n    engine: polytope\n    zoom: 10\n")
-    args = parse_arguments(
-        [
-            "--model",
-            "IFS",
-            "--exp",
-            "test-tco79",
-            "--source",
-            "short",
-            "--config",
-            str(config_path),
-            "--realization",
-            "r1",
-        ]
-    )
-    engine, reader_kwargs = build_reader_kwargs(args)
-    assert engine == "polytope"
-    assert reader_kwargs == {"zoom": 10, "realization": "r1"}
-
-
-def test_build_reader_kwargs_cli_engine_overrides_config(tmp_path):
-    """Test CLI --engine overrides engine from config reader_kwargs."""
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text("job:\n  reader_kwargs:\n    engine: polytope\n")
-    args = parse_arguments(
-        [
-            "--model",
-            "IFS",
-            "--exp",
-            "test-tco79",
-            "--source",
-            "short",
-            "--config",
-            str(config_path),
-            "--engine",
-            "fdb",
-        ]
-    )
-    engine, reader_kwargs = build_reader_kwargs(args)
-    assert engine == "fdb"
-    assert reader_kwargs == {}
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fix setup checker failures for Polytope (and other non-default Reader options) by merging Reader kwargs from config/CLI instead of only forwarding `realization`, and passing `engine` explicitly to Reader.
Link to: https://github.com/DestinE-Climate-DT/AQUA/issues/2906

 - [ ] Changelog is updated.
 - [ ] Run Cross check tests for AQUA-diagnostics [AQUA-diagnostics cross-check workflow](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/actions/workflows/aqua-diagnostics-cross-check.yml)
 - [ ] Check `ruff` and `pre-commit` commands: `ruff check . --no-cache`, `pre-commit run --all-files` and `ruff format --check . --no-cache` are successful.
