### PR TITLE
Cli_checker fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Main changes:
 ClimateDT workflow modifications:
 
 Complete list:
+- Cli_checker adjustments after Backend new developments (#3081)
 - Seldate method using pandas as reader method and allows dates beyond 2262 (#3072)
-
 - Suppress Intake2 warning (#3077)
 
 ## [v1.1.0]

--- a/aqua/core/analysis/cli_checker.py
+++ b/aqua/core/analysis/cli_checker.py
@@ -110,7 +110,7 @@ def main(args):
             dump_yaml(outfile=yaml_path, cfg=metadata)
 
         if fread:
-            reader.retrieve(sample=True)
+            reader._retrieve_plain()
 
     except Exception as e:
         logger.error("Failed to retrieve data: {}".format(e))

--- a/aqua/core/analysis/cli_checker.py
+++ b/aqua/core/analysis/cli_checker.py
@@ -100,9 +100,9 @@ def main(args):
         # extract metadata from catalog
         if yamldir:
             logger.info("Creating experiment.yaml")
-            metadata = reader.expcat.metadata.copy()
+            metadata = reader.backend.expcat.metadata.copy()
             metadata.pop("catalog_dir", None)
-            metadata["description"] = getattr(reader.expcat, "description", "")
+            metadata["description"] = getattr(reader.backend.expcat, "description", "")
             metadata["catalog"] = catalog
             metadata["model"] = model
             metadata["experiment"] = exp

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from jinja2 import UndefinedError
 
-from aqua.core.analysis import Analysis
+from aqua.core.analysis import Analysis, cli_checker
 from aqua.core.console.analysis import analysis_parser
 from aqua.core.util import dump_yaml, load_yaml
 
@@ -773,3 +773,37 @@ class TestEdgeCases:
         # Verify rmtree was called to clean up temp rendered config directory
         # Called at least once after running diagnostic tools
         assert mock_rm.call_count >= 1
+
+
+class TestCliChecker:
+    """Guards the code path every `aqua analysis` run takes: cli_checker with --yaml.
+
+    cli_checker reaches into Reader internals, and the backend refactor moved two of them
+    (`expcat`, and the `sample` kwarg of `retrieve`) with no test going red — see #3080.
+    The pre-existing checker test cannot catch that: it asserts the run exits 1, so a
+    regression that also exits 1 is indistinguishable from the failure it means to check.
+    """
+
+    def test_checker_writes_experiment_yaml(self, tmp_path):
+        """The --yaml branch must run to completion and produce the file."""
+        args = cli_checker.parse_arguments(
+            [
+                "--catalog",
+                "ci",
+                "--model",
+                "ERA5",
+                "--exp",
+                "era5-hpz3",
+                "--source",
+                "monthly",
+                "--yaml",
+                str(tmp_path),
+                "--no-rebuild",
+            ]
+        )
+        cli_checker.main(args)
+
+        experiment = load_yaml(str(tmp_path / "experiment.yaml"))
+        assert experiment["catalog"] == "ci"
+        assert experiment["model"] == "ERA5"
+        assert experiment["experiment"] == "era5-hpz3"


### PR DESCRIPTION
## PR description:

Following issue #3080, This PR adapt cli_checker to recent big backend updates in the core codebase. In addition, a proper test able to better monitor cli_checker setup is implemented.

In addition to the problem that #3080 raised, also a few lines later cli_checker was failing, in 

```
        if fread:
            reader.retrieve(sample=True)
```

Now `_retrieve_plain` should handle the same task.


## Issues closed by this pull request:

Close #3080

----


 - [x] Tests are included if a new feature is included.
 - [x] Changelog is updated.
