### PR TITLE
New fix for ERA5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ClimateDT workflow modifications:
 Complete list:
 
 - Suppress Intake2 warning (#3077)
+- New version of the ERA5 data, including clear-sky variables, for Fixer (#3079)
 
 ## [v1.1.0]
 

--- a/aqua/core/config/fixes/OBS-climatedt.yaml
+++ b/aqua/core/config/fixes/OBS-climatedt.yaml
@@ -66,6 +66,18 @@ fixer_name:
             tnlwrf:
                 src_units: J m**-2 day**-1
                 source: ttr
+            snswrfcs:
+                src_units: J m**-2 day**-1
+                source: ssrc
+            snlwrfcs:
+                src_units: J m**-2 day**-1
+                source: strc
+            tnswrfcs:
+                src_units: J m**-2 day**-1
+                source: tsrc
+            tnlwrfcs:
+                src_units: J m**-2 day**-1
+                source: ttrc
 
     ERA5-daily-destine-v1:
         convention: eccodes

--- a/aqua/core/config/fixes/OBS-climatedt.yaml
+++ b/aqua/core/config/fixes/OBS-climatedt.yaml
@@ -33,6 +33,40 @@ fixer_name:
                 src_units: J m**-2 day**-1
                 source: TTR
 
+    ERA5-destine-v2:
+        convention: eccodes
+        vars:
+            ie:
+                source: e
+                src_units: m/day
+            tprate:
+                source: tp
+                src_units: m/day
+            slhtf:
+                src_units: J m**-2 day**-1
+                source: slhf
+            ishf:
+                src_units: J m**-2 day**-1
+                source: sshf
+            snswrf:
+                src_units: J m**-2 day**-1
+                source: ssr
+            sdswrf:
+                src_units: J m**-2 day**-1
+                source: ssrd
+            snlwrf:
+                src_units: J m**-2 day**-1
+                source: str
+            sdlwrf:
+                src_units: J m**-2 day**-1
+                source: strd
+            tnswrf:
+                src_units: J m**-2 day**-1
+                source: tsr
+            tnlwrf:
+                src_units: J m**-2 day**-1
+                source: ttr
+
     ERA5-daily-destine-v1:
         convention: eccodes
         delete:

--- a/aqua/core/data_model/coordtransformer.py
+++ b/aqua/core/data_model/coordtransformer.py
@@ -189,10 +189,8 @@ class CoordTransformer:
                 data[tgt_coord["name"]].attrs["flipped"] = 1
                 log_history(
                     data,
-                    (
-                        f"Flipped coordinate {tgt_coord['name']} from ",
-                        f"{src_coord['stored_direction']} to {tgt_coord['stored_direction']} by datamodel",
-                    ),
+                    f"Flipped coordinate {tgt_coord['name']} from "
+                    f"{src_coord['stored_direction']} to {tgt_coord['stored_direction']} by datamodel",
                 )
             else:
                 self.logger.info(


### PR DESCRIPTION
## PR description:

Following a change in the file shortnames in ERA5 dataset, we need to create a new fixer for this. 
Simply replacing upper case with lower case shortnames. 

In addition, clear-sky variables are finally recognized and their units correcly converted by the `Fixer`.