### PR TITLE
Remove `datetime`call for pandas

### DIFF
--- a/aqua/core/drop/drop.py
+++ b/aqua/core/drop/drop.py
@@ -16,7 +16,6 @@ Main features:
 
 import os
 import shutil
-from datetime import datetime
 from time import time
 
 import dask
@@ -247,7 +246,7 @@ class Drop:
         self.check = False
 
         # stats file written in basedir (timestamped, with run details to avoid overwrites)
-        _ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        _ts = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
         self.stats_file = os.path.join(
             self.basedir,
             f"drop_stats_{self.catalog}_{self.model}_{self.exp}_{self.source}_{output_format}_{_ts}.txt",
@@ -664,7 +663,7 @@ class Drop:
         """Write a run header block to the stats file."""
         if not self.definitive:
             return
-        now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        now = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
         header = (
             "\n=== DROP Performance Stats ===\n"
             f"Model: {self.model} | Exp: {self.exp} | Source: {self.source} |"
@@ -681,7 +680,7 @@ class Drop:
             return
         chunk_stats = getattr(self.writer, "_chunk_stats", [])
         total_time = t_end - t_beg
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        ts = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
         line = f"[{ts}] SUMMARY  var={var}  total_time={total_time:.2f}s  chunks={len(chunk_stats)}\n"
         with open(self.stats_file, "a", encoding="utf-8") as fh:
             fh.write(line)

--- a/aqua/core/drop/drop_writer_base.py
+++ b/aqua/core/drop/drop_writer_base.py
@@ -9,7 +9,6 @@ import glob
 import os
 import shutil
 from abc import ABC, abstractmethod
-from datetime import datetime
 from time import time
 
 import numpy as np
@@ -620,7 +619,7 @@ class BaseWriter(ABC):
 
     def _write_chunk_stat_line(self, entry, stats_file):
         """Write a single chunk stat line immediately to the stats file."""
-        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        ts = pd.Timestamp.now().strftime("%Y-%m-%d %H:%M:%S")
         mem = entry.get("mem")
         size_bytes = entry.get("size_bytes")
         tp = entry.get("throughput_mib_s")

--- a/aqua/core/fixer/fixer_operator.py
+++ b/aqua/core/fixer/fixer_operator.py
@@ -1,7 +1,5 @@
 """Strategies for fixing issues in the code."""
 
-from datetime import timedelta
-
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -159,7 +157,7 @@ class FixerOperator:
 
         if jump:
             # universal mask based on the change of month (shifted by one timestep)
-            dt = np.timedelta64(timedelta(seconds=deltat))
+            dt = pd.Timedelta(seconds=deltat).to_timedelta64()
             data1 = data.assign_coords(time=data.time - dt)
             data2 = data.assign_coords(time=data1.time - dt)
             # Mask of dates where month changed in the previous timestep
@@ -220,9 +218,9 @@ class FixerOperator:
 
         first = data.time.groupby(data["time.year"] * 100 + data["time.month"]).first()
         if enddate:
-            first = first.where(first < np.datetime64(str(enddate)), drop=True)
+            first = first.where(first < pd.Timestamp(enddate), drop=True)
         if startdate:
-            first = first.where(first > np.datetime64(str(startdate)), drop=True)
+            first = first.where(first > pd.Timestamp(startdate), drop=True)
         mask = data.time.isin(first)
         data = data.where(~mask, np.nan)
 

--- a/aqua/core/util/io_util.py
+++ b/aqua/core/util/io_util.py
@@ -127,7 +127,7 @@ def file_is_complete(filename, loglevel="WARNING"):
         if mindate is not None:
             logger.warning("Some NaN and mindate found: %s", mindate)
             last_nan = xfield.time[np.where(nan_count == nan_count[0])].max()
-            if np.datetime64(mindate) > last_nan:
+            if pd.Timestamp(mindate) > last_nan:
                 logger.info(
                     "File %s has some NaN up to %s but it is ok according to mindate %s",
                     filename,


### PR DESCRIPTION
## PR description:

Remove datetime in favour of pandas 

## Issues closed by this pull request:

Close #3052 


----

 - [ ] Tests are included if a new feature is included.
 - [ ] Documentation is included if a new feature is included.
 - [ ] Docstrings are updated if needed.
 - [ ] Changelog is updated.
 - [ ] Notebooks which requires changes are updated.
 - [ ] Run Cross check tests for AQUA-diagnostics [AQUA-diagnostics cross-check workflow](https://github.com/DestinE-Climate-DT/AQUA-diagnostics/actions/workflows/aqua-diagnostics-cross-check.yml)
 - [ ] environment.yml and pyproject.toml are updated if needed, together with the lumi installation tool. Installation instructions are updated if new conda dependencies are added.
 - [ ] If environment files have been updated, then conda-lock files need to be updated: run the `conda-relock` action, check that tests pass in the new PR and merge it into this one.
 - [ ] Check that the `ruff` action was successful.
