### PR TITLE
fix log_history message for flipped string

### DIFF
--- a/aqua/core/data_model/coordtransformer.py
+++ b/aqua/core/data_model/coordtransformer.py
@@ -189,10 +189,8 @@ class CoordTransformer:
                 data[tgt_coord["name"]].attrs["flipped"] = 1
                 log_history(
                     data,
-                    (
-                        f"Flipped coordinate {tgt_coord['name']} from ",
-                        f"{src_coord['stored_direction']} to {tgt_coord['stored_direction']} by datamodel",
-                    ),
+                    f"Flipped coordinate {tgt_coord['name']} from "
+                    f"{src_coord['stored_direction']} to {tgt_coord['stored_direction']} by datamodel",
                 )
             else:
                 self.logger.info(


### PR DESCRIPTION
## PR description:

Mini fix, without the message appears like:

('Flipped coordinate lat from ', 'decreasing to increasing by datamodel');

Notice parenthesis and extra ',' in the message