### PR TITLE
Seldate work with datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ClimateDT workflow modifications:
 
 Complete list:
 - Update Data Portfolio to v2.2.0 (#3084)
-- Seldate method using pandas as reader method and allows dates beyond 2262 (#3072)
+- Seldate method using pandas as reader method and allows dates beyond 2262 (#3072, #3085)
 - Trender works also with irregular monthly data (#3041)
 - Suppress Intake2 warning (#3077)
 

--- a/aqua/core/backend/backend.py
+++ b/aqua/core/backend/backend.py
@@ -181,8 +181,16 @@ class Backend(ABC):
             enddate = startdate
 
         t_start = pd.Timestamp(startdate) if startdate else None
-        # This guarantees that the end of year, day, hour etc is correctly selected
-        t_end = pd.Period(enddate).end_time if enddate else None
+
+        # Strings are treated as periods to cover the full end of year, day, etc.
+        # Explicit datetime/Timestamp objects are preserved as-is.
+        if isinstance(enddate, str):
+            t_end = pd.Period(enddate).end_time
+        elif enddate is not None:
+            t_end = pd.Timestamp(enddate)
+        else:
+            t_end = None
+
         return data.sel(time=slice(t_start, t_end))
 
     def _sellevel(

--- a/tests/test_seldate.py
+++ b/tests/test_seldate.py
@@ -116,3 +116,22 @@ class TestSeldate:
         # Open-ended via accessor
         res_open = sample_dataset.aqua.seldate("1985-01-04", enddate=None)
         assert len(res_open.time) == 8
+
+    def test_backend_seldate_datetime_objects(self, sample_dataset):
+        import datetime
+
+        backend = DummyBackend()
+
+        # Test datetime.date / datetime.datetime objects
+        dt_start = datetime.datetime(1985, 1, 1, 0, 0)
+        dt_end = datetime.datetime(1985, 1, 2, 12, 0)
+        res = backend.seldate(sample_dataset, dt_start, dt_end)
+        assert len(res.time) == 7  # 00:00, 06:00, 12:00, 18:00 (Jan 1) + 00:00, 06:00, 12:00 (Jan 2)
+
+        # Test pd.Timestamp objects
+        ts_start = pd.Timestamp("1985-01-01 06:00:00")
+        ts_end = pd.Timestamp("1985-01-01 18:00:00")
+        res_ts = backend.seldate(sample_dataset, ts_start, ts_end)
+        assert len(res_ts.time) == 3
+        assert pd.Timestamp(res_ts.time.values[0]) == ts_start
+        assert pd.Timestamp(res_ts.time.values[-1]) == ts_end


### PR DESCRIPTION
## PR description:

This is a small followup to #3072 to cover the marginal case where a datetime (or a pandas timestamp etc) is passed instead of a string as `enddate`. Normally if a string like "1985-12-31" is passed, the end of day is included (it becomes 1985-12-31T2359". If a datetime-like object is passed it is used as it is.

Related to AQUA-diagnostics  https://github.com/DestinE-Climate-DT/AQUA-diagnostics/pull/403

-----
 - [x] Changelog is updated.
 - [x] Test included
