### PR TITLE
Better eccodes interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased in the current development version (target v1.0.0):
 ClimateDT workflow modifications:
 
 Complete list:
+- Fix and rewrite get_eccodes_attr for paramId case (#3008)
 - Add memory option to submit-aqua-web (#3006)
 - Synchronize the available statistics in DROP with the TimStat class (#2991)
 - Specify min and max allowed versions for all dependencies (#2984)

--- a/aqua/core/util/eccodes.py
+++ b/aqua/core/util/eccodes.py
@@ -23,11 +23,13 @@ from aqua.core.logger import log_configure
 
 
 @functools.cache
-def _get_attrs_from_shortname(sn, grib_version="GRIB2", table=0):
-    """Get the attributes of a parameter by its short name.
+def _get_attrs_from_shortname_or_pid(sn=None, pid=None, grib_version="GRIB2", table=0, logger=None):
+    """Get the attributes of a parameter by its short name or pid.
     Args:
         sn (str): The short name to look up.
+        pid (str): The parameter ID to look up.
         grib_version (str): The GRIB version to use, either "GRIB2" or "GRIB1".
+        logger (logging.Logger, optional): The logger to use for logging. Defaults to None.
     Returns:
         dict: A dictionary containing the attributes of the parameter, namely
         'paramId', 'long_name', 'units', 'shortName', 'cfVarName'.
@@ -39,14 +41,26 @@ def _get_attrs_from_shortname(sn, grib_version="GRIB2", table=0):
     codes_set(gid, "centre", table)
     # HACK: if the sn is not defined in the WMO table, first set the GRIB2 template
     # handler to use Destine local parameters definitions (12)
-    try:
-        codes_set(gid, "shortName", sn)
-    except CodesInternalError:
-        logger = log_configure(log_level="WARNING", log_name="eccodes")
-        logger.warning("shortName %s not found in default WMO definitions, switching to destine local parameters", sn)
-        codes_set(gid, "productionStatusOfProcessedData", 12)
-        codes_set(gid, "shortName", sn)
-    pid = codes_get(gid, "paramId", ktype=str)
+
+    if sn:
+        try:
+            codes_set(gid, "shortName", sn)
+        except CodesInternalError:
+            if logger:
+                logger.debug("shortName %s not found in default WMO definitions, switching to DestinE local parameters", sn)
+            codes_set(gid, "productionStatusOfProcessedData", 12)
+            codes_set(gid, "shortName", sn)
+        pid = codes_get(gid, "paramId", ktype=str)
+    else:
+        try:
+            codes_set(gid, "paramId", pid)
+        except CodesInternalError:
+            if logger:
+                logger.debug("paramId %s not found in default WMO definitions, switching to DestinE local parameters", pid)
+            codes_set(gid, "productionStatusOfProcessedData", 12)
+            codes_set(gid, "paramId", pid)
+        sn = codes_get(gid, "shortName")
+
     nm = codes_get(gid, "name")
     un = codes_get(gid, "units")
     # cf = codes_get(gid, "cfName")
@@ -60,31 +74,6 @@ def _get_attrs_from_shortname(sn, grib_version="GRIB2", table=0):
         #'cfName': cf,
         "cfVarName": cfv,
     }
-
-
-@functools.cache
-def _get_shortname_from_paramid(pid):
-    """Get the attributes of a parameter by its paramId.
-
-    Args:
-        paramid (str): The parameter ID to look up.
-
-    Returns:
-        string: The short name associated with the given paramId.
-    """
-    gid = codes_grib_new_from_samples("GRIB2")
-    # HACK: if the pid is not defined in the WMO table, first set the GRIB2 template
-    # handler to use Destine local parameters definitions (12)
-    try:
-        codes_set(gid, "paramId", pid)
-    except CodesInternalError:
-        logger = log_configure(log_level="WARNING", log_name="eccodes")
-        logger.warning("paramId %s not found in default WMO definitions,switching to destine local parameters", pid)
-        codes_set(gid, "productionStatusOfProcessedData", 12)
-        codes_set(gid, "paramId", pid)
-    sn = codes_get(gid, "shortName")
-    codes_release(gid)
-    return sn
 
 
 def get_eccodes_attr(sn, loglevel="WARNING"):
@@ -101,18 +90,13 @@ def get_eccodes_attr(sn, loglevel="WARNING"):
     logger = log_configure(log_level=loglevel, log_name="eccodes")
 
     # If sn is an integer or a string that can be converted to an integer, treat it as a paramId
+    if isinstance(sn, str) and sn.startswith("var"):
+        sn = sn[3:]
     if isinstance(sn, int) or (isinstance(sn, str) and sn.isdigit()):
-        logger.debug("Input is a paramId: %s", sn)
-        sn = _get_shortname_from_paramid(sn)
-    # extract the short name from the variable name if it starts with 'var'
-    if sn.startswith("var"):
-        logger.debug("Input is a variable name, extracting short name from: %s", sn)
-        sn = _get_shortname_from_paramid(sn[3:])
-
-    # warning at wrapper level to avoid duplication of logger
-    # if sn in NOT_UNIQUE_SHORTNAMES:
-    #    logger.warning('Short name %s is not unique, using the first paramId in the list: %s',
-    #                   sn, NOT_UNIQUE_SHORTNAMES[sn][0])
+        pid = int(sn)
+        sn = None
+    else:
+        pid = None
 
     # Try to get attributes from 4 tables: WMO+GRIB2, ECMF+GRIB2, WMO+GRIB1, ECMF+GRIB1
     strategies = [
@@ -123,30 +107,38 @@ def get_eccodes_attr(sn, loglevel="WARNING"):
     ]
 
     for _, strategy in enumerate(strategies):
-        try:
+        if sn:
             logger.debug(
                 "Trying short name %s with GRIB version %s and table %s", sn, strategy["grib_version"], strategy["table"]
             )
-            return _get_attrs_from_shortname(sn, **strategy)
-        except CodesInternalError as e:
-            if strategy["grib_version"] == "GRIB1":
-                logger.warning("No GRIB2 codes found, trying GRIB1 for shortName %s", sn)
+        else:
             logger.debug(
-                "Failed guessing for shortName %s, grib_version %s and table %s: %s",
-                strategy["grib_version"],
-                strategy["table"],
-                sn,
-                e,
+                "Trying paramId %s with GRIB version %s and table %s", pid, strategy["grib_version"], strategy["table"]
             )
 
-    raise NoEcCodesShortNameError(f"Cannot find any grib codes for ShortName {sn}")
+        try:
+            return _get_attrs_from_shortname_or_pid(sn=sn, pid=pid, **strategy, logger=logger)
+        except CodesInternalError as e:
+            if strategy["grib_version"] == "GRIB1":
+                logger.debug("No GRIB2 codes found, trying GRIB1 for shortName %s", sn)
+            if sn:
+                logger.debug(
+                    "Failed guessing for shortName %s, grib_version %s and table %s: %s",
+                    strategy["grib_version"],
+                    strategy["table"],
+                    sn,
+                    e,
+                )
+            else:
+                logger.debug(
+                    "Failed guessing for paramId %s, grib_version %s and table %s: %s",
+                    strategy["grib_version"],
+                    strategy["table"],
+                    pid,
+                    e,
+                )
 
-
-def get_eccodes_shortname(pid):
-    """
-    Wrapper for _get_shortname_from_paramid to retrieve the short name for a given paramId.
-    """
-    try:
-        return _get_shortname_from_paramid(pid)
-    except CodesInternalError as e:
-        raise NoEcCodesShortNameError(f"Cannot find any grib codes for paramId {pid}") from e
+    if sn:
+        raise NoEcCodesShortNameError(f"Cannot find any grib codes for ShortName {sn}")
+    else:
+        raise NoEcCodesShortNameError(f"Cannot find any grib codes for paramId {pid}")

--- a/aqua/core/util/eccodes.py
+++ b/aqua/core/util/eccodes.py
@@ -93,7 +93,7 @@ def get_eccodes_attr(sn, loglevel="WARNING"):
     if isinstance(sn, str) and sn.startswith("var"):
         sn = sn[3:]
     if isinstance(sn, int) or (isinstance(sn, str) and sn.isdigit()):
-        pid = int(sn)
+        pid = str(sn)
         sn = None
     else:
         pid = None

--- a/tests/test_eccodes.py
+++ b/tests/test_eccodes.py
@@ -13,7 +13,7 @@ from aqua.core.util import get_eccodes_attr
         (
             235288,
             {
-                "paramId": 235288,
+                "paramId": "235288",
                 "long_name": "Time-mean total cloud cover",
                 "units": "%",
                 "shortName": "avg_tcc",
@@ -33,7 +33,7 @@ from aqua.core.util import get_eccodes_attr
         (
             164,
             {
-                "paramId": 164,
+                "paramId": "164",
                 "long_name": "Total cloud cover",
                 "units": "(0 - 1)",
                 "shortName": "tcc",
@@ -53,7 +53,7 @@ from aqua.core.util import get_eccodes_attr
         (
             228164,
             {
-                "paramId": 228164,
+                "paramId": "228164",
                 "long_name": "Total Cloud Cover",
                 "units": "%",
                 "shortName": "tcc",
@@ -73,7 +73,7 @@ from aqua.core.util import get_eccodes_attr
         (
             72,
             {
-                "paramId": 72,
+                "paramId": "72",
                 "long_name": "Instantaneous surface solar radiation downwards",
                 "units": "W m**-2",
                 "shortName": "issrd",

--- a/tests/test_eccodes.py
+++ b/tests/test_eccodes.py
@@ -1,0 +1,144 @@
+"""Tests for ecCodes utilities."""
+
+import pytest
+
+from aqua.core.exceptions import NoEcCodesShortNameError
+from aqua.core.util import get_eccodes_attr
+
+
+@pytest.mark.aqua
+@pytest.mark.parametrize(
+    "query, expected_attr",
+    [
+        (
+            235288,
+            {
+                "paramId": 235288,
+                "long_name": "Time-mean total cloud cover",
+                "units": "%",
+                "shortName": "avg_tcc",
+                "cfVarName": "avg_tcc",
+            },
+        ),
+        (
+            "avg_tcc",
+            {
+                "paramId": "235288",
+                "long_name": "Time-mean total cloud cover",
+                "units": "%",
+                "shortName": "avg_tcc",
+                "cfVarName": "avg_tcc",
+            },
+        ),
+        (
+            164,
+            {
+                "paramId": 164,
+                "long_name": "Total cloud cover",
+                "units": "(0 - 1)",
+                "shortName": "tcc",
+                "cfVarName": "tcc",
+            },
+        ),
+        (
+            "tcc",
+            {
+                "paramId": "228164",
+                "long_name": "Total Cloud Cover",
+                "units": "%",
+                "shortName": "tcc",
+                "cfVarName": "tcc",
+            },
+        ),
+        (
+            228164,
+            {
+                "paramId": 228164,
+                "long_name": "Total Cloud Cover",
+                "units": "%",
+                "shortName": "tcc",
+                "cfVarName": "tcc",
+            },
+        ),
+        (
+            "issrd",
+            {
+                "paramId": "72",
+                "long_name": "Instantaneous surface solar radiation downwards",
+                "units": "W m**-2",
+                "shortName": "issrd",
+                "cfVarName": "issrd",
+            },
+        ),
+        (
+            72,
+            {
+                "paramId": 72,
+                "long_name": "Instantaneous surface solar radiation downwards",
+                "units": "W m**-2",
+                "shortName": "issrd",
+                "cfVarName": "issrd",
+            },
+        ),
+    ],
+)
+def test_get_eccodes_attr_examples(query, expected_attr):
+    """Test get_eccodes_attr against expected parameter attributes."""
+    result = get_eccodes_attr(query, loglevel="debug")
+    assert result == expected_attr
+    for key, value in expected_attr.items():
+        assert result[key] == value
+
+
+@pytest.mark.aqua
+@pytest.mark.parametrize(
+    "pid, expected_short_name",
+    [
+        (235288, "avg_tcc"),
+        (164, "tcc"),
+        (228164, "tcc"),
+        (72, "issrd"),
+    ],
+)
+def test_get_eccodes_attr_param_to_shortname(pid, expected_short_name):
+    """Test looking up shortName from paramId."""
+    res = get_eccodes_attr(pid, loglevel="debug")
+    assert res["shortName"] == expected_short_name
+
+
+@pytest.mark.aqua
+@pytest.mark.parametrize(
+    "sn, expected_pid",
+    [
+        ("avg_tcc", "235288"),
+        ("tcc", "228164"),
+        ("issrd", "72"),
+    ],
+)
+def test_get_eccodes_attr_shortname_to_param(sn, expected_pid):
+    """Test looking up paramId from shortName."""
+    res = get_eccodes_attr(sn, loglevel="debug")
+    assert str(res["paramId"]) == expected_pid
+
+
+@pytest.mark.aqua
+@pytest.mark.parametrize(
+    "var_str, expected_short_name",
+    [
+        ("var235288", "avg_tcc"),
+        ("var72", "issrd"),
+        ("var164", "tcc"),
+    ],
+)
+def test_get_eccodes_attr_var_prefix(var_str, expected_short_name):
+    """Test string paramId with 'var' prefix."""
+    res = get_eccodes_attr(var_str, loglevel="debug")
+    assert res["shortName"] == expected_short_name
+
+
+@pytest.mark.aqua
+@pytest.mark.parametrize("invalid_query", ["nonexistent_short_name_xyz", 99999999])
+def test_get_eccodes_attr_not_found(invalid_query):
+    """Test that NoEcCodesShortNameError is raised for invalid paramId or shortName."""
+    with pytest.raises(NoEcCodesShortNameError):
+        get_eccodes_attr(invalid_query, loglevel="debug")


### PR DESCRIPTION
## PR description:

This fixes the eccodes interface function `get_eccodes_attr()` to work with different tables and when a pid is passed.

The previous version when a numerical paramId was passed would do a quite crazy series of passages:
1) convert to a shortname (ALWAYS using the ecmwf table!)
2) from the sn recover the ECCODES info

This is obviously wrong and was leading to issue #3007 

It also could potentially lead to crazy results if a shortname exists in two different tables. Think of tcc which exists in both wMO and ECMWF tables. If I asked for pid 164 it would return info about pid 228164 (tcc in WMO) !:
```

get_eccodes_attr(164, loglevel="debug")
2026-08-18 17:56:49 :: eccodes :: DEBUG    -> Input is a paramId: 164
2026-08-18 17:56:49 :: eccodes :: DEBUG    -> Trying short name tcc with GRIB version GRIB2 and table 0
{'paramId': '228164', 'long_name': 'Total Cloud Cover', 'units': '%', 'shortName': 'tcc', 'cfVarName': 'tcc'}


```
This version correctly follows the different strategies recovering directly the needed info if the input is a shortname or a pid.

## Issues closed by this pull request:

Close #3007

## People involved:

@silviacaprioli 

----

 - [x] Tests are included if a new feature is included.
 - [x] Docstrings are updated if needed.
 - [x] Changelog is updated.