### PR TITLE
Add memory option to submit-aqua-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v1.0.0):
 ClimateDT workflow modifications:
 
 Complete list:
+- Add memory option to submit-aqua-web (#3006)
 - Synchronize the available statistics in DROP with the TimStat class (#2991)
 - Specify min and max allowed versions for all dependencies (#2984)
 - CI/CD: fix micromamba setup broken by setup-micromamba v3.2.0 (#2985)

--- a/cli/aqua-web/aqua-web.job.j2
+++ b/cli/aqua-web/aqua-web.job.j2
@@ -7,6 +7,7 @@
 #SBATCH --time={{ time }}
 #SBATCH --error={{ logdir_error }}/{{ error }}
 #SBATCH --output={{ logdir_output }}/{{ output }}
+#SBATCH --mem={{ memory }}
 
 model={{ model }}
 exp={{ exp }}

--- a/cli/aqua-web/config.aqua-web.yaml
+++ b/cli/aqua-web/config.aqua-web.yaml
@@ -4,11 +4,12 @@ username: jvonhar
 
 analysis:
     job_name: aqua-web
-    emplate: aqua-web.job.j2
+    template: aqua-web.job.j2
     partition: small
     nodes: 1
     ntasks_per_node: 128
     time: 04:30:00
+    memory: 224G
 push:
     job_name: aqua-web.push
     template: aqua-web.push.job.j2

--- a/cli/aqua-web/submit-aqua-web.py
+++ b/cli/aqua-web/submit-aqua-web.py
@@ -153,6 +153,7 @@ class Submitter:
         definitions["nodes"] = definitions["analysis"]["nodes"]
         definitions["ntasks_per_node"] = definitions["analysis"]["ntasks_per_node"]
         definitions["time"] = definitions["analysis"]["time"]
+        definitions["memory"] = definitions["analysis"]["memory"]
 
         definitions["output"] = full_job_name + "_%j.out"
         definitions["error"] = full_job_name + "_%j.err"


### PR DESCRIPTION
## PR description:

The default job script used submit-aqua-web did not specify memory, resulting in only 120GiB allocated.
This now allows to specify how much memory on the node we wish to use
  
Tag here relevant people to involve in the discussion:

@CostanzaD @mcadau 

----

 - [x] Changelog is updated.
