### PR TITLE
v1.0.0-preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -51,6 +51,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v1.0.0
       - v1.0.0a6
       - v1.0.0a5
       - v1.0.0a4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ ClimateDT workflow modifications:
 
 Complete list:
 
+## [v1.0.0]
+
+Main changes:
+- No changes respect with v1.0.0a6
+
+Complete list:
+- No changes respect with v1.0.0a6
+
 ## [v1.0.0a6]
 
 ClimateDT workflow modifications:
@@ -1470,7 +1478,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers.
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a6...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a6...v1.0.0
 [v1.0.0a6]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a5...v1.0.0a6
 [v1.0.0a5]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a4...v1.0.0a5
 [v1.0.0a4]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a3...v1.0.0a4

--- a/aqua/core/version.py
+++ b/aqua/core/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = "1.0.0a6"
+__version__ = "1.0.0"


### PR DESCRIPTION
## Version release PR:

Release of v1.0.0!

The run of aqua_analysis was performed setting the following parameters:
- `--serial` (although the run did not run in serial)
- `--maxprocesses=3` 

People involved:
@mcadau 

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `aqua/core/version.py`
