### PR TITLE
Synchronize available statistics with TimStat class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v1.0.0):
 ClimateDT workflow modifications:
 
 Complete list:
+- Synchronize the available statistics in DROP with the TimStat class (#2991)
 - Specify min and max allowed versions for all dependencies (#2984)
 - CI/CD: fix micromamba setup broken by setup-micromamba v3.2.0 (#2985)
 

--- a/aqua/core/drop/drop.py
+++ b/aqua/core/drop/drop.py
@@ -27,6 +27,7 @@ from aqua.core.configurer import ConfigPath
 from aqua.core.lock import SafeFileLock
 from aqua.core.logger import log_configure, log_history
 from aqua.core.reader import Reader
+from aqua.core.timstat import TimStat
 from aqua.core.util import dump_yaml, load_yaml
 from aqua.core.util.io_util import create_folder
 from aqua.core.util.string import generate_random_string
@@ -37,8 +38,8 @@ from .drop_writer_icechunk import IcechunkWriter
 from .drop_writer_netcdf import NetCDFWriter
 from .drop_writer_zarr import ZarrWriter
 
-# available statistics
-available_stats = ["mean", "std", "max", "min", "sum", "histogram"]
+# available statistics are synchronized with the TimStat class
+available_stats = TimStat().available_stats
 
 
 class Drop:


### PR DESCRIPTION
## PR description:

The DROP available statistics were hardcoded. For this reason 'first' and 'last' statistics were not available. This PR update the list so that automatically uses the list from TimStat, so that there is no need for manual maintenance of that part of code.

 - [x] Tests are included if a new feature is included.
 - [x] Changelog is updated.
