### PR TITLE
Fix nmaxprocesses logging bug

### DIFF
--- a/aqua/core/console/analysis.py
+++ b/aqua/core/console/analysis.py
@@ -100,7 +100,8 @@ def analysis_execute(args):
 
     # maximum parallel processes for the ThreadPoolExecutor
     nmaxprocesses = args.nmaxprocesses if args.nmaxprocesses > 0 else None
-    logger.debug("nmaxprocesses: %d", nmaxprocesses)
+    if nmaxprocesses:
+        logger.debug("nmaxprocesses: %d", nmaxprocesses)
 
     # read the experiment kind and configure
     exp_kind_file = job_config.get("experiment_kind")


### PR DESCRIPTION
## PR description:

This fixes an annoying bug in analysis which leads to reporting an error if `nmaxprocesses` has not been set.
It is solved also in aqua-backend, but since it appears always in my analysisi runs I think that we should fix it in the main before any new release.

So small that it probably does not deserve a changelog
