### PR TITLE
[Rel] v1.1.0-preparation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -51,6 +51,7 @@ body:
       description: Which AQUA version are you using?
       options:
       - main
+      - v1.1.0
       - v1.0.1
       - v1.0.0
       - v1.0.0a6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
-Unreleased in the current development version (target v1.1.0):
+Unreleased in the current development version (target v1.2.0):
+
+Main changes:
+
+ClimateDT workflow modifications:
+
+Complete list:
+
+## [v1.1.0]
 
 Main changes:
 - `Reader` now supports `icechunk` and `z3fdb` sources
@@ -1520,7 +1528,8 @@ This is mostly built on the `AQUA` `Reader` class which support for climate mode
 This is the AQUA pre-release to be sent to internal reviewers.
 Documentations is completed and notebooks are working.
 
-[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.1...HEAD
+[unreleased]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.1.0...HEAD
+[v1.1.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.1...v1.1.0
 [v1.0.1]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a6...v1.0.0
 [v1.0.0a6]: https://github.com/DestinE-Climate-DT/AQUA/compare/v1.0.0a5...v1.0.0a6

--- a/aqua/core/version.py
+++ b/aqua/core/version.py
@@ -1,3 +1,3 @@
 """Module where to define the version of the package."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"


### PR DESCRIPTION
## Version release PR:

Issue to keep track of what is needed for a new AQUA release

- [x] update changelog
- [x] update bug report menu
- [x] update version number in `aqua/core/version.py`
- [ ] Check key pyproject pins (gsv, xarray, pandas, etc.)
- [ ] if a major operational release, update Dockerfiles and relative action
- [x] if it's an operational release, be sure the bug report menu is updated in the main as well
