### PR TITLE
Add scheduled cron job for conda relock workflow

### DIFF
--- a/.github/workflows/conda-relock.yml
+++ b/.github/workflows/conda-relock.yml
@@ -1,6 +1,8 @@
 name: relock conda
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1" # run every Monday night at 4AM UTC
 
 permissions:
   contents: write


### PR DESCRIPTION
## PR description:

Run conda-lock every monday morning at 4